### PR TITLE
Raise coverage past 85%

### DIFF
--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -958,8 +958,9 @@ class TestPriorTimeBasedCalculations:
         mock_intervals = [
             {
                 "state": "on",
-                "start": base_time + timedelta(hours=10),  # Different time
-                "end": base_time + timedelta(hours=12),
+                # Use a time window well outside the 7:00 AM slot
+                "start": base_time + timedelta(hours=15),
+                "end": base_time + timedelta(hours=17),
             },
         ]
         mock_get_intervals.return_value = mock_intervals


### PR DESCRIPTION
## Summary
- fix prior test timeslot to avoid accidental overlap
- add likelihood tests covering calculation and overlap helper

## Testing
- `pytest --cov=custom_components.area_occupancy --cov-report term -q`

------
https://chatgpt.com/codex/tasks/task_e_687e92b7fa08832fa3475b2913d21a40