### PR TITLE
Improve tests to reach 85% coverage

### DIFF
--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -954,7 +954,9 @@ class TestPriorTimeBasedCalculations:
         prior = Prior(mock_coordinator)
 
         # Mock intervals that don't overlap with time slot
-        base_time = dt_util.utcnow() - timedelta(days=7)
+        base_time = (dt_util.utcnow() - timedelta(days=7)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
         mock_intervals = [
             {
                 "state": "on",


### PR DESCRIPTION
## Summary
- adjust time calculations in prior tests so intervals don’t overlap
- add tests for async coordinator helpers
- exercise database round trip in storage tests

## Testing
- `pytest -q`
- `coverage run -m pytest -q && coverage report -m | tail -n 20`

------
https://chatgpt.com/codex/tasks/task_e_687e92b7fa08832fa3475b2913d21a40