### PR TITLE
Refactor SQLite storage table and index creation in Area Occupancy component

### DIFF
--- a/custom_components/area_occupancy/data/prior.py
+++ b/custom_components/area_occupancy/data/prior.py
@@ -484,7 +484,6 @@ class Prior:  # exported name must stay identical
                 # Get intervals for this entity during the analysis period
                 intervals = (
                     await self.coordinator.sqlite_store.get_historical_intervals(
-                        self.coordinator,
                         entity_id,
                         start_time,
                         end_time,

--- a/custom_components/area_occupancy/sqlite_storage.py
+++ b/custom_components/area_occupancy/sqlite_storage.py
@@ -24,7 +24,6 @@ from .schema import (
     area_occupancy_table,
     area_time_priors_table,
     entities_table,
-    indexes,
     metadata,
     metadata_table,
     state_intervals_table,
@@ -109,23 +108,8 @@ class AreaOccupancyStorage:
 
                     _LOGGER.debug("Existing tables: %s", existing_tables)
 
-                # Create tables individually if they don't exist
-                for table_name, table in metadata.tables.items():
-                    if table_name not in existing_tables:
-                        _LOGGER.debug("Creating table: %s", table_name)
-                        table.create(self.engine)
-                    else:
-                        _LOGGER.debug("Table %s already exists, skipping", table_name)
-
-                # Create all indexes
-                with self.engine.connect() as conn:
-                    for index in indexes:
-                        try:
-                            index.create(conn, checkfirst=True)
-                        except sa.exc.SQLAlchemyError as idx_err:
-                            _LOGGER.debug(
-                                "Index creation skipped (likely exists): %s", idx_err
-                            )
+                # Create all tables and indexes in one call
+                metadata.create_all(self.engine, checkfirst=True)
 
                 # Initialize/check version metadata
                 with self.engine.connect() as conn:


### PR DESCRIPTION
- Simplified the table and index creation process by using `metadata.create_all` to handle both in a single call, improving efficiency and readability.
- Removed redundant code related to individual table and index creation.
- Cleaned up import statements in `sqlite_storage.py` to enhance maintainability.

- Updated the `Prior` class to remove an unnecessary reference to the coordinator during historical interval retrieval, streamlining the code.