### PR TITLE
Improve docs for likelihood and area purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This integration provides advanced room occupancy detection by combining multipl
 - **Configurable Time Decay**: Gradually reduces occupancy probability if no new triggers occur
 - **Real-Time Threshold Adjustment**: Modify the occupancy threshold without reconfiguration
 - **Weighted Sensor Contributions**: Fine-tune how much each sensor type influences the final probability
+- **Sensor Likelihoods**: Learns how reliable each sensor is and lets you recalculate those values via service call
+- **Purpose-Based Defaults**: Selecting a room purpose automatically sets a sensible decay half life
 
 ## Documentation
 
@@ -87,7 +89,7 @@ The setup wizard will guide you through:
    - Occupancy Threshold: Percentage at which binary sensor indicates occupancy (default: 50%)
    - History Period: Days of history to analyze for learning (default: 7 days)
    - Enable Time Decay: Whether probability should decay over time
-   - Decay Window: How long until probability fully decays (default: 600 seconds)
+   - Decay Half Life: Time for probability to halve when no activity is detected (default: 600 seconds)
    - Enable Historical Analysis: Whether to learn from historical data
 
    *Note: The Decay Minimum Delay parameter has been removed as of version 9.2. Existing configurations are migrated automatically.*
@@ -104,8 +106,8 @@ The setup wizard will guide you through:
 ### Time Decay
 
 - Uses an exponential decay function with λ = 0.866433976
-- This decay rate reduces probability to 25% at half of the decay window
-- Example: With default 600s window, probability reduces to 25% after 300s
+- The probability drops to 25% at one decay half life
+- Example: With the default 600 s half life the probability reduces to 25% after 300 s
 
 ### Historical Analysis
 
@@ -150,7 +152,7 @@ The integration creates several entities, all prefixed with your configured area
   - Attributes:
     - `decay_start_time`: When decay began
     - `original_probability`: Probability before decay started
-    - `decay_window`: Current decay window setting
+    - `decay_half_life`: Current decay half life setting
 
 ### Number
 - `number.[name]_occupancy_threshold`: Adjustable threshold for occupancy determination
@@ -167,6 +169,16 @@ Service Data:
 ```yaml
 entry_id: "<config_entry_id>"  # Required: ID of the Area Occupancy instance
 history_period: 7              # Optional: Days of history to analyze (1-30 days)
+```
+
+### area_occupancy.update_likelihoods
+
+Recalculate the stored sensor likelihoods. Use this after changing sensors or if you want to refresh how reliable each sensor is considered.
+
+Service Data:
+```yaml
+entry_id: "<config_entry_id>"  # Required: ID of the Area Occupancy instance
+history_period: 7              # Optional: Days of history to analyse
 ```
 
 ## Example Automations

--- a/docs/docs/features/decay.md
+++ b/docs/docs/features/decay.md
@@ -13,7 +13,7 @@ The decay feature provides a smoother transition from an occupied state to an un
     *   The system notes the **current time** (`decay_start_time`).
     *   It records the **probability value *before* the decrease** (`decay_start_probability`). This value serves as the starting point for the decay curve.
     *   The **Decay Status** sensor likely becomes active (showing > 0%).
-3.  **Exponential Decay:** As time passes from `decay_start_time`, the system calculates a decay factor based on an exponential function. The rate of decay is determined by the **Decay Window** configuration setting (in seconds) and an internal decay constant (`DECAY_LAMBDA`). A shorter window results in faster decay.
+3.  **Exponential Decay:** As time passes from `decay_start_time`, the system calculates a decay factor based on an exponential function. The rate of decay is determined by the configured **Decay Half Life** and an internal decay constant (`DECAY_LAMBDA`). A shorter half life results in faster decay.
 4.  **Applying Decay:** The calculated decay factor is applied to the `decay_start_probability`. This results in a potentially lower probability value.
 5.  **Floor Value:** Importantly, the decayed probability can **never go below** the probability currently being calculated based on any sensors that *are* still active. If, during decay, a sensor reactivates and pushes the calculated probability up, that new higher value becomes the floor.
 6.  **Decay Stops When:**
@@ -23,7 +23,7 @@ The decay feature provides a smoother transition from an occupied state to an un
 ## Configuration
 
 *   **Decay Enabled:** A toggle to turn the decay feature on or off entirely.
