### PR TITLE
Add purge_intervals service to manage state intervals retention

### DIFF
--- a/custom_components/area_occupancy/services.yaml
+++ b/custom_components/area_occupancy/services.yaml
@@ -155,3 +155,32 @@ update_time_based_priors:
       selector:
         config_entry:
           integration: area_occupancy
+
+purge_intervals:
+  name: Purge State Intervals
+  description: "Purge the state_intervals table based on filter_intervals and a retention period. Optionally filter by entity_ids. Removes intervals older than the retention period that do not pass filter_intervals."
+  fields:
+    entry_id:
+      name: Entry ID
+      description: "Select the Area Occupancy instance to purge intervals for."
+      required: true
+      selector:
+        config_entry:
+          integration: area_occupancy
+    retention_days:
+      name: Retention Days
+      description: "Number of days to retain intervals (intervals older than this may be purged). Default is 365."
+      required: false
+      default: 365
+      selector:
+        number:
+          min: 1
+          max: 3650
+          mode: box
+    entity_ids:
+      name: Entity IDs
+      description: "List of entity IDs to purge (leave empty for all configured entities)."
+      required: false
+      selector:
+        entity:
+          multiple: true


### PR DESCRIPTION
This pull request introduces a new service, `purge_intervals`, to manage the cleanup of historical state intervals in the `area_occupancy` integration. The service allows for purging intervals based on a retention period and optional filtering by entity IDs. Key changes include the implementation of the service logic, registration in the integration, and updates to the service schema.

### New Service Implementation:

* **Service Logic for Purging State Intervals:**
  - Added `_purge_intervals` function to handle purging intervals from the `state_intervals` table. It deletes intervals older than a specified retention period and filters out intervals that do not meet criteria defined by `filter_intervals`. (`custom_components/area_occupancy/service.py`, [custom_components/area_occupancy/service.pyR786-R901](diffhunk://#diff-1bf8507e412d7bc8cac8ece33506110e5edb5db202140c2c4e12ca31697ff2ffR786-R901))

* **Service Schema Definition:**
  - Introduced `purge_intervals_schema` to define the parameters for the new service, including `entry_id`, `retention_days` (default: 365), and `entity_ids` (optional). (`custom_components/area_occupancy/service.py`, [custom_components/area_occupancy/service.pyR937-R944](diffhunk://#diff-1bf8507e412d7bc8cac8ece33506110e5edb5db202140c2c4e12ca31697ff2ffR937-R944))

### Integration with `area_occupancy`:

* **Service Registration:**
  - Registered the `purge_intervals` service within the `async_setup_services` function, enabling it to be used within the Home Assistant environment. (`custom_components/area_occupancy/service.py`, [custom_components/area_occupancy/service.pyR1087-R1094](diffhunk://#diff-1bf8507e412d7bc8cac8ece33506110e5edb5db202140c2c4e12ca31697ff2ffR1087-R1094))

* **Service Handler:**
  - Added `handle_purge_intervals` to wrap and call the `_purge_intervals` function when the service is invoked. (`custom_components/area_occupancy/service.py`, [custom_components/area_occupancy/service.pyR982-R984](diffhunk://#diff-1bf8507e412d7bc8cac8ece33506110e5edb5db202140c2c4e12ca31697ff2ffR982-R984))

### Documentation Updates:

* **Service Description in `services.yaml`:**
  - Documented the `purge_intervals` service, detailing its purpose, parameters, and usage. This includes descriptions for `entry_id`, `retention_days`, and `entity_ids`. (`custom_components/area_occupancy/services.yaml`, [custom_components/area_occupancy/services.yamlR158-R186](diffhunk://#diff-ab7cc66880b15aee07c7194f23a982125b650c5497bea1f7fe2141086a8f4655R158-R186))