### PR TITLE
Fix lingering timer test failures

### DIFF
--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.util import dt as dt_util
 
 # Add marker for tests that may have lingering timers due to HA internals
-pytestmark = [pytest.mark.expected_lingering_timers(True)]
+pytestmark = [pytest.mark.parametrize("expected_lingering_timers", [True])]
 
 
 # ruff: noqa: SLF001
@@ -77,7 +77,6 @@ class TestOccupancy:
         assert entity.is_on is False
 
 
-@pytest.mark.expected_lingering_timers(True)
 class TestWaspInBoxSensor:
     """Test WaspInBoxSensor binary sensor entity."""
 
@@ -536,7 +535,6 @@ class TestAsyncSetupEntry:
         assert isinstance(entities[0], Occupancy)
 
 
-@pytest.mark.expected_lingering_timers(True)
 class TestWaspInBoxIntegration:
     """Test WaspInBoxSensor integration scenarios."""
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -41,7 +41,7 @@ from homeassistant.data_entry_flow import AbortFlow, FlowResultType
 
 
 # ruff: noqa: SLF001
-@pytest.mark.expected_lingering_timers(True)
+@pytest.mark.parametrize("expected_lingering_timers", [True])
 class TestBaseOccupancyFlow:
     """Test BaseOccupancyFlow class."""
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -702,6 +702,7 @@ class TestCoordinatorSetupScenarios:
             patch.object(coordinator, "track_entity_state_changes", new=AsyncMock()),
             patch.object(coordinator, "_start_prior_timer"),
             patch.object(coordinator, "_start_decay_timer"),
+            patch.object(coordinator, "_start_historical_timer"),
             patch.object(
                 coordinator.entity_types, "get_entity_type"
             ) as mock_get_entity_type,
@@ -738,6 +739,7 @@ class TestCoordinatorSetupScenarios:
             patch.object(coordinator, "track_entity_state_changes", new=AsyncMock()),
             patch.object(coordinator, "_start_prior_timer"),
             patch.object(coordinator, "_start_decay_timer"),
+            patch.object(coordinator, "_start_historical_timer"),
             patch.object(
                 coordinator.entity_types, "get_entity_type"
             ) as mock_get_entity_type,
@@ -772,6 +774,9 @@ class TestCoordinatorSetupScenarios:
                 "async_initialize",
                 side_effect=HomeAssistantError("Entity init failed"),
             ),
+            patch.object(coordinator, "_start_prior_timer"),
+            patch.object(coordinator, "_start_decay_timer"),
+            patch.object(coordinator, "_start_historical_timer"),
             patch.object(
                 coordinator.entity_types, "get_entity_type"
             ) as mock_get_entity_type,
@@ -804,6 +809,7 @@ class TestCoordinatorSetupScenarios:
             patch.object(coordinator, "track_entity_state_changes", new=AsyncMock()),
             patch.object(coordinator, "_start_prior_timer"),
             patch.object(coordinator, "_start_decay_timer"),
+            patch.object(coordinator, "_start_historical_timer"),
             patch.object(
                 coordinator.entity_types, "get_entity_type"
             ) as mock_get_entity_type,


### PR DESCRIPTION
## Summary
- patch out coordinator historical timer in tests so timer cleanup is not required
- mark lingering timers via `parametrize` so the cleanup fixture allows them

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880d9679318832fb69b0c38c26711d7