### PR TITLE
Removal of "force" and "history_period" Parameters

### DIFF
--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -179,9 +179,9 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self.entities = EntityManager(self)
                 await self.entities.__post_init__()
             # Calculate priors and likelihoods
-            await self.prior.update(force=True)
+            await self.prior.update()
             await self.entities.update_all_entity_likelihoods()
-            await self.sqlite_store.async_save_data(force=True)
+            await self.sqlite_store.async_save_data()
             # Track entity state changes
             await self.track_entity_state_changes(self.entities.entity_ids)
             # Start timers only after everything is ready
@@ -229,7 +229,7 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self._analysis_timer()
             self._analysis_timer = None
 
-        await self.sqlite_store.async_save_data(force=True)
+        await self.sqlite_store.async_save_data()
 
         # Clean up entity manager
         await self.entities.cleanup()
@@ -264,7 +264,7 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         await self.track_entity_state_changes(self.entities.entity_ids)
 
         # Force immediate save after configuration changes
-        await self.sqlite_store.async_save_data(force=True)
+        await self.sqlite_store.async_save_data()
 
         await self.async_request_refresh()
 
@@ -344,7 +344,7 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     )
 
                     # Recalculate priors with new data
-                    await self.prior.update(force=True)
+                    await self.prior.update()
 
                     # Recalculate likelihoods with new data
                     await self.entities.update_all_entity_likelihoods()

--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -386,13 +386,12 @@ class EntityManager:
         }
 
     async def update_all_entity_likelihoods(
-        self, history_period: int | None = None, force: bool = False
+        self, history_period: int | None = None
     ) -> int:
         """Update all entity likelihoods.
 
         Args:
             history_period: Period in days for historical data
-            force: If True, bypass cache validation and force recalculation
 
         Returns:
             int: Number of entities updated
@@ -414,7 +413,7 @@ class EntityManager:
             tasks = []
             for entity in chunk:
                 task = self._update_entity_likelihood(
-                    entity, force=force, history_period=history_period
+                    entity, history_period=history_period
                 )
                 tasks.append(task)
 
@@ -439,13 +438,12 @@ class EntityManager:
         return updated_count
 
     async def _update_entity_likelihood(
-        self, entity: Entity, force: bool = False, history_period: int | None = None
+        self, entity: Entity, history_period: int | None = None
     ) -> int:
         """Safely update a single entity's likelihood with error handling.
 
         Args:
             entity: The entity to update
-            force: If True, bypass cache validation and force recalculation
             history_period: Period in days for historical data
 
         Returns:
@@ -453,7 +451,7 @@ class EntityManager:
 
         """
         try:
-            await entity.likelihood.update(force=force, history_period=history_period)
+            await entity.likelihood.update(history_period=history_period)
         except (ValueError, TypeError) as err:
             _LOGGER.warning(
                 "Failed to update likelihood for entity %s: %s",

--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -385,13 +385,8 @@ class EntityManager:
             InputType.TEMPERATURE: self.config.sensors.temperature,
         }
 
-    async def update_all_entity_likelihoods(
-        self, history_period: int | None = None
-    ) -> int:
+    async def update_all_entity_likelihoods(self) -> int:
         """Update all entity likelihoods.
-
-        Args:
-            history_period: Period in days for historical data
 
         Returns:
             int: Number of entities updated
@@ -412,9 +407,7 @@ class EntityManager:
             # Create tasks for parallel processing
             tasks = []
             for entity in chunk:
-                task = self._update_entity_likelihood(
-                    entity, history_period=history_period
-                )
+                task = self._update_entity_likelihood(entity)
                 tasks.append(task)
 
             # Wait for all tasks in this chunk to complete
@@ -437,21 +430,18 @@ class EntityManager:
         )
         return updated_count
 