-*   **Decay Window (seconds):** The duration over which the probability decays from its starting point towards the minimum. For example, a 300-second window means it takes 5 minutes for the full decay cycle (though it might stop earlier if probability increases).
+*   **Decay Half Life (seconds):** The time for the probability to fall to half of its starting value when no new activity occurs. For example, a 300-second half life means the probability halves every 5 minutes (it may stop earlier if activity resumes).
 
 Note: The previous *Decay Minimum Delay* option has been removed in version 9.2. Any existing configurations are updated automatically during migration.
 

--- a/docs/docs/features/likelihood.md
+++ b/docs/docs/features/likelihood.md
@@ -1,0 +1,12 @@
+# Sensor Likelihoods
+
+Each sensor has two learned values that describe how reliable it is as evidence of occupancy:
+
+* **P(Active \| Occupied)** – how often the sensor is active when the area really is occupied.
+* **P(Active \| Not Occupied)** – how often the sensor is active when the area is not occupied.
+
+These values are called *likelihoods* and are calculated from your history data during the [Prior Learning](prior-learning.md) process. They are weighted according to the sensor type and used by the Bayesian calculation to update the occupancy probability whenever that sensor is active.
+
+If history based learning is disabled, or insufficient history is available, default likelihoods from the integration are used instead.
+
+You can manually refresh the stored likelihoods by calling the `area_occupancy.update_likelihoods` service.

--- a/docs/docs/features/purpose.md
+++ b/docs/docs/features/purpose.md
@@ -1,0 +1,18 @@
+# Area Purpose and Decay Behaviour
+
+The integration lets you assign an **Area Purpose** to each instance. The purpose describes how the room is typically used and determines a sensible default for the probability decay speed.
+
+Selecting a purpose automatically sets the **Decay Half Life** – the time it takes for the occupancy probability to halve when no new activity occurs. You can still override this value in the options flow if required.
+
+| Purpose | Description | Default Half Life (s) |
+|---------|-------------|-----------------------|
+| Passageway | Short transit spaces such as hallways or landings. Evidence fades very quickly. | 60 |
+| Utility | Functional rooms like laundries or boot rooms. | 120 |
+| Food‑Prep | Kitchen work zones. | 300 |
+| Eating | Dining or breakfast areas. | 600 |
+| Working / Studying | Offices or desks. | 600 |
+| Social | Living rooms or play areas. | 720 |
+| Relaxing | Lounges or reading nooks. | 900 |
+| Sleeping | Bedrooms and similar spaces. | 1800 |
+
+The chosen purpose does not directly alter the Bayesian calculation beyond this decay timing. A shorter half life causes the probability to drop faster after activity stops; a longer half life keeps the area marked as occupied for longer.

--- a/docs/docs/features/services.md
+++ b/docs/docs/features/services.md
@@ -27,3 +27,19 @@ data:
 
 *   Running this service can be resource-intensive as it queries the recorder database.
 *   After the priors are updated, the coordinator will automatically refresh, potentially updating the **Prior Probability** sensor and influencing future **Occupancy Probability** calculations. 
+## `area_occupancy.update_likelihoods`
+
+Recalculates the sensor likelihood values used in the Bayesian calculation. This is similar to updating priors but focuses on the per-sensor probabilities.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+| `history_period` | No | Number of days of history to analyse. Defaults to the configured history period. | `7` |
+
+**Example:**
+```yaml
+service: area_occupancy.update_likelihoods
+data:
+  entry_id: your_config_entry_id_here
+```
+

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -12,6 +12,10 @@ Area Occupancy Detection is configured entirely through the Home Assistant user 
 
 ## Configuration Options
 
+### Area Purpose
+
+The first step after naming the area is choosing its **purpose**. This sets a sensible default for the decay half life used when probability decreases. Purposes include options like *Passageway*, *Utility*, *Social*, and *Sleeping*. You can override the resulting half life in the options if needed.
+
 After providing the name, you'll be guided through selecting sensors and configuring parameters. You can also reconfigure these later by clicking **Configure** on the integration card.
 
 ### Sensor Selection
