### PR TITLE
Fix door sensors attribute naming

### DIFF
--- a/custom_components/area_occupancy/binary_sensor.py
+++ b/custom_components/area_occupancy/binary_sensor.py
@@ -149,7 +149,7 @@ class WaspInBoxSensor(RestoreEntity, BinarySensorEntity):
         self._last_occupied_time: datetime | None = None
 
         # Initialize tracking resources
-        self._door_entities = self._config.sensors.doors or []
+        self._door_entities = self._config.sensors.door or []
         self._motion_entities = self._config.sensors.motion or []
         self._remove_state_listener: Callable[[], None] | None = None
         self._remove_timer: Callable[[], None] | None = None

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -85,7 +85,7 @@ def wasp_coordinator(mock_coordinator: Mock) -> Mock:
     mock_coordinator.config.wasp_in_box.max_duration = 3600
     mock_coordinator.config.wasp_in_box.weight = 0.85
     mock_coordinator.config.sensors = Mock()
-    mock_coordinator.config.sensors.doors = ["binary_sensor.door1"]
+    mock_coordinator.config.sensors.door = ["binary_sensor.door1"]
     mock_coordinator.config.sensors.motion = ["binary_sensor.motion1"]
 
     # Add missing entities attribute with AsyncMock


### PR DESCRIPTION
## Summary
- use correct `sensors.door` attribute when initializing WaspInBoxSensor
- update tests accordingly

## Testing
- `ruff check custom_components/area_occupancy/binary_sensor.py tests/test_binary_sensor.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899ed68c95c832f8789b3b9673a246d