### PR TITLE
Add basic lovelace card

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,19 @@ Key things to check in the logs:
 
 ![Probability Cards](docs/docs/images/probability-cards.png)
 
+## Lovelace Card
+
+The integration provides a small custom card to display the current
+occupancy probability. Copy `area-occupancy-card.js` from the `www`
+folder to your Home Assistant `config/www` directory and add it as a
+resource. Then use the card with:
+
+```yaml
+type: custom:area-occupancy-card
+entity: sensor.living_room_occupancy_probability
+status_entity: binary_sensor.living_room_occupancy_status
+``` 
+
 ## Support & Feedback
 
 - **Issues**: [GitHub Issues][issues]

--- a/README.md
+++ b/README.md
@@ -277,9 +277,10 @@ Key things to check in the logs:
 ## Lovelace Card
 
 The integration provides a small custom card to display the current
-occupancy probability. Copy `area-occupancy-card.js` from the `www`
-folder to your Home Assistant `config/www` directory and add it as a
-resource. Then use the card with:
+occupancy probability and a graph of recent values. Copy
+`area-occupancy-card.js` from the `www` folder to your Home Assistant
+`config/www` directory and add it as a resource. Once added you can
+configure the card through the Lovelace UI or via YAML. Example YAML:
 
 ```yaml
 type: custom:area-occupancy-card

--- a/custom_components/area_occupancy/www/area-occupancy-card-editor.js
+++ b/custom_components/area_occupancy/www/area-occupancy-card-editor.js
@@ -1,0 +1,58 @@
+import { LitElement, html } from 'https://unpkg.com/lit?module';
+
+function fireEvent(node, type, detail, options) {
+  options = options || {};
+  options.bubbles = options.bubbles ?? true;
+  options.cancelable = options.cancelable ?? false;
+  options.composed = options.composed ?? true;
+  const event = new CustomEvent(type, {
+    detail,
+    bubbles: options.bubbles,
+    cancelable: options.cancelable,
+    composed: options.composed,
+  });
+  node.dispatchEvent(event);
+  return event;
+}
+
+class AreaOccupancyCardEditor extends LitElement {
+  static properties = {
+    hass: {},
+    _config: {},
+  };
+
+  setConfig(config) {
+    this._config = { ...config };
+  }
+
+  render() {
+    if (!this.hass) return html``;
+    return html`
+      <div class="form">
+        <ha-textfield
+          label="Probability entity"
+          .value=${this._config.entity || ''}
+          @change=${this._valueChanged}
+          .configValue=${'entity'}
+        ></ha-textfield>
+        <ha-textfield
+          label="Status entity (optional)"
+          .value=${this._config.status_entity || ''}
+          @change=${this._valueChanged}
+          .configValue=${'status_entity'}
+        ></ha-textfield>
+      </div>
+    `;
+  }
+
+  _valueChanged(ev) {
+    const target = ev.target;
+    this._config = {
+      ...this._config,
+      [target.configValue]: target.value,
+    };
+    fireEvent(this, 'config-changed', { config: this._config });
+  }
+}
+
+customElements.define('area-occupancy-card-editor', AreaOccupancyCardEditor);

--- a/custom_components/area_occupancy/www/area-occupancy-card.js
+++ b/custom_components/area_occupancy/www/area-occupancy-card.js
@@ -1,10 +1,18 @@
 import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+import Chart from 'https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js';
 
 class AreaOccupancyCard extends LitElement {
   static properties = {
     hass: {},
     config: {},
+    _history: {},
   };
+
+  constructor() {
+    super();
+    this._history = [];
+    this._chart = null;
+  }
 
   setConfig(config) {
     if (!config.entity) {
@@ -17,9 +25,76 @@ class AreaOccupancyCard extends LitElement {
     };
   }
 
+  static async getConfigElement() {
+    await import('./area-occupancy-card-editor.js');
+    return document.createElement('area-occupancy-card-editor');
+  }
+
+  static getStubConfig(hass) {
+    const [entity] = Object.keys(hass.states).filter((e) =>
+      e.includes('occupancy_probability')
+    );
+    return { entity };
+  }
+
   get probability() {
     const stateObj = this.hass.states[this.config.entity];
     return stateObj ? Number(stateObj.state) : 0;
+  }
+
+  updated(changedProps) {
+    if (changedProps.has('hass')) {
+      this._fetchHistory();
+    }
+  }
+
+  async _fetchHistory() {
+    if (!this.config.entity || !this.hass) return;
+    const end = new Date();
+    const start = new Date(end.getTime() - 3600 * 1000);
+    const url = `history/period/${start.toISOString()}?filter_entity_id=${this.config.entity}&minimal_response&no_attributes&end_time=${end.toISOString()}`;
+    const result = await this.hass.callApi('GET', url);
+    if (Array.isArray(result) && result[0]) {
+      this._history = result[0].map((it) => ({
+        t: new Date(it.last_changed),
+        v: Number(it.state),
+      }));
+      this._updateChart();
+    }
+  }
+
+  _updateChart() {
+    const canvas = this.renderRoot?.querySelector('#chart');
+    if (!canvas) return;
+    const labels = this._history.map((h) => h.t.toLocaleTimeString());
+    const data = this._history.map((h) => h.v);
+    if (!this._chart) {
+      this._chart = new Chart(canvas.getContext('2d'), {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              data,
+              fill: false,
+              borderColor: '#03a9f4',
+              tension: 0.1,
+            },
+          ],
+        },
+        options: {
+          animation: false,
+          plugins: {legend: {display: false}},
+          scales: {
+            y: {min: 0, max: 100},
+          },
+        },
+      });
+    } else {
+      this._chart.data.labels = labels;
+      this._chart.data.datasets[0].data = data;
+      this._chart.update();
+    }
   }
 
   get occupied() {
@@ -38,6 +113,7 @@ class AreaOccupancyCard extends LitElement {
         <div class="value">${probability}%</div>
         <div class="status">${statusText}</div>
         <ha-linear-progress .value=${this.probability / 100}></ha-linear-progress>
+        <canvas id="chart" height="60"></canvas>
       </ha-card>
     `;
   }
