### PR TITLE
Update appliance detection to include light entities

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -139,8 +139,13 @@ def _get_include_entities(hass: HomeAssistant) -> dict[str, list[str]]:
         BinarySensorDeviceClass.OPENING,
     ]
 
-    # Check binary_sensor, switch, fan for potential appliances
-    domains_to_check = [Platform.BINARY_SENSOR, Platform.SWITCH, Platform.FAN]
+    # Check binary_sensor, switch, fan, light for potential appliances
+    domains_to_check = [
+        Platform.BINARY_SENSOR,
+        Platform.SWITCH,
+        Platform.FAN,
+        Platform.LIGHT,
+    ]
     entity_ids = []
     for domain in domains_to_check:
         entity_ids.extend(hass.states.async_entity_ids(domain))


### PR DESCRIPTION
This pull request makes a minor update to the `config_flow.py` logic for identifying potential appliances. The change expands the domains checked for appliance entities to include lights.

* The list of domains checked for potential appliances in `_get_include_entities` now includes `Platform.LIGHT` in addition to binary sensors, switches, and fans.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Extend appliance discovery by adding `Platform.LIGHT` to the domains scanned in `_get_include_entities`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cde385286f18743767c3258b8d9e74d2c174a012. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->