### PR TITLE
Handle unavailable evidence gracefully

### DIFF
--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -33,7 +33,7 @@ class Entity:
     last_updated: datetime = field(default_factory=dt_util.utcnow)
 
     # Minimal state tracking for proper decay behavior
-    _previous_evidence: bool = field(default=False, init=False, repr=False)
+    _previous_evidence: bool | None = field(default=False, init=False, repr=False)
     _effective_probability: float = field(default=0.0, init=False, repr=False)
 
     def __post_init__(self):
@@ -113,15 +113,15 @@ class Entity:
         return None
 
     @property
-    def evidence(self) -> bool:
+    def evidence(self) -> bool | None:
         """Determine if entity is active.
 
         Returns:
-            bool: True if entity is active, False otherwise
+            bool | None: True if entity is active, False if inactive, None if state unknown
 
         """
         if self.state is None:
-            return False
+            return None
 
         # Convert state to string for comparison
         state_str = str(self.state)
@@ -152,6 +152,9 @@ class Entity:
 
         """
         current_evidence = self.evidence  # Pure calculation from current HA state
+
+        if current_evidence is None:
+            return False
 
         if current_evidence != self._previous_evidence:
             if current_evidence:  # OFF→ON transition

--- a/custom_components/area_occupancy/utils.py
+++ b/custom_components/area_occupancy/utils.py
@@ -257,14 +257,12 @@ def overall_probability(
     """Combine current beliefs of all entities into one room posterior."""
     posterior = prior
     for e in entities.values():
+        evidence = e.evidence
+        if evidence is None:
+            continue
+
         # Calculate observed evidence
-        observed = (
-            True
-            if e.evidence or e.decay.is_decaying
-            else False
-            if not e.evidence and not e.decay.is_decaying
-            else None
-        )
+        observed = bool(evidence or e.decay.is_decaying)
 
         # Update posterior probability (no weight parameter needed)
         posterior = bayesian_probability(

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -673,7 +673,7 @@ class TestEntityPropertiesAndMethods:
 
         # Test None state
         mock_state.state = None
-        assert entity.evidence is False
+        assert entity.evidence is None
 
     def test_has_new_evidence_transitions(
         self,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -343,3 +343,32 @@ class TestOverallProbability:
         # Should combine all evidence appropriately and return valid probability
         result = overall_probability(entities, prior)
         assert 0.0 <= result <= 1.0
+
+    def test_unavailable_entity_ignored(self) -> None:
+        """Unavailable sensor should not alter probability."""
+        mock_active = Mock()
+        mock_active.evidence = True
+        mock_active.decay.is_decaying = False
+        mock_active.type.weight = 1.0
+        mock_active.likelihood.prob_given_true = 0.8
+        mock_active.likelihood.prob_given_false = 0.1
+
+        mock_unavailable = Mock()
+        mock_unavailable.evidence = None
+        mock_unavailable.decay.is_decaying = False
+        mock_unavailable.type.weight = 1.0
+        mock_unavailable.likelihood.prob_given_true = 0.8
+        mock_unavailable.likelihood.prob_given_false = 0.1
+
+        prior = 0.3
+
+        entities_base = {"active": cast("Entity", mock_active)}
+        entities_with_unavail = {
+            "active": cast("Entity", mock_active),
+            "unavail": cast("Entity", mock_unavailable),
+        }
+
+        result_base = overall_probability(entities_base, prior)
+        result_unavail = overall_probability(entities_with_unavail, prior)
+
+        assert result_base == result_unavail


### PR DESCRIPTION
## Summary
- return `None` from `Entity.evidence` when the entity has no state
- ignore entities without evidence in `overall_probability`
- guard `has_new_evidence` against `None` evidence
- update tests for new behaviour and cover unavailable sensors

## Testing
- `scripts/lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a9e4379c832fa88f1e69e5f5ef91