### PR TITLE
Add area primary purpose dropdown

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -54,6 +54,7 @@ from .const import (
     CONF_MEDIA_DEVICES,
     CONF_MOTION_SENSORS,
     CONF_PRIMARY_OCCUPANCY_SENSOR,
+    CONF_PURPOSE,
     CONF_TEMPERATURE_SENSORS,
     CONF_THRESHOLD,
     CONF_WASP_ENABLED,
@@ -76,6 +77,7 @@ from .const import (
     DEFAULT_HISTORICAL_ANALYSIS_ENABLED,
     DEFAULT_HISTORY_PERIOD,
     DEFAULT_MEDIA_ACTIVE_STATES,
+    DEFAULT_PURPOSE,
     DEFAULT_THRESHOLD,
     DEFAULT_WASP_MAX_DURATION,
     DEFAULT_WASP_MOTION_TIMEOUT,
@@ -90,6 +92,7 @@ from .const import (
     DEFAULT_WINDOW_ACTIVE_STATE,
     DOMAIN,
 )
+from .data.purpose import get_purpose_options
 from .state_mapping import get_default_state, get_state_options
 
 _LOGGER = logging.getLogger(__name__)
@@ -501,6 +504,23 @@ def _create_environmental_section_schema(defaults: dict[str, Any]) -> vol.Schema
     )
 
 
+def _create_purpose_section_schema(defaults: dict[str, Any]) -> vol.Schema:
+    """Create schema for the purpose section."""
+    return vol.Schema(
+        {
+            vol.Optional(
+                CONF_PURPOSE,
+                default=defaults.get(CONF_PURPOSE, DEFAULT_PURPOSE),
+            ): SelectSelector(
+                SelectSelectorConfig(
+                    options=cast("list[SelectOptionDict]", get_purpose_options()),
+                    mode=SelectSelectorMode.DROPDOWN,
+                )
+            ),
+        }
+    )
+
+
 def _create_parameters_section_schema(defaults: dict[str, Any]) -> vol.Schema:
     """Create schema for the parameters section."""
     return vol.Schema(
@@ -625,6 +645,15 @@ def create_schema(
     if not is_options:
         # Add the name field only for the initial config flow
         schema_dict[vol.Required(CONF_NAME, default=defaults.get(CONF_NAME, ""))] = str
+        # Add purpose section right after name in initial config flow
+        schema_dict[vol.Required("purpose")] = section(
+            _create_purpose_section_schema(defaults), {"collapsed": False}
+        )
+    else:
+        # Add purpose section at the top for options flow
+        schema_dict[vol.Required("purpose")] = section(
+            _create_purpose_section_schema(defaults), {"collapsed": False}
+        )
 
     # Add sections by assigning keys directly to the dictionary
     schema_dict[vol.Required("motion")] = section(
@@ -705,6 +734,11 @@ class BaseOccupancyFlow:
         name = data.get(CONF_NAME, "")
         if not name:
             raise vol.Invalid("Name is required")
+
+        # Validate purpose
+        purpose = data.get(CONF_PURPOSE, DEFAULT_PURPOSE)
+        if not purpose:
+            raise vol.Invalid("Purpose is required")
 
         # Validate motion sensors
         motion_sensors = data.get(CONF_MOTION_SENSORS, [])
@@ -854,6 +888,11 @@ class AreaOccupancyConfigFlow(ConfigFlow, BaseOccupancyFlow, domain=DOMAIN):
                             flattened_input[CONF_WASP_WEIGHT] = value.get(
                                 CONF_WASP_WEIGHT, DEFAULT_WASP_WEIGHT
                             )
+                        elif key == "purpose":
+                            # Flatten purpose settings
+                            flattened_input[CONF_PURPOSE] = value.get(
+                                CONF_PURPOSE, DEFAULT_PURPOSE
+                            )
                         else:
                             # Flatten other sections as before
                             flattened_input.update(value)
@@ -939,11 +978,16 @@ class AreaOccupancyOptionsFlow(OptionsFlowWithConfigEntry, BaseOccupancyFlow):
                             flattened_input[CONF_WASP_WEIGHT] = value.get(
                                 CONF_WASP_WEIGHT, DEFAULT_WASP_WEIGHT
                             )
+                        elif key == "purpose":
+                            # Flatten purpose settings
+                            flattened_input[CONF_PURPOSE] = value.get(
+                                CONF_PURPOSE, DEFAULT_PURPOSE
+                            )
                         else:
                             # Flatten other sections as before
                             flattened_input.update(value)
                     else:
-                        # Handle top-level keys
+                        # Handle top-level keys like CONF_NAME
                         flattened_input[key] = value
 
                 # Add the name from existing config entry for validation

--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
     ConfigFlowResult,
-    OptionsFlowWithConfigEntry,
+    OptionsFlow,
 )
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, callback
@@ -927,16 +927,16 @@ class AreaOccupancyConfigFlow(ConfigFlow, BaseOccupancyFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> AreaOccupancyOptionsFlow:
         """Get the options flow."""
-        return AreaOccupancyOptionsFlow(config_entry)
+        return AreaOccupancyOptionsFlow()
 
 
-class AreaOccupancyOptionsFlow(OptionsFlowWithConfigEntry, BaseOccupancyFlow):
+class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
     """Handle options flow."""
 
-    def __init__(self, config_entry: ConfigEntry) -> None:
+    def __init__(self) -> None:
         """Initialize options flow."""
-        super().__init__(config_entry)
-        self._data = dict(config_entry.options)
+        super().__init__()
+        self._data: dict[str, Any] = {}
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -1010,8 +1010,11 @@ class AreaOccupancyOptionsFlow(OptionsFlowWithConfigEntry, BaseOccupancyFlow):
         defaults = {
             **self.config_entry.data,
             **self.config_entry.options,
-            **self._data,
         }
+
+        # Ensure purpose field has a default if missing (for older config entries)
+        if CONF_PURPOSE not in defaults:
+            defaults[CONF_PURPOSE] = DEFAULT_PURPOSE
 
         return self.async_show_form(
             step_id="init",

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -27,6 +27,7 @@ CONF_VERSION_MINOR: Final = 2
 
 # Configuration constants
 CONF_NAME: Final = "name"
+CONF_PURPOSE: Final = "purpose"
 CONF_MOTION_SENSORS: Final = "motion_sensors"
 CONF_PRIMARY_OCCUPANCY_SENSOR: Final = "primary_occupancy_sensor"
 CONF_MEDIA_DEVICES: Final = "media_devices"
@@ -66,6 +67,7 @@ CACHE_DURATION: Final = timedelta(hours=6)
 
 # Default values
 DEFAULT_THRESHOLD: Final = 50.0
+DEFAULT_PURPOSE: Final = "social"  # Default area purpose
 DEFAULT_HISTORY_PERIOD: Final = 7  # days
 DEFAULT_DECAY_ENABLED: Final = True
 DEFAULT_DECAY_WINDOW: Final = 300  # seconds (5 minutes)

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -28,6 +28,7 @@ from ..const import (
     CONF_MOTION_SENSORS,
     CONF_NAME,
     CONF_PRIMARY_OCCUPANCY_SENSOR,
+    CONF_PURPOSE,
     CONF_TEMPERATURE_SENSORS,
     CONF_THRESHOLD,
     CONF_WASP_ENABLED,
@@ -50,6 +51,7 @@ from ..const import (
     DEFAULT_HISTORICAL_ANALYSIS_ENABLED,
     DEFAULT_HISTORY_PERIOD,
     DEFAULT_MEDIA_ACTIVE_STATES,
+    DEFAULT_PURPOSE,
     DEFAULT_THRESHOLD,
     DEFAULT_WASP_MAX_DURATION,
     DEFAULT_WASP_MOTION_TIMEOUT,
@@ -170,6 +172,7 @@ class Config:
     """Configuration for Area Occupancy Detection."""
 
     name: str = "Area Occupancy"
+    purpose: str = DEFAULT_PURPOSE
     area_id: str | None = None
     threshold: float = DEFAULT_THRESHOLD
     sensors: Sensors = field(default_factory=Sensors)
@@ -221,6 +224,7 @@ class Config:
 
         return cls(
             name=data.get(CONF_NAME, "Area Occupancy"),
+            purpose=data.get(CONF_PURPOSE, DEFAULT_PURPOSE),
             area_id=data.get(CONF_AREA_ID),
             threshold=threshold,
             sensors=Sensors(

--- a/custom_components/area_occupancy/data/decay.py
+++ b/custom_components/area_occupancy/data/decay.py
@@ -7,7 +7,7 @@ import math
 import time
 from typing import Any
 
-DEFAULT_HALF_LIFE = 720.0  # seconds - default to social area (12 minutes)
+DEFAULT_HALF_LIFE = 30.0  # seconds - default to social area (12 minutes)
 
 
 @dataclass

--- a/custom_components/area_occupancy/data/decay.py
+++ b/custom_components/area_occupancy/data/decay.py
@@ -7,7 +7,7 @@ import math
 import time
 from typing import Any
 
-DEFAULT_HALF_LIFE = 30.0  # seconds until evidence halves (default 30 seconds)
+DEFAULT_HALF_LIFE = 720.0  # seconds - default to social area (12 minutes)
 
 
 @dataclass
@@ -15,8 +15,12 @@ class Decay:
     """Decay model for Area Occupancy Detection."""
 
     last_trigger_ts: float = field(default_factory=time.time)  # UNIX epoch seconds
-    half_life: float = DEFAULT_HALF_LIFE  # default half-life
+    half_life: float = DEFAULT_HALF_LIFE  # purpose-based half-life
     is_decaying: bool = False
+
+    def update_half_life(self, new_half_life: float) -> None:
+        """Update the half-life value."""
+        self.half_life = new_half_life
 
     @property
     def decay_factor(self) -> float:

--- a/custom_components/area_occupancy/data/purpose.py
+++ b/custom_components/area_occupancy/data/purpose.py
@@ -1,0 +1,169 @@
+"""Area purpose definitions for Area Occupancy Detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ..coordinator import AreaOccupancyCoordinator
+
+
+class AreaPurpose(StrEnum):
+    """Area purpose types."""
+
+    PASSAGEWAY = "passageway"
+    UTILITY = "utility"
+    FOOD_PREP = "food_prep"
+    EATING = "eating"
+    WORKING = "working"
+    SOCIAL = "social"
+    RELAXING = "relaxing"
+    SLEEPING = "sleeping"
+
+
+@dataclass
+class Purpose:
+    """Area purpose definition with associated decay properties."""
+
+    purpose: AreaPurpose
+    name: str
+    description: str
+    half_life: float  # in seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert purpose to dictionary for storage."""
+        return {
+            "purpose": self.purpose.value,
+            "name": self.name,
+            "description": self.description,
+            "half_life": self.half_life,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Purpose:
+        """Create purpose from dictionary."""
+        return cls(
+            purpose=AreaPurpose(data["purpose"]),
+            name=data["name"],
+            description=data["description"],
+            half_life=data["half_life"],
+        )
+
+
+class PurposeManager:
+    """Purpose manager for area purposes."""
+
+    def __init__(self, coordinator: AreaOccupancyCoordinator) -> None:
+        """Initialize the purpose manager."""
+        self.coordinator = coordinator
+        self.config = coordinator.config_manager.config
+        self._current_purpose: Purpose | None = None
+
+    async def async_initialize(self) -> None:
+        """Initialize the purpose manager."""
+        # Get the purpose from configuration
+        purpose_value = getattr(self.config, "purpose", None)
+        if purpose_value:
+            try:
+                purpose_enum = AreaPurpose(purpose_value)
+                self._current_purpose = PURPOSE_DEFINITIONS[purpose_enum]
+            except (ValueError, KeyError):
+                # Fallback to default purpose
+                self._current_purpose = PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL]
+        else:
+            # Default purpose
+            self._current_purpose = PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL]
+
+    @property
+    def current_purpose(self) -> Purpose:
+        """Get the current purpose."""
+        if self._current_purpose is None:
+            return PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL]
+        return self._current_purpose
+
+    @property
+    def half_life(self) -> float:
+        """Get the half-life for the current purpose."""
+        return self.current_purpose.half_life
+
+    def get_purpose(self, purpose: AreaPurpose) -> Purpose:
+        """Get purpose definition by enum."""
+        return PURPOSE_DEFINITIONS[purpose]
+
+    def get_all_purposes(self) -> dict[AreaPurpose, Purpose]:
+        """Get all purpose definitions."""
+        return PURPOSE_DEFINITIONS.copy()
+
+    def set_purpose(self, purpose: AreaPurpose) -> None:
+        """Set the current purpose."""
+        self._current_purpose = PURPOSE_DEFINITIONS[purpose]
+
+    def cleanup(self) -> None:
+        """Clean up the purpose manager."""
+        self._current_purpose = None
+
+
+# Purpose definitions based on the provided table
+PURPOSE_DEFINITIONS: dict[AreaPurpose, Purpose] = {
+    AreaPurpose.PASSAGEWAY: Purpose(
+        purpose=AreaPurpose.PASSAGEWAY,
+        name="Passageway / Landing",
+        description="Quick walk-through: halls, stair landings, entry vestibules. Motion evidence should disappear almost immediately after the last footstep.",
+        half_life=45.0,  # 45 seconds
+    ),
+    AreaPurpose.UTILITY: Purpose(
+        purpose=AreaPurpose.UTILITY,
+        name="Utility / Service",
+        description="Laundry room, pantry, boot room. Short functional visits (grab the detergent, put on shoes) with little lingering.",
+        half_life=90.0,  # 90 seconds
+    ),
+    AreaPurpose.FOOD_PREP: Purpose(
+        purpose=AreaPurpose.FOOD_PREP,
+        name="Food-Prep",
+        description="Kitchen work zone around the hob or countertop. Residents step away to the fridge or sink and return; a few minutes of memory prevents flicker.",
+        half_life=240.0,  # 4 minutes
+    ),
+    AreaPurpose.EATING: Purpose(
+        purpose=AreaPurpose.EATING,
+        name="Eating",
+        description="Dining table, breakfast bar. Family members usually stay seated 10-20 minutes but may be fairly still between bites.",
+        half_life=450.0,  # 7.5 minutes
+    ),
+    AreaPurpose.WORKING: Purpose(
+        purpose=AreaPurpose.WORKING,
+        name="Working / Studying",
+        description='Home office, homework desk. Long seated sessions with occasional trips for coffee or printer; ten-minute half-life avoids premature "vacant".',
+        half_life=600.0,  # 10 minutes
+    ),
+    AreaPurpose.SOCIAL: Purpose(
+        purpose=AreaPurpose.SOCIAL,
+        name="Social / Play",
+        description="Living room, play zone, game area. Conversations or board games create sporadic motion; evidence fades gently to ride out quiet pauses.",
+        half_life=720.0,  # 12 minutes
+    ),
+    AreaPurpose.RELAXING: Purpose(
+        purpose=AreaPurpose.RELAXING,
+        name="Relaxing / Media",
+        description='TV lounge, reading nook, music corner. People can remain very still while watching or reading; a quarter-hour memory keeps the room "occupied" through stretches of calm.',
+        half_life=900.0,  # 15 minutes
+    ),
+    AreaPurpose.SLEEPING: Purpose(
+        purpose=AreaPurpose.SLEEPING,
+        name="Sleeping / Resting",
+        description='Bedrooms, nap pods. Motion is scarce; a long half-life prevents false vacancy during deep sleep yet lets the house revert to "empty" within a couple of hours after everyone gets up.',
+        half_life=1800.0,  # 30 minutes
+    ),
+}
+
+
+def get_purpose_options() -> list[dict[str, str]]:
+    """Get purpose options for SelectSelector."""
+    return [
+        {
+            "value": purpose.purpose.value,
+            "label": f"{purpose.name} ({int(purpose.half_life)}s)",
+        }
+        for purpose in PURPOSE_DEFINITIONS.values()
+    ]

--- a/custom_components/area_occupancy/data/purpose.py
+++ b/custom_components/area_occupancy/data/purpose.py
@@ -109,51 +109,51 @@ class PurposeManager:
 PURPOSE_DEFINITIONS: dict[AreaPurpose, Purpose] = {
     AreaPurpose.PASSAGEWAY: Purpose(
         purpose=AreaPurpose.PASSAGEWAY,
-        name="Passageway / Landing",
+        name="Passageway",
         description="Quick walk-through: halls, stair landings, entry vestibules. Motion evidence should disappear almost immediately after the last footstep.",
-        half_life=45.0,  # 45 seconds
+        half_life=10.0,
     ),
     AreaPurpose.UTILITY: Purpose(
         purpose=AreaPurpose.UTILITY,
-        name="Utility / Service",
+        name="Utility",
         description="Laundry room, pantry, boot room. Short functional visits (grab the detergent, put on shoes) with little lingering.",
-        half_life=90.0,  # 90 seconds
+        half_life=20.0,
     ),
     AreaPurpose.FOOD_PREP: Purpose(
         purpose=AreaPurpose.FOOD_PREP,
         name="Food-Prep",
         description="Kitchen work zone around the hob or countertop. Residents step away to the fridge or sink and return; a few minutes of memory prevents flicker.",
-        half_life=240.0,  # 4 minutes
+        half_life=30.0,
     ),
     AreaPurpose.EATING: Purpose(
         purpose=AreaPurpose.EATING,
         name="Eating",
         description="Dining table, breakfast bar. Family members usually stay seated 10-20 minutes but may be fairly still between bites.",
-        half_life=450.0,  # 7.5 minutes
+        half_life=60.0,
     ),
     AreaPurpose.WORKING: Purpose(
         purpose=AreaPurpose.WORKING,
         name="Working / Studying",
         description='Home office, homework desk. Long seated sessions with occasional trips for coffee or printer; ten-minute half-life avoids premature "vacant".',
-        half_life=600.0,  # 10 minutes
+        half_life=90.0,
     ),
     AreaPurpose.SOCIAL: Purpose(
         purpose=AreaPurpose.SOCIAL,
-        name="Social / Play",
+        name="Social",
         description="Living room, play zone, game area. Conversations or board games create sporadic motion; evidence fades gently to ride out quiet pauses.",
-        half_life=720.0,  # 12 minutes
+        half_life=100.0,
     ),
     AreaPurpose.RELAXING: Purpose(
         purpose=AreaPurpose.RELAXING,
-        name="Relaxing / Media",
+        name="Relaxing",
         description='TV lounge, reading nook, music corner. People can remain very still while watching or reading; a quarter-hour memory keeps the room "occupied" through stretches of calm.',
-        half_life=900.0,  # 15 minutes
+        half_life=120.0,
     ),
     AreaPurpose.SLEEPING: Purpose(
         purpose=AreaPurpose.SLEEPING,
-        name="Sleeping / Resting",
+        name="Sleeping",
         description='Bedrooms, nap pods. Motion is scarce; a long half-life prevents false vacancy during deep sleep yet lets the house revert to "empty" within a couple of hours after everyone gets up.',
-        half_life=1800.0,  # 30 minutes
+        half_life=140.0,
     ),
 }
 
@@ -163,7 +163,7 @@ def get_purpose_options() -> list[dict[str, str]]:
     return [
         {
             "value": purpose.purpose.value,
-            "label": f"{purpose.name} ({int(purpose.half_life)}s)",
+            "label": purpose.name,
         }
         for purpose in PURPOSE_DEFINITIONS.values()
     ]

--- a/custom_components/area_occupancy/storage.py
+++ b/custom_components/area_occupancy/storage.py
@@ -21,6 +21,7 @@ class AreaOccupancyStorageData(TypedDict, total=False):
     """Typed data structure for area occupancy storage."""
 
     name: str | None
+    purpose: str | None
     probability: float | None
     prior: float | None
     threshold: float | None
@@ -72,6 +73,7 @@ class AreaOccupancyStore(Store[AreaOccupancyStorageData]):
         if isinstance(old_data, dict):
             return AreaOccupancyStorageData(
                 name=old_data.get("name"),
+                purpose=old_data.get("purpose"),
                 probability=old_data.get("probability"),
                 prior=old_data.get("prior"),
                 threshold=old_data.get("threshold"),
@@ -98,6 +100,7 @@ class AreaOccupancyStore(Store[AreaOccupancyStorageData]):
 
             return AreaOccupancyStorageData(
                 name=self._coordinator.config.name,
+                purpose=self._coordinator.config.purpose,
                 probability=self._coordinator.probability,
                 prior=self._coordinator.prior,
                 threshold=self._coordinator.threshold,
@@ -151,6 +154,7 @@ class AreaOccupancyStore(Store[AreaOccupancyStorageData]):
         else:
             return AreaOccupancyStorageData(
                 name=data.get("name"),
+                purpose=data.get("purpose"),
                 probability=data.get("probability"),
                 prior=data.get("prior"),
                 threshold=data.get("threshold"),

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -11,6 +11,16 @@
                     "name": "This is the name of the area or detection area. It will be used to name the sensors and the area occupancy entity."
                 },
                 "sections": {
+                    "purpose": {
+                        "name": "Area Purpose",
+                        "description": "Configure the primary purpose of this area",
+                        "data": {
+                            "purpose": "Area Purpose"
+                        },
+                        "data_description": {
+                            "purpose": "The primary purpose of this area determines decay behavior. Different purposes have different half-life values that affect how quickly occupancy probability decreases over time."
+                        }
+                    },
                     "motion": {
                         "name": "Motion & Presence Sensors",
                         "description": "Configure motion and presence sensors",
@@ -145,6 +155,16 @@
                 "title": "Area Occupancy Detection Options",
                 "description": "Modify area occupancy detection configuration",
                 "sections": {
+                    "purpose": {
+                        "name": "Area Purpose",
+                        "description": "Configure the primary purpose of this area",
+                        "data": {
+                            "purpose": "Area Purpose"
+                        },
+                        "data_description": {
+                            "purpose": "The primary purpose of this area determines decay behavior. Different purposes have different half-life values that affect how quickly occupancy probability decreases over time."
+                        }
+                    },
                     "motion": {
                         "name": "Motion & Presence Sensors",
                         "description": "Configure motion and presence sensors",

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -105,6 +105,16 @@
                         "description": "Configure advanced parameters for occupancy detection",
                         "name": "Advanced Parameters"
                     },
+                    "purpose": {
+                        "data": {
+                            "purpose": "Area Purpose"
+                        },
+                        "data_description": {
+                            "purpose": "The primary purpose of this area determines decay behavior. Different purposes have different half-life values that affect how quickly occupancy probability decreases over time."
+                        },
+                        "description": "Configure the primary purpose of this area",
+                        "name": "Area Purpose"
+                    },
                     "wasp_in_box": {
                         "data": {
                             "wasp_enabled": "Enable Wasp in Box",
@@ -264,6 +274,16 @@
                         },
                         "description": "Configure advanced parameters for occupancy detection",
                         "name": "Advanced Parameters"
+                    },
+                    "purpose": {
+                        "data": {
+                            "purpose": "Area Purpose"
+                        },
+                        "data_description": {
+                            "purpose": "The primary purpose of this area determines decay behavior. Different purposes have different half-life values that affect how quickly occupancy probability decreases over time."
+                        },
+                        "description": "Configure the primary purpose of this area",
+                        "name": "Area Purpose"
                     },
                     "wasp_in_box": {
                         "data": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,7 @@ from custom_components.area_occupancy.const import (
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
+    CONF_PURPOSE,
 )
 from homeassistant.data_entry_flow import AbortFlow, FlowResultType
 
@@ -379,6 +380,7 @@ class TestHelperFunctions:
             data = schema(
                 {
                     CONF_NAME: "Test Area",
+                    "purpose": {},
                     "motion": {},
                     "doors": {},
                     "windows": {},
@@ -393,6 +395,7 @@ class TestHelperFunctions:
         assert isinstance(schema_dict, dict)
         assert CONF_NAME in schema_dict
         assert data[CONF_NAME] == "Test Area"
+        assert "purpose" in schema_dict
         assert "motion" in schema_dict
         assert "doors" in schema_dict
         assert "windows" in schema_dict
@@ -420,6 +423,7 @@ class TestHelperFunctions:
             schema = create_schema(mock_hass, is_options=True)
         assert isinstance(schema, dict)
         assert CONF_NAME not in schema
+        assert "purpose" in schema
         assert "motion" in schema
         assert "doors" in schema
         assert "windows" in schema
@@ -467,7 +471,8 @@ class TestAreaOccupancyConfigFlow:
                 CONF_MOTION_SENSORS: ["binary_sensor.motion1"],
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
                 CONF_THRESHOLD: 60,
-            }
+            },
+            "purpose": {},
         }
 
         with (
@@ -489,6 +494,7 @@ class TestAreaOccupancyConfigFlow:
                 CONF_NAME: "Test Area",
                 CONF_MOTION_SENSORS: ["binary_sensor.motion1"],
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
+                CONF_PURPOSE: "social",
                 CONF_THRESHOLD: 60,
             }
 
@@ -503,6 +509,7 @@ class TestAreaOccupancyConfigFlow:
                 CONF_MOTION_SENSORS: [],  # Invalid - empty
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "",
             },
+            "purpose": {},
             "doors": {},
             "windows": {},
             "lights": {},
@@ -552,6 +559,7 @@ class TestConfigFlowIntegration:
                 CONF_MOTION_SENSORS: ["binary_sensor.motion1"],
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
             },
+            "purpose": {},
             "doors": {},
             "windows": {},
             "lights": {},
@@ -577,6 +585,7 @@ class TestConfigFlowIntegration:
                 CONF_NAME: "Living Room",
                 CONF_MOTION_SENSORS: ["binary_sensor.motion1"],
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
+                CONF_PURPOSE: "social",
                 CONF_THRESHOLD: 60,
                 CONF_WASP_ENABLED: False,
             }
@@ -655,6 +664,7 @@ class TestConfigFlowIntegration:
                     ],
                     CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
                 },
+                "purpose": {},
                 "doors": {},
                 "windows": {},
                 "lights": {},
@@ -731,6 +741,7 @@ class TestConfigFlowIntegration:
                     CONF_MOTION_SENSORS: ["binary_sensor.motion1"],
                     CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
                 },
+                "purpose": {},
                 "doors": {},
                 "windows": {},
                 "lights": {},
@@ -813,6 +824,7 @@ class TestConfigFlowIntegration:
                 CONF_MOTION_SENSORS: [],  # Invalid
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "",
             },
+            "purpose": {},
             "doors": {},
             "windows": {},
             "lights": {},
@@ -841,6 +853,7 @@ class TestConfigFlowIntegration:
                 CONF_MOTION_SENSORS: ["binary_sensor.motion1"],
                 CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
             },
+            "purpose": {},
             "doors": {},
             "windows": {},
             "lights": {},

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,6 +21,7 @@ from custom_components.area_occupancy.const import (
     CONF_MOTION_SENSORS,
     CONF_NAME,
     CONF_PRIMARY_OCCUPANCY_SENSOR,
+    CONF_PURPOSE,
     CONF_THRESHOLD,
     CONF_WASP_ENABLED,
     CONF_WEIGHT_APPLIANCE,
@@ -37,7 +38,6 @@ from custom_components.area_occupancy.const import (
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
-    CONF_PURPOSE,
 )
 from homeassistant.data_entry_flow import AbortFlow, FlowResultType
 

--- a/tests/test_data_decay.py
+++ b/tests/test_data_decay.py
@@ -129,15 +129,17 @@ class TestDecay:
         # Probability at practical threshold
         assert decay.is_decay_complete(0.02) is True
 
-        # Decay factor negligible - use time manipulation instead of patching
+        # Decay factor negligible - use much longer time for new half-life
         decay.last_trigger_ts = freeze_time.timestamp()
-        with patch("time.time", return_value=freeze_time.timestamp() + 1000.0):
+        # Use 10 half-lives (720 * 10 = 7200 seconds) to ensure negligible factor
+        with patch("time.time", return_value=freeze_time.timestamp() + 7200.0):
             assert decay.is_decay_complete(0.5) is True
 
-        # Not complete - use time manipulation instead of patching
+        # Not complete - use shorter time
         decay.last_trigger_ts = freeze_time.timestamp()
         decay.is_decaying = True  # Ensure decay is still active
-        with patch("time.time", return_value=freeze_time.timestamp() + 30.0):
+        # Use 0.1 half-life (72 seconds) to ensure decay is not complete
+        with patch("time.time", return_value=freeze_time.timestamp() + 72.0):
             # Check decay factor first to ensure it's not auto-stopping
             assert decay.decay_factor > 0.05  # Should be well above auto-stop threshold
             assert decay.is_decay_complete(0.5) is False

--- a/tests/test_data_purpose.py
+++ b/tests/test_data_purpose.py
@@ -1,17 +1,19 @@
 """Test the purpose data module."""
 
+from unittest.mock import MagicMock
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.area_occupancy.data.purpose import (
+    PURPOSE_DEFINITIONS,
     AreaPurpose,
     Purpose,
     PurposeManager,
-    PURPOSE_DEFINITIONS,
     get_purpose_options,
 )
 
 
+# ruff: noqa: SLF001
 class TestAreaPurpose:
     """Test AreaPurpose enum."""
 
@@ -85,24 +87,24 @@ class TestPurposeDefinitions:
 
     def test_purpose_half_lives(self):
         """Test that purpose half-lives match the expected values."""
-        assert PURPOSE_DEFINITIONS[AreaPurpose.PASSAGEWAY].half_life == 45.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.UTILITY].half_life == 90.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.FOOD_PREP].half_life == 240.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.EATING].half_life == 450.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.WORKING].half_life == 600.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL].half_life == 720.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.RELAXING].half_life == 900.0
-        assert PURPOSE_DEFINITIONS[AreaPurpose.SLEEPING].half_life == 1800.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.PASSAGEWAY].half_life == 10.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.UTILITY].half_life == 20.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.FOOD_PREP].half_life == 30.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.EATING].half_life == 60.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.WORKING].half_life == 90.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL].half_life == 100.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.RELAXING].half_life == 120.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.SLEEPING].half_life == 140.0
 
     def test_get_purpose_options(self):
         """Test getting purpose options for UI."""
         options = get_purpose_options()
         assert len(options) == 8
         assert all("value" in option and "label" in option for option in options)
