### PR TITLE
Add download badge workflow

### DIFF
--- a/.github/workflows/downloads.yml
+++ b/.github/workflows/downloads.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install jq
+        run: sudo apt-get install -y jq
       - name: Fetch download count
         id: fetch
         run: |

--- a/.github/workflows/downloads.yml
+++ b/.github/workflows/downloads.yml
@@ -2,7 +2,7 @@ name: Update Downloads Badge
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 0 * * 0'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/downloads.yml
+++ b/.github/workflows/downloads.yml
@@ -1,0 +1,34 @@
+name: Update Downloads Badge
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch download count
+        id: fetch
+        run: |
+          count=$(curl -s https://analytics.home-assistant.io/custom_integrations.json | jq -r '.area_occupancy')
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+      - name: Update README
+        run: |
+          sed -i -E "s/downloads-[0-9]+/downloads-${{ steps.fetch.outputs.count }}/" README.md
+      - name: Commit changes
+        run: |
+          if git diff --quiet README.md; then
+            echo "No changes to commit"
+          else
+            git config user.name github-actions[bot]
+            git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+            git add README.md
+            git commit -m "Update download badge"
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Hankanman/Area-Occupancy-Detection/validate.yml?branch=main)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Hankanman/Area-Occupancy-Detection/test.yml?label=tests)
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/Hankanman/Area-Occupancy-Detection/docs.yml?branch=main&label=docs)
+![Downloads](https://img.shields.io/badge/downloads-0-blue)
 
 
 


### PR DESCRIPTION
## Summary
- display downloads badge in `README.md`
- add GitHub Action to update the downloads badge from Home Assistant analytics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876b8072924832fa69b45360282500e