@@ -58,6 +134,10 @@ class AreaOccupancyCard extends LitElement {
       color: var(--secondary-text-color);
     }
     ha-linear-progress {
+      width: 100%;
+      margin-top: 8px;
+    }
+    canvas {
       width: 100%;
       margin-top: 8px;
     }

--- a/custom_components/area_occupancy/www/area-occupancy-card.js
+++ b/custom_components/area_occupancy/www/area-occupancy-card.js
@@ -1,0 +1,67 @@
+import { LitElement, html, css } from 'https://unpkg.com/lit?module';
+
+class AreaOccupancyCard extends LitElement {
+  static properties = {
+    hass: {},
+    config: {},
+  };
+
+  setConfig(config) {
+    if (!config.entity) {
+      throw new Error('The "entity" property is required.');
+    }
+    this.config = {
+      name: 'Occupancy',
+      status_entity: null,
+      ...config,
+    };
+  }
+
+  get probability() {
+    const stateObj = this.hass.states[this.config.entity];
+    return stateObj ? Number(stateObj.state) : 0;
+  }
+
+  get occupied() {
+    if (this.config.status_entity) {
+      const status = this.hass.states[this.config.status_entity];
+      return status && status.state === 'on';
+    }
+    return this.probability >= 50;
+  }
+
+  render() {
+    const probability = this.probability.toFixed(0);
+    const statusText = this.occupied ? 'Occupied' : 'Clear';
+    return html`
+      <ha-card .header=${this.config.name}>
+        <div class="value">${probability}%</div>
+        <div class="status">${statusText}</div>
+        <ha-linear-progress .value=${this.probability / 100}></ha-linear-progress>
+      </ha-card>
+    `;
+  }
+
+  static styles = css`
+    ha-card {
+      padding: 16px;
+      text-align: center;
+    }
+    .value {
+      font-size: 2em;
+      font-weight: bold;
+      line-height: 1;
+    }
+    .status {
+      margin-top: 4px;
+      font-size: 1em;
+      color: var(--secondary-text-color);
+    }
+    ha-linear-progress {
+      width: 100%;
+      margin-top: 8px;
+    }
+  `;
+}
+
+customElements.define('area-occupancy-card', AreaOccupancyCard);

--- a/docs/docs/getting-started/lovelace-card.md
+++ b/docs/docs/getting-started/lovelace-card.md
@@ -1,0 +1,23 @@
+# Lovelace Card
+
+This integration includes a simple custom card to display the occupancy probability in the Home Assistant dashboard.
+
+## Installation
+
+1. Ensure the integration is installed through HACS or manually.
+2. Copy `area-occupancy-card.js` from the `www` folder of this repository into your Home Assistant `config/www` directory if not using HACS.
+3. Add the card as a resource in **Settings → Dashboards → Resources** with the URL `/local/area-occupancy-card.js` and type `JavaScript Module`.
+
+## Usage
+
+Add the card to a dashboard using YAML mode or the UI editor.
+Example YAML:
+
+```yaml
+type: custom:area-occupancy-card
+entity: sensor.living_room_occupancy_probability
+status_entity: binary_sensor.living_room_occupancy_status
+name: Living Room
+```
+
+The card shows the current probability, the occupancy status, and a progress bar visualising the probability level.

--- a/docs/docs/getting-started/lovelace-card.md
+++ b/docs/docs/getting-started/lovelace-card.md
@@ -1,6 +1,7 @@
 # Lovelace Card
 
 This integration includes a simple custom card to display the occupancy probability in the Home Assistant dashboard.
+The card also shows a line graph of the last hour of probability values.
 
 ## Installation
 
@@ -20,4 +21,5 @@ status_entity: binary_sensor.living_room_occupancy_status
 name: Living Room
 ```
 
-The card shows the current probability, the occupancy status, and a progress bar visualising the probability level.
+The card shows the current probability, the occupancy status, a progress bar visualising the probability level, and a graph of recent changes.
+The configuration can be done entirely from the UI once the card is added as a resource.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
     - Installation: getting-started/installation.md
     - Configuration: getting-started/configuration.md
     - Basic Usage: getting-started/basic-usage.md
+    - Lovelace Card: getting-started/lovelace-card.md
   - Features:
     - Bayesian Calculation: features/calculation.md
     - Prior Learning: features/prior-learning.md


### PR DESCRIPTION
## Summary
- create a simple Lovelace card to display occupancy probability
- document how to use the card and update docs navigation
- mention card usage in the main README

## Testing
- `scripts/lint`
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_6878b9f06f90832f8b091fac5a359c2d