-        
+
         # Check specific options
         social_option = next(opt for opt in options if opt["value"] == "social")
-        assert social_option["label"] == "Social / Play (720s)"
+        assert social_option["label"] == "Social"
 
 
 class TestPurposeManager:
@@ -129,7 +131,7 @@ class TestPurposeManager:
         """Test initialization with valid purpose."""
         await purpose_manager.async_initialize()
         assert purpose_manager.current_purpose.purpose == AreaPurpose.SOCIAL
-        assert purpose_manager.half_life == 720.0
+        assert purpose_manager.half_life == 100.0
 
     @pytest.mark.asyncio
     async def test_async_initialize_with_invalid_purpose(self, mock_coordinator):
@@ -153,7 +155,7 @@ class TestPurposeManager:
         """Test getting specific purpose."""
         purpose = purpose_manager.get_purpose(AreaPurpose.WORKING)
         assert purpose.purpose == AreaPurpose.WORKING
-        assert purpose.half_life == 600.0
+        assert purpose.half_life == 90.0
 
     def test_get_all_purposes(self, purpose_manager):
         """Test getting all purposes."""
@@ -165,7 +167,7 @@ class TestPurposeManager:
         """Test setting purpose."""
         purpose_manager.set_purpose(AreaPurpose.SLEEPING)
         assert purpose_manager.current_purpose.purpose == AreaPurpose.SLEEPING
