### PR TITLE
Remove deprecated light sensor configuration

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -49,7 +49,6 @@ from .const import (
     CONF_HISTORY_PERIOD,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
-    CONF_LIGHTS,
     CONF_MEDIA_ACTIVE_STATES,
     CONF_MEDIA_DEVICES,
     CONF_MOTION_SENSORS,
@@ -64,7 +63,6 @@ from .const import (
     CONF_WEIGHT_APPLIANCE,
     CONF_WEIGHT_DOOR,
     CONF_WEIGHT_ENVIRONMENTAL,
-    CONF_WEIGHT_LIGHT,
     CONF_WEIGHT_MEDIA,
     CONF_WEIGHT_MOTION,
     CONF_WEIGHT_WINDOW,
@@ -85,7 +83,6 @@ from .const import (
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
-    DEFAULT_WEIGHT_LIGHT,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
@@ -109,10 +106,6 @@ THRESHOLD_MAX = 100
 HISTORY_PERIOD_STEP = 1
 HISTORY_PERIOD_MIN = 1
 HISTORY_PERIOD_MAX = 30
-
-DECAY_WINDOW_STEP = 60
-DECAY_WINDOW_MIN = 60
-DECAY_WINDOW_MAX = 3600
 
 
 def _get_state_select_options(state_type: str) -> list[dict[str, str]]:
@@ -150,7 +143,6 @@ def _get_include_entities(hass: HomeAssistant) -> dict[str, list[str]]:
         BinarySensorDeviceClass.DOOR,
         BinarySensorDeviceClass.GARAGE_DOOR,
         BinarySensorDeviceClass.OPENING,
-        BinarySensorDeviceClass.LIGHT,
     ]
 
     # Check binary_sensor, switch, fan for potential appliances
@@ -340,33 +332,6 @@ def _create_windows_section_schema(
             vol.Optional(
                 CONF_WEIGHT_WINDOW,
                 default=defaults.get(CONF_WEIGHT_WINDOW, DEFAULT_WEIGHT_WINDOW),
-            ): NumberSelector(
-                NumberSelectorConfig(
-                    min=WEIGHT_MIN,
-                    max=WEIGHT_MAX,
-                    step=WEIGHT_STEP,
-                    mode=NumberSelectorMode.SLIDER,
-                ),
-            ),
-        }
-    )
-
-
-def _create_lights_section_schema(defaults: dict[str, Any]) -> vol.Schema:
-    """Create schema for the lights section."""
-    return vol.Schema(
-        {
-            vol.Optional(
-                CONF_LIGHTS, default=defaults.get(CONF_LIGHTS, [])
-            ): EntitySelector(
-                EntitySelectorConfig(
-                    domain=[Platform.LIGHT, Platform.SWITCH],
-                    multiple=True,
-                ),
-            ),
-            vol.Optional(
-                CONF_WEIGHT_LIGHT,
-                default=defaults.get(CONF_WEIGHT_LIGHT, DEFAULT_WEIGHT_LIGHT),
             ): NumberSelector(
                 NumberSelectorConfig(
                     min=WEIGHT_MIN,
@@ -695,9 +660,6 @@ def create_schema(
         ),
         {"collapsed": True},
     )
-    schema_dict[vol.Required("lights")] = section(
-        _create_lights_section_schema(defaults), {"collapsed": True}
-    )
     schema_dict[vol.Required("media")] = section(
         _create_media_section_schema(
             defaults, cast("list[SelectOptionDict]", media_state_options)
@@ -826,7 +788,6 @@ class BaseOccupancyFlow:
             ),
             (CONF_WEIGHT_DOOR, data.get(CONF_WEIGHT_DOOR, DEFAULT_WEIGHT_DOOR)),
             (CONF_WEIGHT_WINDOW, data.get(CONF_WEIGHT_WINDOW, DEFAULT_WEIGHT_WINDOW)),
-            (CONF_WEIGHT_LIGHT, data.get(CONF_WEIGHT_LIGHT, DEFAULT_WEIGHT_LIGHT)),
             (
                 CONF_WEIGHT_ENVIRONMENTAL,
                 data.get(CONF_WEIGHT_ENVIRONMENTAL, DEFAULT_WEIGHT_ENVIRONMENTAL),

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -22,7 +22,7 @@ DEVICE_MANUFACTURER: Final = "Hankanman"
 DEVICE_MODEL: Final = "Area Occupancy Detector"
 DEVICE_SW_VERSION: Final = "2025.6.1-pre4"
 CONF_VERSION: Final = 9
-CONF_VERSION_MINOR: Final = 2
+CONF_VERSION_MINOR: Final = 3
 
 # Configuration constants
 CONF_NAME: Final = "name"
@@ -39,7 +39,6 @@ CONF_DOOR_ACTIVE_STATE: Final = "door_active_state"
 CONF_WINDOW_SENSORS: Final = "window_sensors"
 CONF_WINDOW_ACTIVE_STATE: Final = "window_active_state"
 CONF_APPLIANCE_ACTIVE_STATES: Final = "appliance_active_states"
-CONF_LIGHTS: Final = "lights"
 CONF_THRESHOLD: Final = "threshold"
 CONF_HISTORY_PERIOD: Final = "history_period"
 CONF_DECAY_ENABLED: Final = "decay_enabled"
@@ -57,7 +56,6 @@ CONF_WEIGHT_MEDIA: Final = "weight_media"
 CONF_WEIGHT_APPLIANCE: Final = "weight_appliance"
 CONF_WEIGHT_DOOR: Final = "weight_door"
 CONF_WEIGHT_WINDOW: Final = "weight_window"
-CONF_WEIGHT_LIGHT: Final = "weight_light"
 CONF_WEIGHT_ENVIRONMENTAL: Final = "weight_environmental"
 CONF_WEIGHT_WASP: Final = "weight_wasp"
 
@@ -81,7 +79,6 @@ DEFAULT_WEIGHT_MEDIA: Final = 0.7
 DEFAULT_WEIGHT_APPLIANCE: Final = 0.4
 DEFAULT_WEIGHT_DOOR: Final = 0.3
 DEFAULT_WEIGHT_WINDOW: Final = 0.2
-DEFAULT_WEIGHT_LIGHT: Final = 0.2
 DEFAULT_WEIGHT_ENVIRONMENTAL: Final = 0.1
 
 # Safety bounds
@@ -117,11 +114,6 @@ DOOR_DEFAULT_PRIOR: Final[float] = 0.1356
 WINDOW_PROB_GIVEN_TRUE: Final[float] = 0.2
 WINDOW_PROB_GIVEN_FALSE: Final[float] = 0.02
 WINDOW_DEFAULT_PRIOR: Final[float] = 0.1569
-
-# Light sensor defaults
-LIGHT_PROB_GIVEN_TRUE: Final[float] = 0.2
-LIGHT_PROB_GIVEN_FALSE: Final[float] = 0.02
-LIGHT_DEFAULT_PRIOR: Final[float] = 0.3846
 
 # Media device defaults
 MEDIA_PROB_GIVEN_TRUE: Final[float] = 0.25

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -22,7 +22,6 @@ from ..const import (
     CONF_HISTORY_PERIOD,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
-    CONF_LIGHTS,
     CONF_MEDIA_ACTIVE_STATES,
     CONF_MEDIA_DEVICES,
     CONF_MOTION_SENSORS,
@@ -38,7 +37,6 @@ from ..const import (
     CONF_WEIGHT_APPLIANCE,
     CONF_WEIGHT_DOOR,
     CONF_WEIGHT_ENVIRONMENTAL,
-    CONF_WEIGHT_LIGHT,
     CONF_WEIGHT_MEDIA,
     CONF_WEIGHT_MOTION,
     CONF_WEIGHT_WINDOW,
@@ -59,7 +57,6 @@ from ..const import (
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
-    DEFAULT_WEIGHT_LIGHT,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
@@ -80,7 +77,6 @@ class Sensors:
     primary_occupancy: str | None = None
     media: list[str] = field(default_factory=list)
     appliances: list[str] = field(default_factory=list)
-    lights: list[str] = field(default_factory=list)
     illuminance: list[str] = field(default_factory=list)
     humidity: list[str] = field(default_factory=list)
     temperature: list[str] = field(default_factory=list)
@@ -136,7 +132,6 @@ class Weights:
     appliance: float = DEFAULT_WEIGHT_APPLIANCE
     door: float = DEFAULT_WEIGHT_DOOR
     window: float = DEFAULT_WEIGHT_WINDOW
-    light: float = DEFAULT_WEIGHT_LIGHT
     environmental: float = DEFAULT_WEIGHT_ENVIRONMENTAL
     wasp: float = DEFAULT_WASP_WEIGHT
 
@@ -207,7 +202,6 @@ class Config:
             (CONF_WEIGHT_APPLIANCE, DEFAULT_WEIGHT_APPLIANCE),
             (CONF_WEIGHT_DOOR, DEFAULT_WEIGHT_DOOR),
             (CONF_WEIGHT_WINDOW, DEFAULT_WEIGHT_WINDOW),
-            (CONF_WEIGHT_LIGHT, DEFAULT_WEIGHT_LIGHT),
             (CONF_WEIGHT_ENVIRONMENTAL, DEFAULT_WEIGHT_ENVIRONMENTAL),
             (CONF_WASP_WEIGHT, DEFAULT_WASP_WEIGHT),
         ]:
@@ -232,7 +226,6 @@ class Config:
                 primary_occupancy=data.get(CONF_PRIMARY_OCCUPANCY_SENSOR),
                 media=data.get(CONF_MEDIA_DEVICES, []),
                 appliances=data.get(CONF_APPLIANCES, []),
-                lights=data.get(CONF_LIGHTS, []),
                 illuminance=data.get(CONF_ILLUMINANCE_SENSORS, []),
                 humidity=data.get(CONF_HUMIDITY_SENSORS, []),
                 temperature=data.get(CONF_TEMPERATURE_SENSORS, []),
@@ -257,7 +250,6 @@ class Config:
                 appliance=weights_data[CONF_WEIGHT_APPLIANCE],
                 door=weights_data[CONF_WEIGHT_DOOR],
                 window=weights_data[CONF_WEIGHT_WINDOW],
-                light=weights_data[CONF_WEIGHT_LIGHT],
                 environmental=weights_data[CONF_WEIGHT_ENVIRONMENTAL],
                 wasp=weights_data[CONF_WASP_WEIGHT],
             ),

--- a/custom_components/area_occupancy/data/entity_type.py
+++ b/custom_components/area_occupancy/data/entity_type.py
@@ -27,7 +27,6 @@ class InputType(StrEnum):
     APPLIANCE = "appliance"
     DOOR = "door"
     WINDOW = "window"
-    LIGHT = "light"
     ENVIRONMENTAL = "environmental"
 
 
@@ -255,14 +254,6 @@ _ENTITY_TYPE_DATA: dict[InputType, dict[str, Any]] = {
         "prob_false": 0.02,
         "prior": 0.1569,
         "active_states": [STATE_OPEN],
-        "active_range": None,
-    },
-    InputType.LIGHT: {
-        "weight": 0.1,
-        "prob_true": 0.2,
-        "prob_false": 0.02,
-        "prior": 0.13846,
-        "active_states": [STATE_ON],
         "active_range": None,
     },
     InputType.ENVIRONMENTAL: {

--- a/custom_components/area_occupancy/migrations.py
+++ b/custom_components/area_occupancy/migrations.py
@@ -103,24 +103,34 @@ def remove_decay_min_delay(config: dict[str, Any]) -> dict[str, Any]:
     return config
 
 
+CONF_LIGHTS_KEY = "lights"
+
+
+def remove_lights_key(config: dict[str, Any]) -> dict[str, Any]:
+    """Remove deprecated lights key from config."""
+    if CONF_LIGHTS_KEY in config:
+        config.pop(CONF_LIGHTS_KEY)
+        _LOGGER.debug("Removed deprecated lights key from config")
+    return config
+
+
 CONF_DECAY_WINDOW_KEY = "decay_window"
+
+
+def remove_decay_window_key(config: dict[str, Any]) -> dict[str, Any]:
+    """Remove deprecated decay window key from config."""
+    if CONF_DECAY_WINDOW_KEY in config:
+        config.pop(CONF_DECAY_WINDOW_KEY)
+        _LOGGER.debug("Removed deprecated decay window key from config")
+    return config
 
 
 def migrate_decay_half_life(config: dict[str, Any]) -> dict[str, Any]:
     """Migrate configuration to add decay half life."""
     if CONF_DECAY_HALF_LIFE not in config:
-        if CONF_DECAY_WINDOW_KEY in config:
-            config[CONF_DECAY_HALF_LIFE] = config[CONF_DECAY_WINDOW_KEY]
-            config.pop(CONF_DECAY_WINDOW_KEY)
-            _LOGGER.debug(
-                "Migrated decay window to decay half life: %s",
-                config[CONF_DECAY_WINDOW_KEY],
-            )
-        else:
-            config[CONF_DECAY_HALF_LIFE] = DEFAULT_DECAY_HALF_LIFE
-            _LOGGER.debug(
-                "Migrated decay half life to default value: %s", DEFAULT_DECAY_HALF_LIFE
-            )
+        config[CONF_DECAY_HALF_LIFE] = DEFAULT_DECAY_HALF_LIFE
+        _LOGGER.debug("Added decay half life to config")
+
     return config
 
 
@@ -195,6 +205,8 @@ def migrate_config(config: dict[str, Any]) -> dict[str, Any]:
     config = remove_decay_min_delay(config)
     config = migrate_primary_occupancy_sensor(config)
     config = migrate_decay_half_life(config)
+    config = remove_decay_window_key(config)
+    config = remove_lights_key(config)
     return migrate_purpose_field(config)
 
 

--- a/custom_components/area_occupancy/state_mapping.py
+++ b/custom_components/area_occupancy/state_mapping.py
@@ -72,15 +72,6 @@ APPLIANCE_STATES: Final[PlatformStates] = {
     "default": STATE_ON,
 }
 
-# Light states configuration
-LIGHT_STATES: Final[PlatformStates] = {
-    "options": [
-        StateOption(STATE_ON, "On", "mdi:lightbulb"),
-        StateOption(STATE_OFF, "Off", "mdi:lightbulb-off"),
-    ],
-    "default": STATE_ON,
-}
-
 # Motion sensor states configuration
 MOTION_STATES: Final[PlatformStates] = {
     "options": [
@@ -98,7 +89,6 @@ def get_state_options(platform_type: str) -> PlatformStates:
         "window": WINDOW_STATES,
         "media": MEDIA_STATES,
         "appliance": APPLIANCE_STATES,
-        "light": LIGHT_STATES,
         "motion": MOTION_STATES,
     }
     return platform_map.get(platform_type, MOTION_STATES)

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -77,17 +77,6 @@
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation."
                         }
                     },
-                    "lights": {
-                        "name": "Light Sensors",
-                        "description": "Configure light sensors",
-                        "data": {
-                            "lights": "Lights",
-                            "weight_light": "Light Weight"
-                        },
-                        "data_description": {
-                            "weight_light": "The weight given to light sensor inputs in the occupancy calculation."
-                        }
-                    },
                     "media": {
                         "name": "Media Players",
                         "description": "Configure media players and their states",
@@ -219,17 +208,6 @@
                         "data_description": {
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation."
-                        }
-                    },
-                    "lights": {
-                        "name": "Light Sensors",
-                        "description": "Configure light sensors",
-                        "data": {
-                            "lights": "Lights",
-                            "weight_light": "Light Weight"
-                        },
-                        "data_description": {
-                            "weight_light": "The weight given to light sensor inputs in the occupancy calculation."
                         }
                     },
                     "media": {

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -77,17 +77,6 @@
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation."
                         }
                     },
-                    "lights": {
-                        "name": "Light Sensors",
-                        "description": "Configure light sensors",
-                        "data": {
-                            "lights": "Lights",
-                            "weight_light": "Light Weight"
-                        },
-                        "data_description": {
-                            "weight_light": "The weight given to light sensor inputs in the occupancy calculation."
-                        }
-                    },
                     "media": {
                         "name": "Media Players",
                         "description": "Configure media players and their states",
@@ -219,17 +208,6 @@
                         "data_description": {
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation."
-                        }
-                    },
-                    "lights": {
-                        "name": "Light Sensors",
-                        "description": "Configure light sensors",
-                        "data": {
-                            "lights": "Lights",
-                            "weight_light": "Light Weight"
-                        },
-                        "data_description": {
-                            "weight_light": "The weight given to light sensor inputs in the occupancy calculation."
                         }
                     },
                     "media": {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,6 @@ from custom_components.area_occupancy.const import (
     CONF_HISTORY_PERIOD,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
-    CONF_LIGHTS,
     CONF_MEDIA_ACTIVE_STATES,
     CONF_MEDIA_DEVICES,
     CONF_MOTION_SENSORS,
@@ -43,7 +42,6 @@ from custom_components.area_occupancy.const import (
     CONF_WEIGHT_APPLIANCE,
     CONF_WEIGHT_DOOR,
     CONF_WEIGHT_ENVIRONMENTAL,
-    CONF_WEIGHT_LIGHT,
     CONF_WEIGHT_MEDIA,
     CONF_WEIGHT_MOTION,
     CONF_WEIGHT_WINDOW,
@@ -63,7 +61,6 @@ from custom_components.area_occupancy.const import (
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
-    DEFAULT_WEIGHT_LIGHT,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
@@ -211,7 +208,6 @@ def mock_config_entry() -> Mock:
         CONF_HISTORY_PERIOD: DEFAULT_HISTORY_PERIOD,
         CONF_DOOR_SENSORS: [],
         CONF_WINDOW_SENSORS: [],
-        CONF_LIGHTS: [],
         CONF_MEDIA_DEVICES: [],
         CONF_APPLIANCES: [],
         CONF_ILLUMINANCE_SENSORS: [],
@@ -222,7 +218,6 @@ def mock_config_entry() -> Mock:
         CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
         CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
         CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-        CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
         CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
         CONF_WASP_ENABLED: False,
         CONF_WASP_MOTION_TIMEOUT: DEFAULT_WASP_MOTION_TIMEOUT,
@@ -461,15 +456,6 @@ def mock_states() -> list[Mock]:
     motion_state.last_updated = dt_util.utcnow() - timedelta(minutes=5)
     motion_state.attributes = {"device_class": "motion"}
     states.append(motion_state)
-
-    # Light sensor states
-    light_state = Mock()
-    light_state.entity_id = "light.test_light"
-    light_state.state = STATE_ON
-    light_state.last_changed = dt_util.utcnow() - timedelta(minutes=10)
-    light_state.last_updated = dt_util.utcnow() - timedelta(minutes=10)
-    light_state.attributes = {}
-    states.append(light_state)
 
     return states
 
@@ -898,15 +884,6 @@ def mock_coordinator_with_sensors(mock_coordinator: Mock) -> Mock:
             decay=Mock(is_decaying=True, decay_factor=0.8),
             likelihood=Mock(prob_given_true=0.8, prob_given_false=0.1),
         ),
-        "light.test_light": Mock(
-            entity_id="light.test_light",
-            available=False,
-            evidence=False,
-            probability=0.15,
-            type=Mock(input_type=InputType.LIGHT, weight=0.2),
-            decay=Mock(is_decaying=False, decay_factor=1.0),
-            likelihood=Mock(prob_given_true=0.8, prob_given_false=0.1),
-        ),
         "media_player.tv": Mock(
             entity_id="media_player.tv",
             available=True,
@@ -1158,7 +1135,7 @@ def mock_entity_for_likelihood_tests() -> Mock:
     from custom_components.area_occupancy.data.entity import Entity
 
     entity = Mock(spec=Entity)
-    entity.entity_id = "light.test_light"
+    entity.entity_id = "binary_sensor.motion_sensor_1"
 
     # Mock entity type with proper numeric values (not Mock objects)
     entity.type = Mock()
@@ -1167,7 +1144,7 @@ def mock_entity_for_likelihood_tests() -> Mock:
     entity.type.prob_true = 0.8  # Real float value, not Mock
     entity.type.prob_false = 0.1  # Real float value, not Mock
     entity.type.input_type = Mock()
-    entity.type.input_type.value = "light"
+    entity.type.input_type.value = "motion"
 
     # Mock likelihood with proper numeric values
     entity.likelihood = Mock()
@@ -1339,29 +1316,6 @@ def mock_area_occupancy_storage_data():
                     "is_decaying": False,
                 },
             },
-            "light.test_light": {
-                "entity_id": "light.test_light",
-                "probability": 0.01,
-                "type": {
-                    "input_type": "light",
-                    "weight": 0.2,
-                    "prob_true": 0.2,
-                    "prob_false": 0.02,
-                    "prior": 0.13,
-                    "active_states": ["on"],
-                    "active_range": None,
-                },
-                "likelihood": {
-                    "prob_given_true": 0.08,
-                    "prob_given_false": 0.01,
-                    "last_updated": "2025-06-19T12:06:18.158463+00:00",
-                },
-                "decay": {
-                    "last_trigger_ts": 1750328374.235967,
-                    "half_life": 300,
-                    "is_decaying": False,
-                },
-            },
             "sensor.illuminance_sensor_1": {
                 "entity_id": "sensor.illuminance_sensor_1",
                 "probability": 0.01,
@@ -1491,7 +1445,6 @@ def mock_config():
             primary_occupancy="binary_sensor.motion1",
             media=["media_player.tv"],
             appliances=["switch.computer"],
-            lights=["light.test_light"],
             illuminance=["sensor.illuminance_sensor_1"],
             humidity=["sensor.humidity_sensor"],
             temperature=["sensor.temperature_sensor"],
@@ -1510,7 +1463,6 @@ def mock_config():
             appliance=0.6,
             door=0.5,
             window=0.4,
-            light=0.1,
             environmental=0.3,
             wasp=0.8,
         ),
@@ -1570,7 +1522,6 @@ def mock_realistic_config_entry():
             "sensor.illuminance_sensor_1",
             "sensor.illuminance_sensor_2",
         ],
-        "lights": [],
         "media_active_states": ["playing", "paused"],
         "media_devices": ["media_player.mock_tv_player"],
         "motion_sensors": [
@@ -1588,7 +1539,6 @@ def mock_realistic_config_entry():
         "weight_appliance": 0.3,
         "weight_door": 0.3,
         "weight_environmental": 0.1,
-        "weight_light": 0.2,
         "weight_media": 0.7,
         "weight_motion": 0.85,
         "weight_window": 0.2,
@@ -1612,7 +1562,6 @@ def mock_realistic_config_entry():
             "sensor.illuminance_sensor_1",
             "sensor.illuminance_sensor_2",
         ],
-        "lights": ["light.study_bulb_1"],
         "media_active_states": ["playing", "paused"],
         "media_devices": ["media_player.mock_tv_player"],
         "motion_sensors": [
@@ -1632,7 +1581,6 @@ def mock_realistic_config_entry():
         "weight_appliance": 0.3,
         "weight_door": 0.3,
         "weight_environmental": 0.1,
-        "weight_light": 0.2,
         "weight_media": 0.7,
         "weight_motion": 0.85,
         "weight_window": 0.2,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -27,14 +27,12 @@ from custom_components.area_occupancy.const import (
     CONF_WEIGHT_APPLIANCE,
     CONF_WEIGHT_DOOR,
     CONF_WEIGHT_ENVIRONMENTAL,
-    CONF_WEIGHT_LIGHT,
     CONF_WEIGHT_MEDIA,
     CONF_WEIGHT_MOTION,
     CONF_WEIGHT_WINDOW,
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
-    DEFAULT_WEIGHT_LIGHT,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
@@ -59,7 +57,6 @@ class TestBaseOccupancyFlow:
             CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
             CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
             CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-            CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
             CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
         }
 
@@ -78,7 +75,6 @@ class TestBaseOccupancyFlow:
             CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
             CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
             CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-            CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
             CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
         }
 
@@ -99,7 +95,6 @@ class TestBaseOccupancyFlow:
             CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
             CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
             CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-            CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
             CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
         }
 
@@ -120,7 +115,6 @@ class TestBaseOccupancyFlow:
             CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
             CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
             CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-            CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
             CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
         }
 
@@ -145,7 +139,6 @@ class TestBaseOccupancyFlow:
             CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
             CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
             CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-            CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
             CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
         }
 
@@ -167,7 +160,6 @@ class TestBaseOccupancyFlow:
             CONF_WEIGHT_APPLIANCE: DEFAULT_WEIGHT_APPLIANCE,
             CONF_WEIGHT_DOOR: DEFAULT_WEIGHT_DOOR,
             CONF_WEIGHT_WINDOW: DEFAULT_WEIGHT_WINDOW,
-            CONF_WEIGHT_LIGHT: DEFAULT_WEIGHT_LIGHT,
             CONF_WEIGHT_ENVIRONMENTAL: DEFAULT_WEIGHT_ENVIRONMENTAL,
             CONF_DECAY_ENABLED: True,
             CONF_DECAY_HALF_LIFE: 0,  # Invalid decay half life
@@ -343,7 +335,6 @@ class TestHelperFunctions:
         assert "motion" in schema
         assert "doors" in schema
         assert "windows" in schema
-        assert "lights" in schema
         assert "media" in schema
         assert "appliances" in schema
         assert "environmental" in schema
@@ -384,7 +375,6 @@ class TestHelperFunctions:
                     "motion": {},
                     "doors": {},
                     "windows": {},
-                    "lights": {},
                     "media": {},
                     "appliances": {},
                     "environmental": {},
@@ -399,7 +389,6 @@ class TestHelperFunctions:
         assert "motion" in schema_dict
         assert "doors" in schema_dict
         assert "windows" in schema_dict
-        assert "lights" in schema_dict
         assert "media" in schema_dict
         assert "appliances" in schema_dict
         assert "environmental" in schema_dict
@@ -427,7 +416,6 @@ class TestHelperFunctions:
         assert "motion" in schema
         assert "doors" in schema
         assert "windows" in schema
-        assert "lights" in schema
         assert "media" in schema
         assert "appliances" in schema
         assert "environmental" in schema
@@ -514,7 +502,6 @@ class TestAreaOccupancyConfigFlow:
             "purpose": {},
             "doors": {},
             "windows": {},
-            "lights": {},
             "media": {},
             "appliances": {},
             "environmental": {},
@@ -564,7 +551,6 @@ class TestConfigFlowIntegration:
             "purpose": {},
             "doors": {},
             "windows": {},
-            "lights": {},
             "media": {},
             "appliances": {},
             "environmental": {},
@@ -669,7 +655,6 @@ class TestConfigFlowIntegration:
                 "purpose": {},
                 "doors": {},
                 "windows": {},
-                "lights": {},
                 "media": {},
                 "appliances": {},
                 "environmental": {},
@@ -746,7 +731,6 @@ class TestConfigFlowIntegration:
                 "purpose": {},
                 "doors": {},
                 "windows": {},
-                "lights": {},
                 "media": {},
                 "appliances": {},
                 "environmental": {},
@@ -829,7 +813,6 @@ class TestConfigFlowIntegration:
             "purpose": {},
             "doors": {},
             "windows": {},
-            "lights": {},
             "media": {},
             "appliances": {},
             "environmental": {},
@@ -858,7 +841,6 @@ class TestConfigFlowIntegration:
             "purpose": {},
             "doors": {},
             "windows": {},
-            "lights": {},
             "media": {},
             "appliances": {},
             "environmental": {},

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -457,7 +457,6 @@ class TestCoordinatorIntegrationUsingCentralizedMocks:
         entity_ids = [
             "binary_sensor.motion1",
             "binary_sensor.motion2",
-            "light.test_light",
             "media_player.tv",
         ]
 
@@ -889,8 +888,8 @@ class TestCoordinatorProbabilityCalculationEdgeCases:
         entities["binary_sensor.motion2"].decay.decay_factor = 0.5
 
         # Entity 3: No evidence, no decay
-        entities["light.test_light"].evidence = False
-        entities["light.test_light"].decay.is_decaying = False
+        entities["binary_sensor.appliance"].evidence = False
+        entities["binary_sensor.appliance"].decay.is_decaying = False
 
         # Entity 4: Active evidence and decaying
         entities["media_player.tv"].evidence = True
@@ -911,8 +910,8 @@ class TestCoordinatorProbabilityCalculationEdgeCases:
         entities["binary_sensor.motion1"].type.weight = 0.9
         entities["binary_sensor.motion1"].evidence = True
 
-        entities["light.test_light"].type.weight = 0.1
-        entities["light.test_light"].evidence = True
+        entities["binary_sensor.appliancet"].type.weight = 0.1
+        entities["binary_sensor.appliance"].evidence = True
 
         # High weight entity should have more impact
         probability = mock_coordinator_with_sensors.probability
@@ -927,7 +926,7 @@ class TestCoordinatorProbabilityCalculationEdgeCases:
         # Set different likelihood values
         entities["binary_sensor.motion1"].likelihood.prob_given_true = 0.9
         entities["binary_sensor.motion2"].likelihood.prob_given_true = 0.3
-        entities["light.test_light"].likelihood.prob_given_true = 0.1
+        entities["binary_sensor.appliance"].likelihood.prob_given_true = 0.1
         entities["media_player.tv"].likelihood.prob_given_true = 0.7
 
         # Calculate expected area prior and set mock to return it
@@ -948,8 +947,8 @@ class TestCoordinatorProbabilityCalculationEdgeCases:
         # Set different decay factors
         entities["binary_sensor.motion1"].decay.decay_factor = 1.0  # No decay
         entities["binary_sensor.motion2"].decay.decay_factor = 0.5  # Half decay
-        entities["light.test_light"].decay.decay_factor = 0.2  # Strong decay
-        entities["media_player.tv"].decay.decay_factor = 0.8  # Light decay
+        entities["binary_sensor.appliance"].decay.decay_factor = 0.2  # Strong decay
+        entities["media_player.tv"].decay.decay_factor = 0.8  # Appliance decay
 
         # Calculate expected decay and set mock to return it
         expected_decay = (1.0 + 0.5 + 0.2 + 0.8) / 4
@@ -1198,13 +1197,13 @@ class TestCoordinatorDeviceInfoAndProperties:
         # Set up mixed decay states
         entities["binary_sensor.motion1"].decay.is_decaying = True
         entities["binary_sensor.motion2"].decay.is_decaying = False
-        entities["light.test_light"].decay.is_decaying = True
+        entities["binary_sensor.appliance"].decay.is_decaying = True
         entities["media_player.tv"].decay.is_decaying = False
 
         # Create expected decaying entities list
         expected_decaying = [
             entities["binary_sensor.motion1"],
-            entities["light.test_light"],
+            entities["binary_sensor.appliance"],
         ]
         mock_coordinator_with_sensors.decaying_entities = expected_decaying
 
@@ -1212,7 +1211,7 @@ class TestCoordinatorDeviceInfoAndProperties:
 
         assert len(decaying) == 2
         assert entities["binary_sensor.motion1"] in decaying
-        assert entities["light.test_light"] in decaying
+        assert entities["binary_sensor.appliance"] in decaying
         assert entities["binary_sensor.motion2"] not in decaying
         assert entities["media_player.tv"] not in decaying
 

--- a/tests/test_data_config.py
+++ b/tests/test_data_config.py
@@ -15,7 +15,6 @@ from custom_components.area_occupancy.const import (
     CONF_HISTORY_PERIOD,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
-    CONF_LIGHTS,
     CONF_MEDIA_ACTIVE_STATES,
     CONF_MEDIA_DEVICES,
     CONF_MOTION_SENSORS,
@@ -30,7 +29,6 @@ from custom_components.area_occupancy.const import (
     CONF_WEIGHT_APPLIANCE,
     CONF_WEIGHT_DOOR,
     CONF_WEIGHT_ENVIRONMENTAL,
-    CONF_WEIGHT_LIGHT,
     CONF_WEIGHT_MEDIA,
     CONF_WEIGHT_MOTION,
     CONF_WEIGHT_WINDOW,
@@ -50,7 +48,6 @@ from custom_components.area_occupancy.const import (
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
-    DEFAULT_WEIGHT_LIGHT,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
     DEFAULT_WEIGHT_WINDOW,
@@ -82,7 +79,6 @@ class TestSensors:
         assert sensors.primary_occupancy is None
         assert sensors.media == []
         assert sensors.appliances == []
-        assert sensors.lights == []
         assert sensors.illuminance == []
         assert sensors.humidity == []
         assert sensors.temperature == []
@@ -96,7 +92,6 @@ class TestSensors:
             primary_occupancy="binary_sensor.motion1",
             media=["media_player.tv"],
             appliances=["switch.coffee_maker"],
-            lights=["light.living_room"],
             illuminance=["sensor.illuminance"],
             humidity=["sensor.humidity"],
             temperature=["sensor.temperature"],
@@ -108,7 +103,6 @@ class TestSensors:
         assert sensors.primary_occupancy == "binary_sensor.motion1"
         assert sensors.media == ["media_player.tv"]
         assert sensors.appliances == ["switch.coffee_maker"]
-        assert sensors.lights == ["light.living_room"]
         assert sensors.illuminance == ["sensor.illuminance"]
         assert sensors.humidity == ["sensor.humidity"]
         assert sensors.temperature == ["sensor.temperature"]
@@ -194,7 +188,6 @@ class TestWeights:
         assert weights.appliance == DEFAULT_WEIGHT_APPLIANCE
         assert weights.door == DEFAULT_WEIGHT_DOOR
         assert weights.window == DEFAULT_WEIGHT_WINDOW
-        assert weights.light == DEFAULT_WEIGHT_LIGHT
         assert weights.environmental == DEFAULT_WEIGHT_ENVIRONMENTAL
         assert weights.wasp == DEFAULT_WASP_WEIGHT
 
@@ -206,7 +199,6 @@ class TestWeights:
             appliance=0.7,
             door=0.6,
             window=0.5,
-            light=0.4,
             environmental=0.3,
             wasp=0.85,
         )
@@ -216,7 +208,6 @@ class TestWeights:
         assert weights.appliance == 0.7
         assert weights.door == 0.6
         assert weights.window == 0.5
-        assert weights.light == 0.4
         assert weights.environmental == 0.3
         assert weights.wasp == 0.85
 
@@ -371,7 +362,6 @@ class TestConfig:
             CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
             CONF_MEDIA_DEVICES: ["media_player.tv"],
             CONF_APPLIANCES: ["switch.coffee_maker"],
-            CONF_LIGHTS: ["light.living_room"],
             CONF_ILLUMINANCE_SENSORS: ["sensor.illuminance"],
             CONF_HUMIDITY_SENSORS: ["sensor.humidity"],
             CONF_TEMPERATURE_SENSORS: ["sensor.temperature"],
@@ -386,7 +376,6 @@ class TestConfig:
             CONF_WEIGHT_APPLIANCE: 0.7,
             CONF_WEIGHT_DOOR: 0.6,
             CONF_WEIGHT_WINDOW: 0.5,
-            CONF_WEIGHT_LIGHT: 0.4,
             CONF_WEIGHT_ENVIRONMENTAL: 0.3,
             CONF_WASP_WEIGHT: 0.85,
             CONF_DECAY_ENABLED: False,
@@ -411,7 +400,6 @@ class TestConfig:
         assert config.sensors.primary_occupancy == "binary_sensor.motion1"
         assert config.sensors.media == ["media_player.tv"]
         assert config.sensors.appliances == ["switch.coffee_maker"]
-        assert config.sensors.lights == ["light.living_room"]
         assert config.sensors.illuminance == ["sensor.illuminance"]
         assert config.sensors.humidity == ["sensor.humidity"]
         assert config.sensors.temperature == ["sensor.temperature"]
@@ -426,7 +414,6 @@ class TestConfig:
         assert config.weights.appliance == 0.7
         assert config.weights.door == 0.6
         assert config.weights.window == 0.5
-        assert config.weights.light == 0.4
         assert config.weights.environmental == 0.3
         assert config.weights.wasp == 0.85
         assert config.decay.enabled is False
@@ -598,7 +585,6 @@ class TestConfigIntegration:
             CONF_PRIMARY_OCCUPANCY_SENSOR: "binary_sensor.motion1",
             CONF_MEDIA_DEVICES: ["media_player.tv", "media_player.stereo"],
             CONF_APPLIANCES: ["switch.coffee_maker", "switch.dishwasher"],
-            CONF_LIGHTS: ["light.living_room", "light.kitchen"],
             CONF_ILLUMINANCE_SENSORS: ["sensor.illuminance1", "sensor.illuminance2"],
             CONF_HUMIDITY_SENSORS: ["sensor.humidity"],
             CONF_TEMPERATURE_SENSORS: ["sensor.temperature"],
@@ -612,7 +598,6 @@ class TestConfigIntegration:
         assert len(config.sensors.motion) == 2
         assert len(config.sensors.media) == 2
         assert len(config.sensors.appliances) == 2
-        assert len(config.sensors.lights) == 2
         assert len(config.sensors.illuminance) == 2
         assert len(config.sensors.humidity) == 1
         assert len(config.sensors.temperature) == 1

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -861,7 +861,6 @@ class TestEntityManagerAdvanced:
         mock_config.sensors.appliances = ["switch.computer"]
         mock_config.sensors.doors = ["binary_sensor.door"]
         mock_config.sensors.windows = ["binary_sensor.window"]
-        mock_config.sensors.lights = ["light.bulb"]
         mock_config.sensors.illuminance = ["sensor.lux"]
         mock_config.sensors.humidity = ["sensor.humidity"]
         mock_config.sensors.temperature = ["sensor.temp"]
@@ -875,7 +874,6 @@ class TestEntityManagerAdvanced:
         assert InputType.APPLIANCE in mappings
         assert InputType.DOOR in mappings
         assert InputType.WINDOW in mappings
-        assert InputType.LIGHT in mappings
         assert InputType.ENVIRONMENTAL in mappings
 
         assert mappings[InputType.MOTION] == [

--- a/tests/test_data_entity_type.py
+++ b/tests/test_data_entity_type.py
@@ -25,7 +25,6 @@ class TestInputType:
         assert InputType.APPLIANCE.value == "appliance"
         assert InputType.DOOR.value == "door"
         assert InputType.WINDOW.value == "window"
-        assert InputType.LIGHT.value == "light"
         assert InputType.ENVIRONMENTAL.value == "environmental"
 
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -164,7 +164,7 @@ class TestMigratePurposeField:
 
     def test_migrate_purpose_field_other_sensors(self) -> None:
         """Test migration with other sensor types."""
-        config = {"lights": ["light.test"]}
+        config = {"appliances": ["binary_sensor.appliance"]}
 
         result = migrate_purpose_field(config)
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -304,7 +304,7 @@ class TestGetEntityMetrics:
         # Use centralized entity fixtures
         mock_coordinator.entities.entities = {
             "binary_sensor.motion1": mock_active_entity,
-            "light.test_light": mock_inactive_entity,
+            "binary_sensor.appliance": mock_inactive_entity,
         }
 
         mock_config_entry.runtime_data = mock_coordinator
@@ -373,7 +373,7 @@ class TestGetProblematicEntities:
         # Use centralized entity fixtures that already have problematic states
         mock_coordinator.entities.entities = {
             "binary_sensor.motion1": mock_unavailable_entity,  # available=False
-            "light.test_light": mock_stale_entity,  # last_updated > 1 hour ago
+            "binary_sensor.appliance": mock_stale_entity,  # last_updated > 1 hour ago
         }
 
         mock_config_entry.runtime_data = mock_coordinator
@@ -387,7 +387,7 @@ class TestGetProblematicEntities:
         assert "unavailable" in problems
         assert "stale_updates" in problems
         assert "binary_sensor.motion1" in problems["unavailable"]
-        assert "light.test_light" in problems["stale_updates"]
+        assert "binary_sensor.appliance" in problems["stale_updates"]
 
     async def test_get_problematic_entities_no_issues(
         self,
@@ -623,7 +623,7 @@ class TestForceEntityUpdate:
         ]
         mock_empty_entity_manager.entities = {
             "binary_sensor.motion1": mock_active_entity,
-            "light.test_light": mock_inactive_entity,
+            "binary_sensor.appliance": mock_inactive_entity,
         }
         mock_coordinator.entities = mock_empty_entity_manager
 


### PR DESCRIPTION
Remove deprecated light sensor configuration and related constants from the area occupancy component. Update migration logic to clean up old configuration keys and adjust tests accordingly.