### PR TITLE
Refactor motion sensor probability logging and enhance test coverage

### DIFF
--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -506,6 +506,8 @@ class EntityManager:
         if entity_obj.type.input_type == InputType.MOTION:
             # Check data quality for motion sensors
             total_occupied_time = true_occ + false_occ
+            total_unoccupied_time = true_empty + false_empty
+
             if total_occupied_time < 3600:  # Less than 1 hour of occupied time
                 _LOGGER.warning(
                     "Motion sensor %s has insufficient occupied time data (%.1fs), using defaults",
@@ -525,13 +527,25 @@ class EntityManager:
                         prob_given_true,
                         total_occupied_time,
                     )
-                if prob_given_false > 0.1:
+
+                # Check if we have sufficient unoccupied data for prob_given_false
+                # If not, the calculated value is just a fallback (0.5), not real data
+                if total_unoccupied_time < 3600:  # Less than 1 hour of unoccupied time
+                    _LOGGER.info(
+                        "Motion sensor %s has insufficient unoccupied time data (%.1fs), "
+                        "using default for prob_given_false (%.3f)",
+                        entity_id,
+                        total_unoccupied_time,
+                        entity_obj.type.prob_given_false,
+                    )
+                    prob_given_false = entity_obj.type.prob_given_false
+                elif prob_given_false > 0.1:
                     _LOGGER.info(
                         "Motion sensor %s has calculated prob_given_false (%.3f) above typical range (0.1), "
                         "but using calculated value due to sufficient data (%.1fs)",
                         entity_id,
                         prob_given_false,
-                        total_occupied_time,
+                        total_unoccupied_time,
                     )
         else:
             # Fallback to defaults if too low for other sensors

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -790,22 +790,21 @@ class TestEntityPropertiesAndMethods:
                 )
 
                 # With sufficient data (>= 3600s), calculated values should be preserved
-                # even if outside typical ranges (prob_given_true < 0.8 or prob_given_false > 0.1)
+                # even if outside typical ranges (prob_given_true < 0.8)
                 calculated_prob_true = test_entity_sufficient.prob_given_true
                 calculated_prob_false = test_entity_sufficient.prob_given_false
                 # First interval: active=True, occupied=True -> true_occ = 3600
                 # Second interval: active=False, occupied=True -> false_occ = 3600
                 # prob_given_true = 3600 / (3600 + 3600) = 0.5
-                # prob_given_false = 0 / (0 + 0) = 0.5 (fallback when no data)
-                # These should be calculated values, not the defaults (0.95, 0.02)
-                # This proves threshold overrides are not applied
+                # Both intervals are during occupied time, so true_empty=0, false_empty=0
+                # total_unoccupied_time = 0 < 3600, so prob_given_false uses default (0.02)
+                # This proves threshold overrides are not applied for prob_given_true
                 assert abs(calculated_prob_true - 0.5) < 0.01  # Calculated value ~0.5
                 assert (
-                    abs(calculated_prob_false - 0.5) < 0.01
-                )  # Fallback when no false_empty data
-                # Verify they are not the defaults
+                    calculated_prob_false == 0.02
+                )  # Default when insufficient unoccupied data
+                # Verify prob_given_true is not the default
                 assert abs(calculated_prob_true - 0.95) > 0.01
-                assert abs(calculated_prob_false - 0.02) > 0.01
 
             # Test non-motion sensor logic - create a fresh entity to avoid interference
             fresh_entity = create_test_entity(


### PR DESCRIPTION
This pull request updates the motion sensor likelihood calculation logic and improves test coverage for scenarios with both sufficient and insufficient data. The main focus is to ensure that calculated probabilities are trusted when enough data is available, while default values are used when data is insufficient. Logging is enhanced to provide better visibility into the decision process.

**Motion sensor likelihood calculation logic:**

* Updated `_update_entity_likelihoods` in `entity.py` to trust calculated `prob_given_true` and `prob_given_false` values for motion sensors when sufficient data exists, logging info messages if values are outside typical ranges instead of reverting to defaults.

**Test improvements and coverage:**

* Refactored and expanded tests in `test_data_entity.py` to separately validate behavior for insufficient and sufficient data scenarios for motion sensors, ensuring correct use of defaults and calculated values. [[1]](diffhunk://#diff-f319e3b31ac389a75ea7b873e3bfc05c4af5730e2c39093ccd37a900bfffdc56L668-R686) [[2]](diffhunk://#diff-f319e3b31ac389a75ea7b873e3bfc05c4af5730e2c39093ccd37a900bfffdc56L698-R809)
* Added a test case for motion sensors with sufficient data, verifying that calculated likelihoods outside typical ranges are preserved and not overridden by defaults.
* Adjusted non-motion sensor test to use insufficient data scenario, confirming that calculated values are used for non-motion sensors regardless of data sufficiency.

#174 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Trusts calculated motion sensor probabilities when enough data exists, falls back for insufficient unoccupied data, and adds targeted tests for both scenarios.
> 
> - **Logic (custom_components/area_occupancy/data/entity.py)**
>   - Motion sensors: trust calculated `prob_given_true` when `total_occupied_time ≥ 3600s`; log info if below typical range instead of reverting.
>   - Motion sensors: use default `prob_given_false` only when `total_unoccupied_time < 3600s`; otherwise keep calculated value even if > 0.1; added `total_unoccupied_time` computation and info logs.
>   - Non-motion sensors: unchanged fallback to defaults when probabilities < `MIN_PROBABILITY`.
> - **Tests (tests/test_data_entity.py)**
>   - Split scenarios to validate motion sensor behavior with insufficient vs sufficient data; ensure defaults used only when data insufficient and calculated values preserved otherwise.
>   - Added case where `prob_given_true ≈ 0.5` is retained with sufficient data, while `prob_given_false` defaults when unoccupied data insufficient.
>   - Adjusted non-motion sensor test to use insufficient data intervals and verify fallback behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 327f3e05cfdd42b730ff33135c8264a60670e38f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->