@@ -36,7 +40,7 @@ You will be prompted to select entities for various categories. You only need to
 | Occupancy Threshold (%) | The probability percentage required for the main **Occupancy Status** binary sensor to turn `on` | 1-99 | 50 |
 | History Period (Days) | The number of past days to analyze when performing [Prior Probability Learning](../features/prior-learning.md) | 1-90 | 7 |
 | Decay Enabled | Toggle whether to enable the [Probability Decay](../features/decay.md) feature | True/False | Enabled |
-| Decay Window (Seconds) | If decay is enabled, this sets the time over which the probability decays when sensors become inactive | 1-3600 | 300 (5 minutes) |
+| Decay Half Life (Seconds) | When decay is enabled this defines how long it takes for the occupancy probability to reduce by half after activity stops | 10-3600 | 300 (5 minutes) |
 
 ### Sensor Weights
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,14 +8,28 @@
 
 This integration provides enhanced room occupancy detection for Home Assistant by intelligently combining data from multiple sensor inputs. Unlike simple motion sensors, it leverages Bayesian probability calculations to factor in various environmental cues and device states, leading to more accurate and resilient occupancy detection.
 
+## Challenges with Basic Motion Sensors
+
+*   **Lights turning off while you're still:** If you sit still for too long, a basic motion sensor assumes the room is empty.
+*   **False triggers:** A pet walking through might trigger occupancy.
+*   **Limited context:** Simple motion doesn't know if you're watching TV, working at a desk, or just passing through.
+
+## How Area Occupancy Detection Helps
+
+*   **Increased Accuracy:** By fusing data from multiple sensor types (motion, doors, lights, media, etc.), the system gains a much richer understanding of the area's status.
+*   **Probabilistic Approach:** Instead of a simple ON/OFF state, it calculates an *occupancy probability*. You decide how certain the system must be before declaring occupancy.
+*   **Adaptability:** The prior probability learning feature analyses how *your* sensors correlate with actual occupancy, learning which sensors are reliable indicators.
+*   **Reduced False Negatives/Positives:** The combination of multi-sensor input, learned probabilities and decay logic significantly reduces incorrect occupancy states.
+
 ## Key Features
 
-*   **Multi-Sensor Fusion:** Combines inputs from motion/occupancy sensors, media players, lights, doors, windows, appliances, and environmental sensors (temperature, humidity, illuminance).
+*   **Multi-Sensor Fusion:** Combines inputs from motion/occupancy sensors, media players, lights, doors, windows, appliances and environmental sensors (temperature, humidity, illuminance).
 *   **Bayesian Inference:** Calculates the probability of occupancy based on the current state of configured sensors and their individual learned likelihoods.
-*   **Prior Probability Learning:** Automatically learns the typical correlation between sensor states and actual occupancy (using a primary motion/occupancy sensor as ground truth) over a configurable history period (e.g., last 7 days). This adapts the system to specific room usage patterns.
-*   **Configurable Weights:** Allows assigning weights to different sensor *types* to influence their impact on the overall probability.
-*   **Probability Decay:** Gradually decreases the occupancy probability when sensors indicate inactivity, providing a more natural transition to 'unoccupied' state.
-*   **Configurable Threshold:** Define the probability percentage required to consider the area 'occupied'.
+*   **Prior Probability Learning:** Automatically learns how sensor states relate to actual occupancy (using a primary sensor as ground truth) over a configurable history period.
+*   **Configurable Weights:** Assign weights to different sensor *types* to influence their impact on the overall probability.
+*   **Probability Decay:** Gradually decreases the occupancy probability when sensors indicate inactivity, providing a natural transition to "unoccupied".
+*   **Purpose-Based Decay:** Choosing a room purpose automatically sets a decay half life suited to the space.
+*   **Configurable Threshold:** Define the probability percentage required to consider the area "occupied".
 *   **Exposed Entities:**
     *   Occupancy Probability Sensor (%)
     *   Occupancy Status Binary Sensor (on/off)
@@ -25,23 +39,6 @@ This integration provides enhanced room occupancy detection for Home Assistant b
 *   **UI Configuration:** Easy setup and management through the Home Assistant UI.
 *   **Manual Prior Update Service:** Trigger the prior learning process on demand.
 
