### PR TITLE
Update Docs and Evidence Sensor

### DIFF
--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -20,7 +20,7 @@ from .utils import format_float, format_percentage
 NAME_PRIORS_SENSOR = "Prior Probability"
 NAME_DECAY_SENSOR = "Decay Status"
 NAME_PROBABILITY_SENSOR = "Occupancy Probability"
-NAME_ENTITIES_SENSOR = "Entities"
+NAME_EVIDENCE_SENSOR = "Evidence"
 
 
 class AreaOccupancySensorBase(
@@ -89,17 +89,17 @@ class ProbabilitySensor(AreaOccupancySensorBase):
         super()._handle_coordinator_update()
 
 
-class EntitiesSensor(AreaOccupancySensorBase):
-    """Sensor for all entities."""
+class EvidenceSensor(AreaOccupancySensorBase):
+    """Sensor for all evidence."""
 
     _unrecorded_attributes = frozenset({"evidence", "no_evidence", "total", "details"})
 
     def __init__(self, coordinator: AreaOccupancyCoordinator, entry_id: str) -> None:
         """Initialize the entities sensor."""
         super().__init__(coordinator, entry_id)
-        self._attr_name = NAME_ENTITIES_SENSOR
+        self._attr_name = NAME_EVIDENCE_SENSOR
         self._attr_unique_id = (
-            f"{entry_id}_{NAME_ENTITIES_SENSOR.lower().replace(' ', '_')}"
+            f"{entry_id}_{NAME_EVIDENCE_SENSOR.lower().replace(' ', '_')}"
         )
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -205,7 +205,7 @@ async def async_setup_entry(
         ProbabilitySensor(coordinator, entry.entry_id),
         DecaySensor(coordinator, entry.entry_id),
         PriorsSensor(coordinator, entry.entry_id),
-        EntitiesSensor(coordinator, entry.entry_id),
+        EvidenceSensor(coordinator, entry.entry_id),
     ]
 
     async_add_entities(entities, update_before_add=True)

--- a/docs/docs/features/services.md
+++ b/docs/docs/features/services.md
@@ -2,7 +2,7 @@
 
 The Area Occupancy Detection integration provides services that can be called from automations or scripts.
 
-## `area_occupancy.update_priors`
+## `area_occupancy.update_area_prior`
 
 Manually triggers the [Prior Probability Learning](../features/prior-learning.md) process for a specific Area Occupancy instance.
 
@@ -16,17 +16,34 @@ This is useful if you want to force the system to re-analyze historical data imm
 **Example Service Call (YAML):**
 
 ```yaml
-service: area_occupancy.update_priors
+service: area_occupancy.update_area_prior
 data:
   entry_id: your_config_entry_id_here # Replace with the actual ID
   # Optional: Specify a different history period for this run
   # history_period: 10
 ```
 
+**Returns:**
+- `area_prior`: The calculated baseline prior probability for the area
+- `history_period`: Number of days of history that were analyzed
+- `update_timestamp`: ISO timestamp of when the update was performed
+- `calculation_details`: Detailed breakdown of the calculation including:
+  - `motion_sensors`: List of sensor IDs used in the calculation
+  - `sensor_count`: Number of sensors analyzed
+  - `calculation_method`: Description of the calculation approach
+  - `sensor_details`: Per-sensor breakdown of occupancy ratios and filtering statistics
+  - `raw_average_ratio`: The raw average occupancy ratio before buffer
+  - `buffer_multiplier`: The buffer multiplier applied (typically 1.05)
+  - `final_prior`: The final calculated prior value
+  - `calculation`: Text description of the calculation formula
+  - `filtering_summary`: Statistics about interval filtering (removes false triggers and stuck sensors)
+
 **Notes:**
 
 *   Running this service can be resource-intensive as it queries the recorder database.
-*   After the priors are updated, the coordinator will automatically refresh, potentially updating the **Prior Probability** sensor and influencing future **Occupancy Probability** calculations. 
+*   After the area prior is updated, the coordinator will automatically refresh, potentially updating the **Prior Probability** sensor and influencing future **Occupancy Probability** calculations.
+*   The service analyzes motion sensor states over the specified history period and calculates an average occupancy ratio with a 5% buffer to establish the area's baseline occupancy probability.
+
 ## `area_occupancy.update_likelihoods`
 
 Recalculates the sensor likelihood values used in the Bayesian calculation. This is similar to updating priors but focuses on the per-sensor probabilities.
@@ -42,4 +59,177 @@ service: area_occupancy.update_likelihoods
 data:
   entry_id: your_config_entry_id_here
 ```
+
+**Returns:**
+- `updated_entities`: Number of entities that had their likelihoods updated
+- `history_period`: Number of days of history that were analyzed
+- `total_entities`: Total number of entities in the system
+- `update_timestamp`: ISO timestamp of when the update was performed
+- `prior`: The current area baseline prior probability
+- `likelihoods`: Detailed likelihood data for each entity including:
+  - `type`: Entity input type (binary_sensor, sensor, etc.)
+  - `weight`: Weight factor for this entity type
+  - `prob_given_true`: Probability of entity state when area is occupied
+  - `prob_given_false`: Probability of entity state when area is unoccupied
+  - `prob_given_true_raw`: Raw probability before smoothing
+  - `prob_given_false_raw`: Raw probability before smoothing
+  - Filtering statistics (intervals processed, filtered, stuck sensor analysis)
+- `likelihood_filtering_summary`: Overall filtering statistics across all entities
+
+## `area_occupancy.reset_entities`
+
+Resets all entity probabilities and learned data for a specific Area Occupancy instance. This will clear all calculated probabilities and return entities to their initial state.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+| `clear_storage` | No | Whether to also clear stored data from disk. Defaults to `false`. | `true` |
+
+**Example:**
+```yaml
+service: area_occupancy.reset_entities
+data:
+  entry_id: your_config_entry_id_here
+  clear_storage: true
+```
+
+## `area_occupancy.get_entity_metrics`
+
+Returns basic metrics about entities in the Area Occupancy instance. This service returns data and can be used for monitoring and diagnostics.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+
+**Example:**
+```yaml
+service: area_occupancy.get_entity_metrics
+data:
+  entry_id: your_config_entry_id_here
+```
+
+**Returns:**
+- `total_entities`: Total number of entities
+- `active_entities`: Number of entities currently providing evidence
+- `available_entities`: Number of available entities
+- `unavailable_entities`: Number of unavailable entities
+- `decaying_entities`: Number of entities currently in decay state
+
+## `area_occupancy.get_problematic_entities`
+
+Identifies entities that may need attention, such as unavailable entities or those with stale updates. This service returns data for troubleshooting purposes.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+
+**Example:**
+```yaml
+service: area_occupancy.get_problematic_entities
+data:
+  entry_id: your_config_entry_id_here
+```
+
+**Returns:**
+- `unavailable`: List of entity IDs that are currently unavailable
+- `stale_updates`: List of entity IDs that haven't been updated in over an hour
+
+## `area_occupancy.get_entity_details`
+
+Returns detailed information about specific entities or all entities if none are specified. This service provides comprehensive data about entity states, probabilities, and configurations.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+| `entity_ids` | No | List of specific entity IDs to get details for. If empty, returns details for all entities. | `["binary_sensor.motion_sensor_1"]` |
+
+**Example:**
+```yaml
+service: area_occupancy.get_entity_details
+data:
+  entry_id: your_config_entry_id_here
+  entity_ids:
+    - binary_sensor.motion_sensor_1
+    - binary_sensor.door_sensor
+```
+
+**Returns detailed information including:**
+- Entity state and evidence
+- Availability and last updated timestamp
+- Current probability and decay status
+- Entity type configuration (weight, probabilities, active states)
+- Prior probability values
+
+## `area_occupancy.force_entity_update`
+
+Forces an immediate update of specific entities or all entities if none are specified. This can be useful for testing or when you need to refresh entity states immediately.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+| `entity_ids` | No | List of specific entity IDs to update. If empty, updates all entities. | `["binary_sensor.motion_sensor_1"]` |
+
+**Example:**
+```yaml
+service: area_occupancy.force_entity_update
+data:
+  entry_id: your_config_entry_id_here
+  entity_ids:
+    - binary_sensor.motion_sensor_1
+```
+
+**Returns:**
+- `updated_entities`: Number of entities that were updated
+
+## `area_occupancy.get_area_status`
+
+Returns the current occupancy status and confidence level for the area, along with entity metrics for context.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+
+**Example:**
+```yaml
+service: area_occupancy.get_area_status
+data:
+  entry_id: your_config_entry_id_here
+```
+
+**Returns:**
+- `area_name`: Name of the area
+- `occupied`: Boolean indicating if area is currently occupied
+- `occupancy_probability`: Current probability of occupancy (0.0-1.0)
+- `area_baseline_prior`: The baseline prior probability
+- `confidence_level`: Text description of confidence (high/medium/low/unknown)
+- Entity metrics (total, active, available, unavailable, decaying counts)
+
+## `area_occupancy.get_entity_type_learned_data`
+
+Returns the learned data for all entity types, including probabilities and configuration values that have been learned from historical data.
+
+| Parameter | Required | Description | Example Value |
+|-----------|---------|-------------|---------------|
+| `entry_id` | Yes | The configuration entry ID for the Area Occupancy instance. | `a1b2c3d4e5f6...` |
+
+**Example:**
+```yaml
+service: area_occupancy.get_entity_type_learned_data
+data:
+  entry_id: your_config_entry_id_here
+```
+
+**Returns learned data for each entity type:**
+- `prior`: Prior probability for the entity type
+- `prob_true`: Probability when condition is true
+- `prob_false`: Probability when condition is false
+- `weight`: Weight factor for the entity type
+- `active_states`: States considered as "active" for this entity type
+- `active_range`: Range of values considered "active" (for numeric entities)
+
+**Notes:**
+
+- All services except `reset_entities` return response data that can be used in automations or scripts
+- Services that query historical data (`update_area_prior`, `update_likelihoods`) can be resource-intensive
+- The `entry_id` can be found in Home Assistant under Settings → Devices & Services → Area Occupancy Detection → (click on an instance)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock
 from custom_components.area_occupancy.sensor import (
     AreaOccupancySensorBase,
     DecaySensor,
-    EntitiesSensor,
+    EvidenceSensor,
     PriorsSensor,
     ProbabilitySensor,
     async_setup_entry,
@@ -127,21 +127,21 @@ class TestProbabilitySensor:
         assert sensor.native_value == 100.0
 
 
-class TestEntitiesSensor:
-    """Test EntitiesSensor class."""
+class TestEvidenceSensor:
+    """Test EvidenceSensor class."""
 
     def test_initialization(self, mock_coordinator_with_sensors: Mock) -> None:
-        """Test EntitiesSensor initialization."""
-        sensor = EntitiesSensor(mock_coordinator_with_sensors, "test_entry")
+        """Test EvidenceSensor initialization."""
+        sensor = EvidenceSensor(mock_coordinator_with_sensors, "test_entry")
 
-        assert sensor.unique_id == "test_entry_entities"
-        assert sensor.name == "Entities"
-        # EntitiesSensor doesn't have an icon property
+        assert sensor.unique_id == "test_entry_evidence"
+        assert sensor.name == "Evidence"
+        # EvidenceSensor doesn't have an icon property
         assert sensor.entity_category == EntityCategory.DIAGNOSTIC
 
     def test_native_value_property(self, mock_coordinator_with_sensors: Mock) -> None:
         """Test native_value property."""
-        sensor = EntitiesSensor(mock_coordinator_with_sensors, "test_entry")
+        sensor = EvidenceSensor(mock_coordinator_with_sensors, "test_entry")
 
         # Should return total number of entities from coordinator.entities.entities
         assert sensor.native_value == 4
@@ -150,7 +150,7 @@ class TestEntitiesSensor:
         """Test native_value when no entity manager."""
         # Set up coordinator with no entities
         mock_coordinator.entities.entities = {}
-        sensor = EntitiesSensor(mock_coordinator, "test_entry")
+        sensor = EvidenceSensor(mock_coordinator, "test_entry")
 
         assert sensor.native_value == 0
 
@@ -161,7 +161,7 @@ class TestEntitiesSensor:
         mock_coordinator_with_sensors.entities.active_entities = []
         mock_coordinator_with_sensors.entities.inactive_entities = []
 
-        sensor = EntitiesSensor(mock_coordinator_with_sensors, "test_entry")
+        sensor = EvidenceSensor(mock_coordinator_with_sensors, "test_entry")
         attributes = sensor.extra_state_attributes
 
         # Should return the expected structure
@@ -173,7 +173,7 @@ class TestEntitiesSensor:
     ) -> None:
         """Test extra_state_attributes when no coordinator data."""
         mock_coordinator.data = None
-        sensor = EntitiesSensor(mock_coordinator, "test_entry")
+        sensor = EvidenceSensor(mock_coordinator, "test_entry")
 
         attributes = sensor.extra_state_attributes
         assert attributes == {}
@@ -280,7 +280,7 @@ class TestAsyncSetupEntry:
         entity_types = [type(entity).__name__ for entity in entities]
         assert "PriorsSensor" in entity_types
         assert "ProbabilitySensor" in entity_types
-        assert "EntitiesSensor" in entity_types
+        assert "EvidenceSensor" in entity_types
         assert "DecaySensor" in entity_types
 
     async def test_async_setup_entry_with_coordinator_data(
@@ -323,13 +323,13 @@ class TestSensorIntegration:
         probability_sensor = ProbabilitySensor(
             mock_coordinator_with_sensors, "test_entry"
         )
-        entities_sensor = EntitiesSensor(mock_coordinator_with_sensors, "test_entry")
+        evidence_sensor = EvidenceSensor(mock_coordinator_with_sensors, "test_entry")
         decay_sensor = DecaySensor(mock_coordinator_with_sensors, "test_entry")
 
         # Test native values
         assert priors_sensor.native_value == 35.0
         assert probability_sensor.native_value == 65.0
-        assert entities_sensor.native_value == 4  # From mock_coordinator_with_sensors
+        assert evidence_sensor.native_value == 4  # From mock_coordinator_with_sensors
         assert decay_sensor.native_value == 85.0  # (1 - 0.15) * 100
 
     def test_sensor_availability_changes(
@@ -339,7 +339,7 @@ class TestSensorIntegration:
         sensors = [
             PriorsSensor(mock_coordinator_with_sensors, "test_entry"),
             ProbabilitySensor(mock_coordinator_with_sensors, "test_entry"),
-            EntitiesSensor(mock_coordinator_with_sensors, "test_entry"),
+            EvidenceSensor(mock_coordinator_with_sensors, "test_entry"),
             DecaySensor(mock_coordinator_with_sensors, "test_entry"),
         ]
 
@@ -385,19 +385,19 @@ class TestSensorIntegration:
         self, mock_coordinator_with_sensors: Mock
     ) -> None:
         """Test entities sensor with dynamic entity updates."""
-        entities_sensor = EntitiesSensor(mock_coordinator_with_sensors, "test_entry")
+        evidence_sensor = EvidenceSensor(mock_coordinator_with_sensors, "test_entry")
 
         # Initial state - 4 entities from mock_coordinator_with_sensors
-        assert entities_sensor.native_value == 4
+        assert evidence_sensor.native_value == 4
 
         # Add more entities
         new_entity = Mock()
         mock_coordinator_with_sensors.entities.entities["new_sensor"] = new_entity
-        assert entities_sensor.native_value == 5
+        assert evidence_sensor.native_value == 5
 
         # Remove entities
         del mock_coordinator_with_sensors.entities.entities["binary_sensor.motion1"]
-        assert entities_sensor.native_value == 4
+        assert evidence_sensor.native_value == 4
 
     def test_decay_sensor_dynamic_updates(
         self, mock_coordinator_with_sensors: Mock
@@ -437,13 +437,13 @@ class TestSensorIntegration:
             side_effect=Exception("Test error")
         )
 
-        entities_sensor = EntitiesSensor(mock_coordinator_with_sensors, "test_entry")
+        evidence_sensor = EvidenceSensor(mock_coordinator_with_sensors, "test_entry")
         decay_sensor = DecaySensor(mock_coordinator_with_sensors, "test_entry")
 
         # Should handle gracefully and not crash
         try:  # noqa: SIM105
             # This should raise the exception since it's not caught in native_value
-            entities_sensor.native_value  # noqa: B018
+            evidence_sensor.native_value  # noqa: B018
         except Exception:  # noqa: BLE001
             # This is expected since the implementation doesn't handle the error
             pass


### PR DESCRIPTION
This pull request introduces several changes to the Area Occupancy Detection integration, focusing on renaming the `EntitiesSensor` to `EvidenceSensor` for improved clarity and updating related documentation and tests. Additionally, new services and return data structures have been added to enhance functionality and diagnostics.

### Sensor Renaming:

* [`custom_components/area_occupancy/sensor.py`](diffhunk://#diff-a8f3467117091981389ed1cf8e2966f1fcb4042dd94df3c1dad3ac622c5c4100L23-R23): Renamed `EntitiesSensor` to `EvidenceSensor` throughout the file, including its class name, initialization logic, attributes, and references. [[1]](diffhunk://#diff-a8f3467117091981389ed1cf8e2966f1fcb4042dd94df3c1dad3ac622c5c4100L23-R23) [[2]](diffhunk://#diff-a8f3467117091981389ed1cf8e2966f1fcb4042dd94df3c1dad3ac622c5c4100L92-R102) [[3]](diffhunk://#diff-a8f3467117091981389ed1cf8e2966f1fcb4042dd94df3c1dad3ac622c5c4100L208-R208)

### Documentation Updates:

* [`docs/docs/features/services.md`](diffhunk://#diff-b7f5b54f24bf3a8cf136c4c5c2ae7c3fddc1506963565dcbfd9495a39b4e0ba2L5-R5): Updated the name of the `area_occupancy.update_priors` service to `area_occupancy.update_area_prior`, added detailed return data structures for multiple services, and introduced new services such as `reset_entities`, `get_entity_metrics`, and `get_area_status`. [[1]](diffhunk://#diff-b7f5b54f24bf3a8cf136c4c5c2ae7c3fddc1506963565dcbfd9495a39b4e0ba2L5-R5) [[2]](diffhunk://#diff-b7f5b54f24bf3a8cf136c4c5c2ae7c3fddc1506963565dcbfd9495a39b4e0ba2L19-R46) [[3]](diffhunk://#diff-b7f5b54f24bf3a8cf136c4c5c2ae7c3fddc1506963565dcbfd9495a39b4e0ba2R63-R235)

### Test Updates:

* [`tests/test_sensor.py`](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L8-R8): Refactored all tests to replace `EntitiesSensor` with `EvidenceSensor`, ensuring consistency with the renamed class. Updated test logic and assertions to reflect the new naming convention. [[1]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L8-R8) [[2]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L130-R144) [[3]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L153-R153) [[4]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L164-R164) [[5]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L176-R176) [[6]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L283-R283) [[7]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L326-R332) [[8]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L342-R342) [[9]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L388-R400) [[10]](diffhunk://#diff-34f337d15c61fe0e5066d0d18584404ebf8f349d35318635850ad7289530f330L440-R446)