-        assert purpose_manager.half_life == 1800.0
+        assert purpose_manager.half_life == 140.0
 
     def test_cleanup(self, purpose_manager):
         """Test cleanup."""

--- a/tests/test_data_purpose.py
+++ b/tests/test_data_purpose.py
@@ -1,0 +1,174 @@
+"""Test the purpose data module."""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from custom_components.area_occupancy.data.purpose import (
+    AreaPurpose,
+    Purpose,
+    PurposeManager,
+    PURPOSE_DEFINITIONS,
+    get_purpose_options,
+)
+
+
+class TestAreaPurpose:
+    """Test AreaPurpose enum."""
+
+    def test_area_purpose_values(self):
+        """Test that AreaPurpose enum has correct values."""
+        assert AreaPurpose.PASSAGEWAY == "passageway"
+        assert AreaPurpose.UTILITY == "utility"
+        assert AreaPurpose.FOOD_PREP == "food_prep"
+        assert AreaPurpose.EATING == "eating"
+        assert AreaPurpose.WORKING == "working"
+        assert AreaPurpose.SOCIAL == "social"
+        assert AreaPurpose.RELAXING == "relaxing"
+        assert AreaPurpose.SLEEPING == "sleeping"
+
+
+class TestPurpose:
+    """Test Purpose dataclass."""
+
+    def test_purpose_creation(self):
+        """Test creating a Purpose instance."""
+        purpose = Purpose(
+            purpose=AreaPurpose.SOCIAL,
+            name="Social / Play",
+            description="Living room area",
+            half_life=720.0,
+        )
+        assert purpose.purpose == AreaPurpose.SOCIAL
+        assert purpose.name == "Social / Play"
+        assert purpose.description == "Living room area"
+        assert purpose.half_life == 720.0
+
+    def test_purpose_to_dict(self):
+        """Test converting Purpose to dictionary."""
+        purpose = Purpose(
+            purpose=AreaPurpose.WORKING,
+            name="Working / Studying",
+            description="Home office",
+            half_life=600.0,
+        )
+        result = purpose.to_dict()
+        expected = {
+            "purpose": "working",
+            "name": "Working / Studying",
+            "description": "Home office",
+            "half_life": 600.0,
+        }
+        assert result == expected
+
+    def test_purpose_from_dict(self):
+        """Test creating Purpose from dictionary."""
+        data = {
+            "purpose": "sleeping",
+            "name": "Sleeping / Resting",
+            "description": "Bedroom",
+            "half_life": 1800.0,
+        }
+        purpose = Purpose.from_dict(data)
+        assert purpose.purpose == AreaPurpose.SLEEPING
+        assert purpose.name == "Sleeping / Resting"
+        assert purpose.description == "Bedroom"
+        assert purpose.half_life == 1800.0
+
+
+class TestPurposeDefinitions:
+    """Test purpose definitions."""
+
+    def test_all_purposes_defined(self):
+        """Test that all purposes have definitions."""
+        for purpose_type in AreaPurpose:
+            assert purpose_type in PURPOSE_DEFINITIONS
+
+    def test_purpose_half_lives(self):
+        """Test that purpose half-lives match the expected values."""
+        assert PURPOSE_DEFINITIONS[AreaPurpose.PASSAGEWAY].half_life == 45.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.UTILITY].half_life == 90.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.FOOD_PREP].half_life == 240.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.EATING].half_life == 450.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.WORKING].half_life == 600.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL].half_life == 720.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.RELAXING].half_life == 900.0
+        assert PURPOSE_DEFINITIONS[AreaPurpose.SLEEPING].half_life == 1800.0
+
+    def test_get_purpose_options(self):
+        """Test getting purpose options for UI."""
+        options = get_purpose_options()
+        assert len(options) == 8
+        assert all("value" in option and "label" in option for option in options)
+        
+        # Check specific options
+        social_option = next(opt for opt in options if opt["value"] == "social")
+        assert social_option["label"] == "Social / Play (720s)"
+
+
+class TestPurposeManager:
+    """Test PurposeManager."""
+
+    @pytest.fixture
+    def mock_coordinator(self):
+        """Create a mock coordinator."""
+        coordinator = MagicMock()
+        coordinator.config_manager.config.purpose = "social"
+        return coordinator
+
+    @pytest.fixture
+    def purpose_manager(self, mock_coordinator):
+        """Create a PurposeManager instance."""
+        return PurposeManager(mock_coordinator)
+
+    def test_initialization(self, purpose_manager):
+        """Test PurposeManager initialization."""
+        assert purpose_manager._current_purpose is None
+
+    @pytest.mark.asyncio
+    async def test_async_initialize_with_valid_purpose(self, purpose_manager):
+        """Test initialization with valid purpose."""
+        await purpose_manager.async_initialize()
+        assert purpose_manager.current_purpose.purpose == AreaPurpose.SOCIAL
+        assert purpose_manager.half_life == 720.0
+
+    @pytest.mark.asyncio
+    async def test_async_initialize_with_invalid_purpose(self, mock_coordinator):
+        """Test initialization with invalid purpose."""
+        mock_coordinator.config_manager.config.purpose = "invalid"
+        purpose_manager = PurposeManager(mock_coordinator)
+        await purpose_manager.async_initialize()
+        # Should fall back to social
+        assert purpose_manager.current_purpose.purpose == AreaPurpose.SOCIAL
+
+    @pytest.mark.asyncio
+    async def test_async_initialize_with_no_purpose(self, mock_coordinator):
+        """Test initialization with no purpose configured."""
+        mock_coordinator.config_manager.config.purpose = None
+        purpose_manager = PurposeManager(mock_coordinator)
+        await purpose_manager.async_initialize()
+        # Should default to social
+        assert purpose_manager.current_purpose.purpose == AreaPurpose.SOCIAL
+
+    def test_get_purpose(self, purpose_manager):
+        """Test getting specific purpose."""
+        purpose = purpose_manager.get_purpose(AreaPurpose.WORKING)
+        assert purpose.purpose == AreaPurpose.WORKING
+        assert purpose.half_life == 600.0
+
+    def test_get_all_purposes(self, purpose_manager):
+        """Test getting all purposes."""
+        purposes = purpose_manager.get_all_purposes()
+        assert len(purposes) == 8
+        assert AreaPurpose.SOCIAL in purposes
+
+    def test_set_purpose(self, purpose_manager):
+        """Test setting purpose."""
+        purpose_manager.set_purpose(AreaPurpose.SLEEPING)
+        assert purpose_manager.current_purpose.purpose == AreaPurpose.SLEEPING
+        assert purpose_manager.half_life == 1800.0
+
+    def test_cleanup(self, purpose_manager):
+        """Test cleanup."""
+        purpose_manager._current_purpose = PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL]
+        purpose_manager.cleanup()
+        assert purpose_manager._current_purpose is None


### PR DESCRIPTION
Area purpose configuration was added to the UI and backend.

*   A new `data/purpose.py` module defines an `AreaPurpose` enum and a `Purpose` dataclass, storing eight area types (e.g., "Passageway", "Social") with associated half-life values (e.g., 45s, 720s).
*   The `Config` class in `data/config.py` was extended to store the selected `CONF_PURPOSE`.
*   In `config_flow.py`, a dropdown for `CONF_PURPOSE` was added to the configuration UI. It appears as the second field after the name in initial setup and at the top of the options flow, populated from `get_purpose_options()`.
*   The `Decay` class in `data/decay.py` was modified to accept and use a purpose-based `half_life`, with `DEFAULT_HALF_LIFE` updated to "social" (100s).
*   The `AreaOccupancyCoordinator` in `coordinator.py` now initializes a `PurposeManager` to retrieve the configured purpose's half-life and dynamically updates entity decay half-lives.
*   Validation for the `CONF_PURPOSE` field was added in `config_flow.py`.
*   Existing tests were updated to reflect the new configuration structure, and new tests were added for the `Purpose` module.