### PR TITLE
Update decaying sensor handling

### DIFF
--- a/custom_components/area_occupancy/utils.py
+++ b/custom_components/area_occupancy/utils.py
@@ -257,21 +257,21 @@ def overall_probability(
     """Combine current beliefs of all entities into one room posterior."""
     posterior = prior
     for e in entities.values():
-        # Calculate observed evidence
-        observed = (
-            True
-            if e.evidence or e.decay.is_decaying
-            else False
-            if not e.evidence and not e.decay.is_decaying
-            else None
-        )
+        # Determine evidence and decay handling
+        evidence = e.evidence
+        decay_factor = 1.0
+        if e.decay.is_decaying:
+            # A decaying sensor should gradually reduce the probability
+            evidence = False
+            decay_factor = e.decay.decay_factor
 
-        # Update posterior probability (no weight parameter needed)
+        # Update posterior probability
         posterior = bayesian_probability(
             prior=posterior,
             prob_given_true=e.likelihood.prob_given_true,  # Already weighted
             prob_given_false=e.likelihood.prob_given_false,  # Already weighted
-            evidence=observed,
-            decay_factor=e.decay.decay_factor if e.decay.is_decaying else 1.0,
+            evidence=evidence,
+            decay_factor=decay_factor,
         )
+
     return validate_prob(posterior)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -293,11 +293,9 @@ class TestOverallProbability:
         entities = {"test_entity": cast("Entity", mock_entity)}
         prior = 0.3
 
-        # With decay factor of 0.5, the evidence weight is reduced
+        # With decay factor of 0.5 the negative update should be softened
         result = overall_probability(entities, prior)
-        assert 0.0 <= result <= 1.0
-        # Result should be between the prior and what it would be with full weight
-        # but closer to prior due to decay
+        assert abs(result - 0.168) < 0.01
 
     def test_no_entities(self) -> None:
         """Test probability calculation with no entities."""
@@ -340,6 +338,6 @@ class TestOverallProbability:
         }
         prior = 0.3
 
-        # Should combine all evidence appropriately and return valid probability
+        # Should combine all evidence appropriately
         result = overall_probability(entities, prior)
-        assert 0.0 <= result <= 1.0
+        assert abs(result - 0.264) < 0.01


### PR DESCRIPTION
## Summary
- soften negative updates from decaying sensors in `overall_probability`
- expect decaying evidence to slowly lower probability
- extend utils tests for decaying behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ac201604832fbfe4dd60a02c39aa