### PR TITLE
Add debounced database save logic

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           AREA_OCCUPANCY_AUTO_INIT_DB: "1"
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: coverage-xml
           path: coverage.xml

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -158,6 +158,9 @@ MAX_INTERVAL_SECONDS: Final = (
 DECAY_INTERVAL: Final = 10  # seconds
 ANALYSIS_INTERVAL: Final = 3600  # seconds (1 hour)
 
+# Database save debounce
+SAVE_DEBOUNCE_SECONDS: Final = 5  # Delay before saving after state changes
+
 ########################################################
 # Virtual sensor constants
 ########################################################


### PR DESCRIPTION
This pull request introduces a debounced database save mechanism to the `AreaOccupancyCoordinator` to prevent excessive database writes during rapid state changes. It also updates the related tests to accommodate the new debouncing logic and ensures proper cleanup of timers. Additionally, there is a minor update to the GitHub Actions workflow.

**Debounced Database Save and Timer Management:**

* Added a `SAVE_DEBOUNCE_SECONDS` constant in `const.py` to control the debounce period for database saves.
* Introduced a `_save_timer` attribute and a `_schedule_save` method in `coordinator.py` to debounce and schedule database saves, ensuring only one save occurs after a burst of state changes. Saves are now triggered by state changes and decay updates, and a final save is performed on shutdown. [[1]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dR75) [[2]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dR328-R371) [[3]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL310-R318) [[4]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dR447) [[5]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dR472) [[6]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dL346-R395)
* Updated import statements and usage throughout `coordinator.py` to support the new debouncing mechanism. [[1]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dR18) [[2]](diffhunk://#diff-bc6dcfe90e28650ab77b13cb727d142fe5c7e320b5b2897f48b991b63f9af39dR35)

**Test Updates:**

* Mocked `async_call_later` and `_schedule_save` in tests to prevent lingering timers and ensure test isolation. Updated several test cases to account for the new debounced save logic. [[1]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R37-R45) [[2]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R753-R759) [[3]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0R1047-R1053) [[4]](diffhunk://#diff-9ed613c223886cb2a65ee0fe0161cb36215b16f72c2d6f84424a19264051baf0L1294-R1322)

**CI/CD Workflow:**

* Updated the GitHub Actions workflow to use `actions/upload-artifact@v5` for uploading coverage reports.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce debounced DB save scheduling in the coordinator (triggered by state/decay, final save on shutdown), update tests accordingly, and bump upload-artifact to v5.
> 
> - **Coordinator (core)**:
>   - Add `SAVE_DEBOUNCE_SECONDS`, `_save_timer`, and `_schedule_save` to debounce DB writes.
>   - `update()` now returns in-memory state only; DB saves are scheduled, not inline.
>   - Schedule saves on entity state changes and decay ticks; perform final save during `async_shutdown()`.
>   - Import and use `async_call_later` for debouncing.
> - **Tests**:
>   - Mock `async_call_later` and `_schedule_save` to avoid lingering timers; adjust tests for new debounced behavior.
>   - Add shutdown test covering presence of `_save_timer` and final save.
> - **CI**:
>   - Update `.github/workflows/test.yml` to `actions/upload-artifact@v5`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfb261c6673beeb4326390e2874dcbc01e487222. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->