-    async def _update_entity_likelihood(
-        self, entity: Entity, history_period: int | None = None
-    ) -> int:
+    async def _update_entity_likelihood(self, entity: Entity) -> int:
         """Safely update a single entity's likelihood with error handling.
 
         Args:
             entity: The entity to update
-            history_period: Period in days for historical data
 
         Returns:
             1 if successful, 0 if failed
 
         """
         try:
-            await entity.likelihood.update(history_period=history_period)
+            await entity.likelihood.update()
         except (ValueError, TypeError) as err:
             _LOGGER.warning(
                 "Failed to update likelihood for entity %s: %s",

--- a/custom_components/area_occupancy/data/likelihood.py
+++ b/custom_components/area_occupancy/data/likelihood.py
@@ -135,28 +135,17 @@ class Likelihood:
             else self.default_prob_false
         )
 
-    async def update(
-        self, force: bool = False, history_period: int | None = None
-    ) -> tuple[float, float]:
-        """Return a likelihood, re-computing if the cache is stale or forced.
+    async def update(self, history_period: int | None = None) -> tuple[float, float]:
+        """Return a likelihood, always re-computing (cache is always stale/forced).
 
         Args:
-            force: If True, bypass cache validation and force recalculation
             history_period: Period in days for historical data (overrides coordinator default)
 
         Returns:
             Tuple of (prob_given_true, prob_given_false) weighted values
 
         """
-        # Check if we can use cached values
-        if not force and self._is_cache_valid():
-            _LOGGER.debug(
-                "Using cached likelihood values for %s (last updated: %s)",
-                self.entity_id,
-                self.last_updated,
-            )
-            return self.prob_given_true, self.prob_given_false
-
+        # Always recalculate
         _LOGGER.debug(
             "Recalculating likelihood for %s (cache invalid or stale)", self.entity_id
         )

--- a/custom_components/area_occupancy/data/prior.py
+++ b/custom_components/area_occupancy/data/prior.py
@@ -176,16 +176,10 @@ class Prior:  # exported name must stay identical
             return self._global_prior_cache
         return PriorCacheEntry(prior=MIN_PRIOR, occupied_seconds=0, total_seconds=0)
 
-    async def update(
-        self, force: bool = False, history_period: int | None = None
-    ) -> float:
+    async def update(self, history_period: int | None = None) -> float:
         """Unified update: calculate all prior tiers and update caches with a single timestamp."""
-        if not force and self._is_cache_valid():
-            return self.value  # type: ignore[return-value]
         try:
-            value = await self.calculate_all_priors(
-                history_period=history_period, force=force
-            )
+            value = await self.calculate_all_priors(history_period=history_period)
         except Exception:  # pragma: no cover
             _LOGGER.exception("Prior calculation failed, using default %.2f", MIN_PRIOR)
             value = MIN_PRIOR
@@ -194,9 +188,7 @@ class Prior:  # exported name must stay identical
             self._last_updated = dt_util.utcnow()
         return value
 
-    async def calculate_all_priors(
-        self, history_period: int | None = None, force: bool = False
-    ) -> float:
+    async def calculate_all_priors(self, history_period: int | None = None) -> float:
         """Calculate and update all prior tiers (global, day, time slot) and caches, with a single last_updated timestamp."""
         days_to_use = history_period if history_period is not None else self.days
         start_time = dt_util.utcnow() - timedelta(days=days_to_use)

--- a/custom_components/area_occupancy/data/prior.py
+++ b/custom_components/area_occupancy/data/prior.py
@@ -57,13 +57,12 @@ class Prior:  # exported name must stay identical
         self._last_updated: datetime | None = None
         self._sensor_hash: int | None = None
         self._time_prior_cache: dict[tuple[int, int], PriorCacheEntry] = {}
-        self._day_prior_cache: dict[int, PriorCacheEntry] = {}
         self._global_prior_cache: PriorCacheEntry | None = None
 
     # --------------------------------------------------------------------- #
     @property
     def value(self) -> float:
-        """Return the best available prior: time-based, day, global, or minimum."""
+        """Return the best available prior: time-based, global, or minimum."""
         try:
             # 1. Try time slot prior
             slot = self.get_time_slot_prior()
@@ -73,15 +72,7 @@ class Prior:  # exported name must stay identical
                 and slot.prior >= MIN_PRIOR
             ):
                 return slot.prior
-            # 2. Try day prior
-            day = self.get_day_prior()
-            if (
-                day
-                and day.occupied_seconds >= MIN_PRIOR_OCCUPIED_SECONDS
-                and day.prior >= MIN_PRIOR
-            ):
-                return day.prior
-            # 3. Try global prior
+            # 2. Try global prior
             global_ = self.get_global_prior()
             if global_ and global_.prior >= MIN_PRIOR:
                 return global_.prior
@@ -146,26 +137,6 @@ class Prior:  # exported name must stay identical
             return self._time_prior_cache
         return PriorCacheEntry(prior=MIN_PRIOR, occupied_seconds=0, total_seconds=0)
 
-    def get_day_prior(self):
-        """Get the day prior."""
-        # Always return a valid PriorCacheEntry
-        if self._day_prior_cache:
-            # If it's a dict (time slot cache), pick the current slot if possible
-            if isinstance(self._day_prior_cache, dict):
-                try:
-                    day, _ = get_current_time_slot()
-                    # Find all slots for this day
-                    slots = [
-                        v for (d, _), v in self._day_prior_cache.items() if d == day
-                    ]
-                    if slots:
-                        # Return the first or average
-                        return slots[0]
-                except Exception:  # noqa: BLE001
-                    pass
-            return self._day_prior_cache
-        return PriorCacheEntry(prior=MIN_PRIOR, occupied_seconds=0, total_seconds=0)
-
     def get_global_prior(self):
         """Get the global prior."""
         # Always return a valid PriorCacheEntry
@@ -186,7 +157,7 @@ class Prior:  # exported name must stay identical
         return value
 
     async def calculate_all_priors(self) -> float:
-        """Calculate and update all prior tiers (global, day, time slot) and caches, with a single last_updated timestamp."""
+        """Calculate and update all prior tiers (global, time slot) and caches, with a single last_updated timestamp."""
         start_time = dt_util.utcnow() - timedelta(days=self.days)
         end_time = dt_util.utcnow()
         total_seconds = int((end_time - start_time).total_seconds())
@@ -195,9 +166,6 @@ class Prior:  # exported name must stay identical
         self._global_prior_cache = await self._calculate_global_prior(
             start_time, end_time, total_seconds
         )
-
-        # --- Day priors ---
-        self._day_prior_cache = await self._calculate_day_priors(start_time, end_time)
 
         # --- Time slot priors ---
         self._time_prior_cache = await self._calculate_time_slot_priors(
@@ -242,58 +210,6 @@ class Prior:  # exported name must stay identical
             total_seconds=total_seconds,
         )
 
-    async def _calculate_day_priors(self, start_time, end_time):
-        """Calculate day priors for each day of the week."""
-        day_priors: dict[int, PriorCacheEntry] = {}
-        for day_of_week in range(7):
-            total_occupied_seconds = 0
-            total_analyzed_seconds = 0
-            for entity_id in self.sensor_ids:
-                intervals = (
-                    await self.coordinator.sqlite_store.get_historical_intervals(
-                        entity_id,
-                        start_time,
-                        end_time,
-                    )
-                )
-                if not intervals:
-                    continue
-                for interval in intervals:
-                    interval_start = interval["start"]
-                    interval_end = interval["end"]
-                    if interval_start.weekday() == day_of_week:
-                        day_start = interval_start.replace(
-                            hour=0, minute=0, second=0, microsecond=0
-                        )
-                        day_end = day_start + timedelta(days=1)
-                        overlap_start = max(interval_start, day_start)
-                        overlap_end = min(interval_end, day_end)
-                        if overlap_start < overlap_end:
-                            overlap_seconds = (
-                                overlap_end - overlap_start
-                            ).total_seconds()
-                            total_occupied_seconds += overlap_seconds
-                # Only add analyzed seconds once per day, not per entity
-                if entity_id == self.sensor_ids[0]:
-                    total_analyzed_seconds += 86400 * (self.days // 7)
-            global_prior = self.global_prior
-            max_prior = min(global_prior * GLOBAL_PRIOR_FACTOR, MAX_PRIOR)
-            if total_analyzed_seconds > 0:
-                smoothed_prior = (
-                    total_occupied_seconds
-                    + SMOOTHING_FACTOR * global_prior * total_analyzed_seconds
-                ) / (total_analyzed_seconds + SMOOTHING_FACTOR * total_analyzed_seconds)
-                smoothed_prior = smoothed_prior * PRIOR_BUFFER_FACTOR
-                prior = max(MIN_PRIOR, min(smoothed_prior, max_prior))
-            else:
-                prior = global_prior
-            day_priors[day_of_week] = PriorCacheEntry(
-                prior=prior,
-                occupied_seconds=int(total_occupied_seconds),
-                total_seconds=int(total_analyzed_seconds),
-            )
-        return day_priors
-
     async def _calculate_time_slot_priors(self, start_time, end_time):
         """Calculate time slot priors for each day and slot."""
         time_priors: dict[tuple[int, int], PriorCacheEntry] = {}
@@ -308,7 +224,6 @@ class Prior:  # exported name must stay identical
                     time_slot,
                     start_time,
                     end_time,
-                    self.days,
                 )
                 time_priors[(day_of_week, time_slot)] = PriorCacheEntry(
                     prior=prior_value,

--- a/custom_components/area_occupancy/service.py
+++ b/custom_components/area_occupancy/service.py
@@ -210,7 +210,6 @@ async def _update_area_prior(hass: HomeAssistant, call: ServiceCall) -> dict[str
         return {
             "area_name": coordinator.config.name,
             "area_prior": coordinator.prior.value,
-            "day_prior": getattr(coordinator.prior.get_day_prior(), "prior", None),
             "time_prior": getattr(
                 coordinator.prior.get_time_slot_prior(), "prior", None
             ),

--- a/custom_components/area_occupancy/service.py
+++ b/custom_components/area_occupancy/service.py
@@ -386,34 +386,6 @@ async def _get_entity_details(hass: HomeAssistant, call: ServiceCall) -> dict[st
         return {"entity_details": details}
 
 
-async def _force_entity_update(
-    hass: HomeAssistant, call: ServiceCall
-) -> dict[str, Any]:
-    """Force immediate update of specific entities."""
-    entry_id = call.data["entry_id"]
-    entity_ids = call.data.get("entity_ids", [])
-
-    try:
-        coordinator = _get_coordinator(hass, entry_id)
-        entities = coordinator.entities
-
-        if not entity_ids:
-            entity_ids = list(entities.entities.keys())
-
-        updated_count = len(entity_ids)
-
-        await coordinator.async_refresh()
-
-        _LOGGER.info("Force updated %d entities in entry %s", updated_count, entry_id)
-
-    except Exception as err:
-        error_msg = f"Failed to force entity updates for {entry_id}: {err}"
-        _LOGGER.error(error_msg)
-        raise HomeAssistantError(error_msg) from err
-    else:
-        return {"updated_entities": updated_count}
-
-
 async def _get_area_status(hass: HomeAssistant, call: ServiceCall) -> dict[str, Any]:
     """Get current area occupancy status and confidence."""
     entry_id = call.data["entry_id"]
@@ -826,10 +798,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         {vol.Required("entry_id"): str, vol.Optional("entity_ids", default=[]): [str]}
     )
 
-    force_update_schema = vol.Schema(
-        {vol.Required("entry_id"): str, vol.Optional("entity_ids", default=[]): [str]}
-    )
-
     entity_type_learned_schema = vol.Schema({vol.Required("entry_id"): str})
 
     purge_intervals_schema = vol.Schema(
@@ -858,9 +826,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
     async def handle_get_entity_details(call: ServiceCall) -> dict[str, Any]:
         return await _get_entity_details(hass, call)
-
-    async def handle_force_entity_update(call: ServiceCall) -> dict[str, Any]:
-        return await _force_entity_update(hass, call)
 
     async def handle_get_area_status(call: ServiceCall) -> dict[str, Any]:
         return await _get_area_status(hass, call)
@@ -919,14 +884,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         "get_entity_details",
         handle_get_entity_details,
         schema=entity_details_schema,
-        supports_response=SupportsResponse.ONLY,
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        "force_entity_update",
-        handle_force_entity_update,
-        schema=force_update_schema,
         supports_response=SupportsResponse.ONLY,
     )
 

--- a/custom_components/area_occupancy/service.py
+++ b/custom_components/area_occupancy/service.py
@@ -775,7 +775,6 @@ async def async_setup_services(hass: HomeAssistant) -> None:
     # Service schemas
     entry_id_schema = vol.Schema({vol.Required("entry_id"): str})
 
-    # Remove history_period from schemas
     update_area_prior_schema = vol.Schema(
         {
             vol.Required("entry_id"): str,

--- a/custom_components/area_occupancy/services.yaml
+++ b/custom_components/area_occupancy/services.yaml
@@ -89,25 +89,6 @@ get_entity_details:
         entity:
           multiple: true
 
-force_entity_update:
-  name: Force Entity Update
-  description: "Force immediate probability recalculation for specific entities."
-  fields:
-    entry_id:
-      name: Entry ID
-      description: "Select the Area Occupancy instance."
-      required: true
-      selector:
-        config_entry:
-          integration: area_occupancy
-    entity_ids:
-      name: Entity IDs
-      description: "List of entity IDs to force update (leave empty for all entities)."
-      required: false
-      selector:
-        entity:
-          multiple: true
-
 get_entity_type_learned_data:
   name: Get Entity Type Learned Data
   description: "Get the current learned prior, prob_true, and prob_false for each entity type. Useful for diagnostics and monitoring the learning process."

--- a/custom_components/area_occupancy/sqlite_storage.py
+++ b/custom_components/area_occupancy/sqlite_storage.py
@@ -773,7 +773,7 @@ class AreaOccupancyStorage:
 
         return await self.hass.async_add_executor_job(_get_count)
 
-    async def async_save_data(self, force: bool = False) -> None:
+    async def async_save_data(self) -> None:
         """Save coordinator data to SQLite storage using normalized schema."""
         if not self.coordinator:
             raise RuntimeError("Coordinator is required for async_save_data")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -669,7 +669,7 @@ class TestCoordinatorSetupScenarios:
         # Verify initialization sequence
         coordinator.entity_types.async_initialize.assert_called_once()
         # EntityManager.__post_init__ is called automatically during object creation, not by setup
-        coordinator.sqlite_store.async_save_data.assert_any_call(force=True)
+        coordinator.sqlite_store.async_save_data.assert_any_call()
         assert coordinator.sqlite_store.async_save_data.call_count == 2
 
     async def test_setup_with_stored_data_restoration(

--- a/tests/test_data_likelihood.py
+++ b/tests/test_data_likelihood.py
@@ -5,7 +5,6 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from custom_components.area_occupancy.const import HA_RECORDER_DAYS
 from custom_components.area_occupancy.data.likelihood import Likelihood
 from homeassistant.util import dt as dt_util
 
@@ -489,9 +488,7 @@ class TestLikelihoodEdgeCases:
         mock_sqlite_store.get_historical_intervals = AsyncMock(return_value=intervals)
         mock_coordinator.sqlite_store = mock_sqlite_store
 
-        active_ratio, inactive_ratio = await likelihood.calculate(
-            history_period=HA_RECORDER_DAYS
-        )
+        active_ratio, inactive_ratio = await likelihood.calculate()
 
         assert active_ratio == pytest.approx(0.8, rel=1e-3)
         assert inactive_ratio == pytest.approx(0.1, rel=1e-3)

--- a/tests/test_data_likelihood.py
+++ b/tests/test_data_likelihood.py
@@ -150,36 +150,6 @@ class TestLikelihood:
             assert likelihood.inactive_ratio == 0.1
             assert likelihood.last_updated is not None
 
-    async def test_update_uses_cache_when_valid(self, mock_coordinator: Mock) -> None:
-        """Test that update() uses cached values when cache is valid."""
-
-        likelihood = Likelihood(
-            coordinator=mock_coordinator,
-            entity_id="binary_sensor.motion",
-            active_states=["on"],
-            default_prob_true=0.8,
-            default_prob_false=0.1,
-            weight=0.7,
-        )
-
-        # Set cached values that are fresh
-        likelihood.active_ratio = 0.6
-        likelihood.inactive_ratio = 0.05
-        likelihood.last_updated = dt_util.utcnow()
-
-        # Mock calculate method to ensure it's not called
-        with patch.object(
-            likelihood, "calculate", new_callable=AsyncMock
-        ) as mock_calculate:
-            prob_true, prob_false = await likelihood.update()
-
-            # Should not call calculate since cache is valid
-            mock_calculate.assert_not_called()
-
-            # Should return weighted values based on cached data
-            assert prob_true == likelihood.prob_given_true
-            assert prob_false == likelihood.prob_given_false
-
     async def test_update_recalculates_when_cache_stale(
         self, mock_coordinator: Mock
     ) -> None:

--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -197,17 +197,7 @@ class TestPrior:
         """Test update method with invalid cache triggers recalculation."""
         prior = Prior(mock_coordinator)
         prior._current_value = None
-        result = await prior.update(force=True)
-        assert result == prior.value
-
-    async def test_update_force_recalculation(self, mock_coordinator: Mock) -> None:
-        """Test update method with force=True always recalculates."""
-        mock_coordinator.config.sensors.motion = ["sensor1"]
-        prior = Prior(mock_coordinator)
-        prior._current_value = 0.4
-        prior._last_updated = dt_util.utcnow() - timedelta(minutes=30)
-        prior._sensor_hash = hash(frozenset(["sensor1"]))
-        result = await prior.update(force=True)
+        result = await prior.update()
         assert result == prior.value
 
     async def test_update_calculation_error(self, mock_coordinator: Mock) -> None:

--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -278,6 +278,9 @@ class TestPrior:
         result = prior.to_dict()
 
         expected = {"value": None, "last_updated": None, "sensor_hash": None}
+        assert result["sensor_hash"] is None
+        assert expected["sensor_hash"] is None
+        result["sensor_hash"] = None
         assert result == expected
 
     def test_from_dict(self, mock_coordinator: Mock) -> None:
@@ -505,7 +508,6 @@ class TestPriorEdgeCases:
 
         # The actual implementation now returns MIN_PRIOR and empty data on error
         prior_value, data, all_intervals = await prior._calculate_prior_for_entities(
-            ["binary_sensor.motion1"],
             start_time,
             end_time,
             total_seconds,
@@ -556,7 +558,6 @@ class TestPriorEdgeCases:
 
         # The actual implementation skips failed entities and does not raise
         prior_value, data, all_intervals = await prior._calculate_prior_for_entities(
-            ["binary_sensor.motion1", "binary_sensor.motion2"],
             start_time,
             end_time,
             total_seconds,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -235,9 +235,7 @@ class TestUpdateLikelihoods:
         assert likelihood_data["prob_given_true_raw"] == 0.75
         assert likelihood_data["prob_given_false_raw"] == 0.05
 
-        # Verify the coordinator was called correctly with history_period
-
-        # Verify the coordinator was called correctly with history_period
+        # Verify the coordinator was called correctly
         mock_coordinator.entities.update_all_entity_likelihoods.assert_called_once_with()
         mock_coordinator.async_refresh.assert_called_once()
 


### PR DESCRIPTION
This pull request simplifies the logic for updating priors, likelihoods, and caching mechanisms in the `area_occupancy` custom component by removing unused features and redundant arguments. The changes streamline the codebase, improve maintainability, and ensure consistency in how calculations are performed.

### Removal of "force" and "history_period" Parameters
* [`custom_components/area_occupancy/coordinator.py`](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL182-R184): Removed the `force` parameter from calls to `prior.update` and `sqlite_store.async_save_data`, as well as the `history_period` parameter from `entities.update_all_entity_likelihoods`. These updates now always recompute values without bypassing cache validation. [[1]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL182-R184) [[2]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL232-R232) [[3]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL267-R267) [[4]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL347-R347)
* [`custom_components/area_occupancy/data/entity.py`](diffhunk://#diff-bf51304cf2e96e4371cdb63d35175f6fef3f589db16cce4c113c27cd33a227a4L388-L396): Simplified `update_all_entity_likelihoods` and `_update_entity_likelihood` by removing the `force` and `history_period` arguments. [[1]](diffhunk://#diff-bf51304cf2e96e4371cdb63d35175f6fef3f589db16cce4c113c27cd33a227a4L388-L396) [[2]](diffhunk://#diff-bf51304cf2e96e4371cdb63d35175f6fef3f589db16cce4c113c27cd33a227a4L416-R410) [[3]](diffhunk://#diff-bf51304cf2e96e4371cdb63d35175f6fef3f589db16cce4c113c27cd33a227a4L441-R444)
* [`custom_components/area_occupancy/data/likelihood.py`](diffhunk://#diff-fbf9ec1181c115e5ada4297ce771b505105c781da7f050718790fa109c9d2e68L138-R151): Updated the `update` and `calculate` methods to always recompute likelihoods, removing reliance on cache validation and `history_period`. [[1]](diffhunk://#diff-fbf9ec1181c115e5ada4297ce771b505105c781da7f050718790fa109c9d2e68L138-R151) [[2]](diffhunk://#diff-fbf9ec1181c115e5ada4297ce771b505105c781da7f050718790fa109c9d2e68L184-R171)

### Removal of Day-Based Priors
* [`custom_components/area_occupancy/data/prior.py`](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L59-R65): Removed all logic and caching related to day-based priors, including the `get_day_prior` method and `_calculate_day_priors`. The code now focuses on global and time-slot priors. [[1]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L59-R65) [[2]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L79-R75) [[3]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L152-R150) [[4]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L211-R172) [[5]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L259-R213)

### Refactoring and Simplification of Prior Calculations
* [`custom_components/area_occupancy/data/prior.py`](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L325-L330): Simplified `_calculate_time_slot_priors` and `_calculate_prior_for_time_slot_full` by removing unused arguments like `entity_ids` and `days_to_use`, leveraging `self.sensor_ids` directly instead. [[1]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L325-L330) [[2]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L341-L346) [[3]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L382-R276)
* Removed redundant arguments from `_calculate_prior_for_entities` and ensured it uses `self.sensor_ids` for consistency. [[1]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L416) [[2]](diffhunk://#diff-dbc4afad7873a2f1108ddb371a22428dc793beacd1e1ee7d2e98fc03a3658be6L429-R324)

### Removal of Day Prior from Service Output
* [`custom_components/area_occupancy/service.py`](diffhunk://#diff-1bf8507e412d7bc8cac8ece33506110e5edb5db202140c2c4e12ca31697ff2ffL213): Removed the `day_prior` field from the `_update_area_prior` service output, as day-based priors are no longer calculated.