### PR TITLE
Convert state mapping utilities to async

### DIFF
--- a/custom_components/area_occupancy/state_mapping.py
+++ b/custom_components/area_occupancy/state_mapping.py
@@ -91,7 +91,7 @@ MOTION_STATES: Final[PlatformStates] = {
 }
 
 
-def get_state_options(platform_type: str) -> PlatformStates:
+async def get_state_options(platform_type: str) -> PlatformStates:
     """Get state options for a given platform type."""
     platform_map = {
         "door": DOOR_STATES,
@@ -104,25 +104,25 @@ def get_state_options(platform_type: str) -> PlatformStates:
     return platform_map.get(platform_type, MOTION_STATES)
 
 
-def get_friendly_state_name(platform_type: str, state: str) -> str:
+async def get_friendly_state_name(platform_type: str, state: str) -> str:
     """Get the friendly name for a state in a given platform type."""
-    states = get_state_options(platform_type)
+    states = await get_state_options(platform_type)
     for option in states["options"]:
         if option.value == state:
             return option.name
     return state
 
 
-def get_state_icon(platform_type: str, state: str) -> str | None:
+async def get_state_icon(platform_type: str, state: str) -> str | None:
     """Get the icon for a state in a given platform type."""
-    states = get_state_options(platform_type)
+    states = await get_state_options(platform_type)
     for option in states["options"]:
         if option.value == state:
             return option.icon
     return None
 
 
-def get_default_state(platform_type: str) -> str:
+async def get_default_state(platform_type: str) -> str:
     """Get the default state for a given platform type."""
-    states = get_state_options(platform_type)
+    states = await get_state_options(platform_type)
     return states["default"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -235,37 +235,38 @@ class TestBaseOccupancyFlow:
             flow._validate_config(invalid_config)
 
 
+@pytest.mark.asyncio
 class TestHelperFunctions:
     """Test helper functions."""
 
-    def test_get_state_select_options(self) -> None:
+    async def test_get_state_select_options(self) -> None:
         """Test _get_state_select_options function."""
         # Test door states
-        door_options = _get_state_select_options("door")
+        door_options = await _get_state_select_options("door")
         assert len(door_options) > 0
         assert all("value" in option and "label" in option for option in door_options)
 
         # Test window states
-        window_options = _get_state_select_options("window")
+        window_options = await _get_state_select_options("window")
         assert len(window_options) > 0
 
         # Test media states
-        media_options = _get_state_select_options("media")
+        media_options = await _get_state_select_options("media")
         assert len(media_options) > 0
 
         # Test appliance states
-        appliance_options = _get_state_select_options("appliance")
+        appliance_options = await _get_state_select_options("appliance")
         assert len(appliance_options) > 0
 
         # Test unknown state type
-        unknown_options = _get_state_select_options("unknown")
+        unknown_options = await _get_state_select_options("unknown")
         # Accept any non-empty list, as the implementation returns default options
         assert isinstance(unknown_options, list)
         assert all(
             "value" in option and "label" in option for option in unknown_options
         )
 
-    def test_get_include_entities(self, mock_hass, mock_entity_registry):
+    async def test_get_include_entities(self, mock_hass, mock_entity_registry):
         """Test getting include entities."""
         # Setup mock entity registry
         mock_hass.helpers.entity_registry.async_get.return_value = mock_entity_registry
@@ -323,7 +324,7 @@ class TestHelperFunctions:
         assert "binary_sensor.window_1" in result["window"]
         assert "switch.appliance_1" in result["appliance"]
 
-    def test_create_schema_defaults(self, mock_hass):
+    async def test_create_schema_defaults(self, mock_hass):
         """Test creating schema with defaults."""
         # Setup mock states
         mock_hass.states = Mock()
@@ -337,7 +338,7 @@ class TestHelperFunctions:
             mock_registry = Mock()
             mock_registry.entities = {}
             mock_er_get.return_value = mock_registry
-            schema = create_schema(mock_hass)
+            schema = await create_schema(mock_hass)
         assert isinstance(schema, dict)
         assert CONF_NAME in schema
         assert "motion" in schema
@@ -350,7 +351,7 @@ class TestHelperFunctions:
         assert "wasp_in_box" in schema
         assert "parameters" in schema
 
-    def test_create_schema_with_defaults(self, mock_hass):
+    async def test_create_schema_with_defaults(self, mock_hass):
         """Test creating schema with provided defaults."""
         # Setup mock states
         mock_hass.states = Mock()
@@ -374,7 +375,7 @@ class TestHelperFunctions:
 
             mock_registry.entities = EntitiesObj()
             mock_er_get.return_value = mock_registry
-            schema_dict = create_schema(mock_hass, defaults)
+            schema_dict = await create_schema(mock_hass, defaults)
             schema = vol.Schema(schema_dict)
             # The default value is set in the voluptuous marker, so we check by instantiating
             data = schema(
@@ -406,7 +407,7 @@ class TestHelperFunctions:
         assert "wasp_in_box" in schema_dict
         assert "parameters" in schema_dict
 
-    def test_create_schema_options_mode(self, mock_hass):
+    async def test_create_schema_options_mode(self, mock_hass):
         """Test creating schema in options mode."""
         # Setup mock states
         mock_hass.states = Mock()
@@ -420,7 +421,7 @@ class TestHelperFunctions:
             mock_registry = Mock()
             mock_registry.entities = {}
             mock_er_get.return_value = mock_registry
-            schema = create_schema(mock_hass, is_options=True)
+            schema = await create_schema(mock_hass, is_options=True)
         assert isinstance(schema, dict)
         assert CONF_NAME not in schema
         assert "purpose" in schema
@@ -435,10 +436,11 @@ class TestHelperFunctions:
         assert "parameters" in schema
 
 
+@pytest.mark.asyncio
 class TestAreaOccupancyConfigFlow:
     """Test AreaOccupancyConfigFlow class."""
 
-    def test_initialization(self) -> None:
+    async def test_initialization(self) -> None:
         """Test ConfigFlow initialization."""
         flow = AreaOccupancyConfigFlow()
 
@@ -451,7 +453,8 @@ class TestAreaOccupancyConfigFlow:
         flow.hass = mock_hass
 
         with patch(
-            "custom_components.area_occupancy.config_flow.create_schema"
+            "custom_components.area_occupancy.config_flow.create_schema",
+            new_callable=AsyncMock,
         ) as mock_create_schema:
             mock_create_schema.return_value = {"test": vol.Required("test")}
 
@@ -523,7 +526,8 @@ class TestAreaOccupancyConfigFlow:
         }
 
         with patch(
-            "custom_components.area_occupancy.config_flow.create_schema"
+            "custom_components.area_occupancy.config_flow.create_schema",
+            new_callable=AsyncMock,
         ) as mock_create_schema:
             mock_create_schema.return_value = {"test": vol.Required("test")}
 
@@ -537,6 +541,7 @@ class TestAreaOccupancyConfigFlow:
             }
 
 
+@pytest.mark.asyncio
 class TestConfigFlowIntegration:
     """Test config flow integration scenarios."""
 
@@ -547,7 +552,8 @@ class TestConfigFlowIntegration:
 
         # Step 1: Show form
         with patch(
-            "custom_components.area_occupancy.config_flow.create_schema"
+            "custom_components.area_occupancy.config_flow.create_schema",
+            new_callable=AsyncMock,
         ) as mock_create_schema:
             mock_create_schema.return_value = {"test": vol.Required("test")}
 
@@ -650,7 +656,8 @@ class TestConfigFlowIntegration:
 
             # Step 1: Show form with current values
             with patch(
-                "custom_components.area_occupancy.config_flow.create_schema"
+                "custom_components.area_occupancy.config_flow.create_schema",
+                new_callable=AsyncMock,
             ) as mock_create_schema:
                 mock_create_schema.return_value = {"test": vol.Required("test")}
 
@@ -840,7 +847,8 @@ class TestConfigFlowIntegration:
         }
 
         with patch(
-            "custom_components.area_occupancy.config_flow.create_schema"
+            "custom_components.area_occupancy.config_flow.create_schema",
+            new_callable=AsyncMock,
         ) as mock_create_schema:
             mock_create_schema.return_value = {"test": vol.Required("test")}
 
