### PR TITLE
Ensure interval coverage for entire range

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,19 +1,23 @@
 """Tests for utils module."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock
+
+import pytest
 
 from custom_components.area_occupancy.utils import (
     bayesian_probability,
     format_float,
     overall_probability,
+    states_to_intervals,
     validate_datetime,
     validate_decay_factor,
     validate_prior,
     validate_prob,
     validate_weight,
 )
+from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 
 if TYPE_CHECKING:
@@ -343,3 +347,31 @@ class TestOverallProbability:
         # Should combine all evidence appropriately and return valid probability
         result = overall_probability(entities, prior)
         assert 0.0 <= result <= 1.0
+
+
+class TestStatesToIntervals:
+    """Test the states_to_intervals helper."""
+
+    @pytest.mark.asyncio
+    async def test_intervals_cover_full_range(self) -> None:
+        """Intervals should span start to end even if first change is later."""
+        start = dt_util.utcnow() - timedelta(minutes=30)
+        end = dt_util.utcnow()
+
+        states = [
+            State(
+                "binary_sensor.test", "off", last_changed=start - timedelta(minutes=5)
+            ),
+            State(
+                "binary_sensor.test", "on", last_changed=start + timedelta(minutes=10)
+            ),
+            State(
+                "binary_sensor.test", "off", last_changed=start + timedelta(minutes=20)
+            ),
+        ]
+
+        intervals = await states_to_intervals(states, start, end)
+
+        assert intervals[0]["start"] == start
+        assert intervals[-1]["end"] == end
+        assert intervals[0]["state"] == "off"


### PR DESCRIPTION
## Summary
- make `states_to_intervals` cover `[start, end]` fully
- test that intervals start and end with requested bounds

## Testing
- `scripts/lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ac255e8c832f817e8802a47d5c18