-## Why Use Area Occupancy Detection?
-
-Traditional occupancy detection often relies on a single motion sensor, leading to common frustrations:
-
-*   **Lights turning off while you're still:** If you sit still for too long, a basic motion sensor assumes the room is empty.
-*   **False triggers:** A pet walking through might trigger occupancy.
-*   **Limited context:** Simple motion doesn't know if you're watching TV, working at a desk, or just passing through.
-
-Area Occupancy Detection addresses these issues by providing:
-
-*   **Increased Accuracy:** By fusing data from multiple sensor types (motion, doors, lights, media, etc.), the system gains a much richer understanding of the area's status. It's less likely to be fooled by the limitations of a single sensor.
-*   **Probabilistic Approach:** Instead of a simple ON/OFF state, it calculates an *occupancy probability*. This gives a more nuanced view and allows fine-tuning through the threshold. You can decide how certain the system needs to be before declaring occupancy.
-*   **Adaptability:** The prior probability learning feature automatically analyzes how *your* sensors correlate with actual occupancy in *your* space over time. It learns which sensors are reliable indicators and adjusts its calculations accordingly, adapting to your specific usage patterns.
-*   **Reduced False Negatives/Positives:** The combination of multi-sensor input, learned probabilities, and decay logic significantly reduces instances where the room is incorrectly marked as empty (false negative) or occupied (false positive).
-
-This leads to more reliable and intelligent automations based on true room presence.
-
 ## Screenshots
 
 ![Probability Cards](images/probability-cards.png)
@@ -49,14 +46,14 @@ This leads to more reliable and intelligent automations based on true room prese
 ## How It Works
 
 1.  **Configuration:** You select various sensors associated with an area (motion, doors, lights, media players, etc.) and configure parameters like weights and the history period for learning.
-2.  **Prior Learning:** The integration analyzes the history of your selected sensors against a designated primary motion/occupancy sensor. It calculates:
+2.  **Prior Learning:** The integration analyses the history of your selected sensors against a designated primary motion/occupancy sensor. It calculates:
     *   **P(Sensor Active | Area Occupied):** How likely is a sensor to be active when the area is truly occupied?
     *   **P(Sensor Active | Area Not Occupied):** How likely is a sensor to be active when the area is *not* occupied?
     *   **P(Area Occupied):** The baseline (prior) probability of the area being occupied, derived from the primary sensor's history.
     These learned probabilities (or defaults if history is insufficient) are stored and used in calculations.
-3.  **Real-time Calculation:** As your sensor states change, the integration uses Bayes' theorem. For each *active* sensor, it updates the probability of occupancy based on its learned likelihoods (P(Active|Occupied) and P(Active|Not Occupied)) and the overall prior probability.
+3.  **Real-time Calculation:** As your sensor states change, the integration uses Bayes' theorem. For each *active* sensor, it updates the probability of occupancy based on its learned likelihoods and the overall prior probability.
 4.  **Weighted Combination:** The contributions from individual active sensors are combined using a complementary probability approach, factoring in their configured weights.
-5.  **Output:** The final calculated probability is exposed. If it crosses the configured threshold, the Occupancy Status sensor turns 'on'.
+5.  **Output:** The final calculated probability is exposed. If it crosses the configured threshold, the Occupancy Status sensor turns "on".
 6.  **Decay:** If the probability starts decreasing (fewer active sensors), an exponential decay function gradually lowers the probability over a configured time window, unless new sensor activity pushes it back up.
 
 ## Getting Started

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -88,6 +88,8 @@ nav:
   - Features:
     - Bayesian Calculation: features/calculation.md
     - Prior Learning: features/prior-learning.md
+    - Sensor Likelihoods: features/likelihood.md
+    - Area Purpose: features/purpose.md
     - Wasp in Box: features/wasp-in-box.md
     - Probability Decay: features/decay.md
     - Entities: features/entities.md


### PR DESCRIPTION
## Summary
- document Area Purpose feature and how it affects decay
- document sensor likelihoods
- mention update_likelihoods service
- rename decay window to decay half life across docs
- update mkdocs navigation
- restructure landing page with challenges and solutions

## Testing
- `scripts/lint`
- `pytest --cov=custom_components/area_occupancy --cov-report=xml --cov-report=term-missing -W ignore::RuntimeWarning --tb=short -v`

------
https://chatgpt.com/codex/tasks/task_e_685e784706b0832fb00b86a1ad630cc2