@@ -887,19 +895,19 @@ class TestConfigFlowIntegration:
                 "door": ["binary_sensor.door1"],
             }
 
-            schema_dict = create_schema(mock_hass)
+            schema_dict = await create_schema(mock_hass)
 
             # Verify schema was created successfully
             assert isinstance(schema_dict, dict)
             assert len(schema_dict) > 0
 
-    def test_state_options_generation(self) -> None:
+    async def test_state_options_generation(self) -> None:
         """Test state options generation for different platforms."""
         # Test all supported platforms
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
-            options = _get_state_select_options(platform)
+            options = await _get_state_select_options(platform)
             assert isinstance(options, list)
             assert len(options) > 0
 

--- a/tests/test_state_mapping.py
+++ b/tests/test_state_mapping.py
@@ -1,5 +1,7 @@
 """Tests for state_mapping module."""
 
+import pytest
+
 from custom_components.area_occupancy.state_mapping import (
     StateOption,
     get_default_state,
@@ -29,12 +31,13 @@ class TestStateOption:
         assert option.icon == "mdi:power"
 
 
+@pytest.mark.asyncio
 class TestGetStateOptions:
     """Test get_state_options function."""
 
-    def test_door_states(self) -> None:
+    async def test_door_states(self) -> None:
         """Test getting door state options."""
-        result = get_state_options("door")
+        result = await get_state_options("door")
 
         assert "options" in result
         assert "default" in result
@@ -46,36 +49,36 @@ class TestGetStateOptions:
             assert hasattr(option, "value")
             assert hasattr(option, "name")
 
-    def test_window_states(self) -> None:
+    async def test_window_states(self) -> None:
         """Test getting window state options."""
-        result = get_state_options("window")
+        result = await get_state_options("window")
 
         assert "options" in result
         assert "default" in result
         assert isinstance(result["options"], list)
         assert len(result["options"]) > 0
 
-    def test_media_states(self) -> None:
+    async def test_media_states(self) -> None:
         """Test getting media state options."""
-        result = get_state_options("media")
+        result = await get_state_options("media")
 
         assert "options" in result
         assert "default" in result
         assert isinstance(result["options"], list)
         assert len(result["options"]) > 0
 
-    def test_appliance_states(self) -> None:
+    async def test_appliance_states(self) -> None:
         """Test getting appliance state options."""
-        result = get_state_options("appliance")
+        result = await get_state_options("appliance")
 
         assert "options" in result
         assert "default" in result
         assert isinstance(result["options"], list)
         assert len(result["options"]) > 0
 
-    def test_unknown_platform(self) -> None:
+    async def test_unknown_platform(self) -> None:
         """Test getting state options for unknown platform."""
-        result = get_state_options("unknown_platform")
+        result = await get_state_options("unknown_platform")
 
         # Should return motion states as default fallback
         assert "options" in result
@@ -83,12 +86,12 @@ class TestGetStateOptions:
         assert len(result["options"]) == 2  # on/off states
         assert result["default"] == "on"
 
-    def test_all_known_platforms(self) -> None:
+    async def test_all_known_platforms(self) -> None:
         """Test that all known platforms return valid state options."""
         known_platforms = ["door", "window", "media", "appliance"]
 
         for platform in known_platforms:
-            result = get_state_options(platform)
+            result = await get_state_options(platform)
             assert len(result["options"]) > 0
             assert result["default"] != ""
 
@@ -97,37 +100,38 @@ class TestGetStateOptions:
             assert result["default"] in option_values
 
 
+@pytest.mark.asyncio
 class TestGetFriendlyStateName:
     """Test get_friendly_state_name function."""
 
-    def test_door_state_names(self) -> None:
+    async def test_door_state_names(self) -> None:
         """Test getting friendly names for door states."""
         # Test known states
-        name = get_friendly_state_name("door", "closed")
+        name = await get_friendly_state_name("door", "closed")
         assert isinstance(name, str)
         assert len(name) > 0
 
-    def test_media_state_names(self) -> None:
+    async def test_media_state_names(self) -> None:
         """Test getting friendly names for media states."""
-        name = get_friendly_state_name("media", "playing")
+        name = await get_friendly_state_name("media", "playing")
         assert isinstance(name, str)
         assert len(name) > 0
 
-    def test_unknown_state(self) -> None:
+    async def test_unknown_state(self) -> None:
         """Test getting friendly name for unknown state."""
-        name = get_friendly_state_name("door", "unknown_state")
+        name = await get_friendly_state_name("door", "unknown_state")
         assert name == "unknown_state"  # Should return the original state
 
-    def test_unknown_platform(self) -> None:
+    async def test_unknown_platform(self) -> None:
         """Test getting friendly name for unknown platform."""
-        name = get_friendly_state_name("unknown_platform", "some_state")
+        name = await get_friendly_state_name("unknown_platform", "some_state")
         assert name == "some_state"  # Should return the original state
 
-    def test_case_sensitivity(self) -> None:
+    async def test_case_sensitivity(self) -> None:
         """Test that state name lookup is case sensitive."""
         # Test that exact case matching is required
-        name1 = get_friendly_state_name("door", "closed")
-        name2 = get_friendly_state_name("door", "CLOSED")
+        name1 = await get_friendly_state_name("door", "closed")
+        name2 = await get_friendly_state_name("door", "CLOSED")
 
         # If the mapping is case sensitive, these should be different
         # (one should be the friendly name, the other the original)
@@ -135,36 +139,37 @@ class TestGetFriendlyStateName:
             assert name2 == "CLOSED"
 
 
+@pytest.mark.asyncio
 class TestGetStateIcon:
     """Test get_state_icon function."""
 
-    def test_door_state_icons(self) -> None:
+    async def test_door_state_icons(self) -> None:
         """Test getting icons for door states."""
-        icon = get_state_icon("door", "closed")
+        icon = await get_state_icon("door", "closed")
         # Icon might be None or a string, both are valid
         assert icon is None or isinstance(icon, str)
 
-    def test_media_state_icons(self) -> None:
+    async def test_media_state_icons(self) -> None:
         """Test getting icons for media states."""
-        icon = get_state_icon("media", "playing")
+        icon = await get_state_icon("media", "playing")
         assert icon is None or isinstance(icon, str)
 
-    def test_unknown_state_icon(self) -> None:
+    async def test_unknown_state_icon(self) -> None:
         """Test getting icon for unknown state."""
-        icon = get_state_icon("door", "unknown_state")
+        icon = await get_state_icon("door", "unknown_state")
         assert icon is None
 
-    def test_unknown_platform_icon(self) -> None:
+    async def test_unknown_platform_icon(self) -> None:
         """Test getting icon for unknown platform."""
-        icon = get_state_icon("unknown_platform", "some_state")
+        icon = await get_state_icon("unknown_platform", "some_state")
         assert icon is None
 
-    def test_icon_format(self) -> None:
+    async def test_icon_format(self) -> None:
         """Test that returned icons have correct format."""
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
-            options = get_state_options(platform)
+            options = await get_state_options(platform)
             for option in options["options"]:
                 if option.icon is not None:
                     # Icons should start with 'mdi:' typically
@@ -172,45 +177,46 @@ class TestGetStateIcon:
                     assert len(option.icon) > 0
 
 
+@pytest.mark.asyncio
 class TestGetDefaultState:
     """Test get_default_state function."""
 
-    def test_door_default(self) -> None:
+    async def test_door_default(self) -> None:
         """Test getting default state for door."""
-        default = get_default_state("door")
+        default = await get_default_state("door")
         assert isinstance(default, str)
         assert len(default) > 0
 
-    def test_window_default(self) -> None:
+    async def test_window_default(self) -> None:
         """Test getting default state for window."""
-        default = get_default_state("window")
+        default = await get_default_state("window")
         assert isinstance(default, str)
         assert len(default) > 0
 
-    def test_media_default(self) -> None:
+    async def test_media_default(self) -> None:
         """Test getting default state for media."""
-        default = get_default_state("media")
+        default = await get_default_state("media")
         assert isinstance(default, str)
         assert len(default) > 0
 
-    def test_appliance_default(self) -> None:
+    async def test_appliance_default(self) -> None:
         """Test getting default state for appliance."""
-        default = get_default_state("appliance")
+        default = await get_default_state("appliance")
         assert isinstance(default, str)
         assert len(default) > 0
 
-    def test_unknown_platform_default(self) -> None:
+    async def test_unknown_platform_default(self) -> None:
         """Test getting default state for unknown platform."""
-        default = get_default_state("unknown_platform")
+        default = await get_default_state("unknown_platform")
         assert default == "on"  # Should return motion default
 
-    def test_default_consistency(self) -> None:
+    async def test_default_consistency(self) -> None:
         """Test that default states are consistent with options."""
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
-            default = get_default_state(platform)
-            options = get_state_options(platform)
+            default = await get_default_state(platform)
+            options = await get_state_options(platform)
 
             # Default should match the default from get_state_options
             assert default == options["default"]
@@ -220,40 +226,41 @@ class TestGetDefaultState:
             assert default in option_values
 
 
+@pytest.mark.asyncio
 class TestStateMapping:
     """Test overall state mapping functionality."""
 
-    def test_mapping_completeness(self) -> None:
+    async def test_mapping_completeness(self) -> None:
         """Test that all platforms have complete mappings."""
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
             # Get options
-            options = get_state_options(platform)
+            options = await get_state_options(platform)
             assert len(options["options"]) > 0
 
             # Test each option
             for option in options["options"]:
                 # Test friendly name lookup
-                name = get_friendly_state_name(platform, option.value)
+                name = await get_friendly_state_name(platform, option.value)
                 assert isinstance(name, str)
                 assert len(name) > 0
 
                 # Test icon lookup (can be None)
-                icon = get_state_icon(platform, option.value)
+                icon = await get_state_icon(platform, option.value)
                 assert icon is None or isinstance(icon, str)
 
             # Test default
-            default = get_default_state(platform)
+            default = await get_default_state(platform)
             assert isinstance(default, str)
             assert len(default) > 0
 
-    def test_state_option_uniqueness(self) -> None:
+    async def test_state_option_uniqueness(self) -> None:
         """Test that state option values are unique within each platform."""
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
-            options = get_state_options(platform)
+            options = await get_state_options(platform)
             values = [opt.value for opt in options["options"]]
 
             # Check for duplicates
@@ -261,24 +268,24 @@ class TestStateMapping:
                 f"Duplicate values found in {platform} options"
             )
 
-    def test_state_option_names_exist(self) -> None:
+    async def test_state_option_names_exist(self) -> None:
         """Test that all state options have non-empty names."""
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
-            options = get_state_options(platform)
+            options = await get_state_options(platform)
 
             for option in options["options"]:
                 assert option.name is not None
                 assert len(option.name.strip()) > 0
 
-    def test_return_type_consistency(self) -> None:
+    async def test_return_type_consistency(self) -> None:
         """Test that return types are consistent across functions."""
         platforms = ["door", "window", "media", "appliance"]
 
         for platform in platforms:
             # get_state_options should return dict with specific structure
-            options = get_state_options(platform)
+            options = await get_state_options(platform)
             assert isinstance(options, dict)
             assert "options" in options
             assert "default" in options
@@ -286,7 +293,7 @@ class TestStateMapping:
             assert isinstance(options["default"], str)
 
             # get_default_state should return string
-            default = get_default_state(platform)
+            default = await get_default_state(platform)
             assert isinstance(default, str)
 
             # Test with a valid state
@@ -294,9 +301,9 @@ class TestStateMapping:
                 test_state = options["options"][0].value
 
                 # get_friendly_state_name should return string
-                name = get_friendly_state_name(platform, test_state)
+                name = await get_friendly_state_name(platform, test_state)
                 assert isinstance(name, str)
 
                 # get_state_icon should return string or None
-                icon = get_state_icon(platform, test_state)
+                icon = await get_state_icon(platform, test_state)
                 assert icon is None or isinstance(icon, str)


### PR DESCRIPTION
## Summary
- convert helper functions in `state_mapping` to async
- update config flow helper and schema creation to use new async helpers
- adjust tests for new async signatures

## Testing
- `scripts/lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b4b96320832f85c6f0c00bf88027