### PR TITLE
Fix prior persistence semantics

### DIFF
--- a/custom_components/area_occupancy/db.py
+++ b/custom_components/area_occupancy/db.py
@@ -1413,9 +1413,10 @@ class AreaOccupancyDB:
 
                 cfg = area_data_obj.config
 
-                # Call area_prior() method to get the actual value
+                # Persist the raw global prior value rather than the
+                # time-adjusted prior returned by area.area_prior().
                 area = self.coordinator.get_area_or_default(area_name_item)
-                area_prior_value = area.area_prior()
+                area_prior_value = getattr(area.prior, "global_prior", None)
 
                 area_data = {
                     "entry_id": self.coordinator.entry_id,
@@ -1445,7 +1446,7 @@ class AreaOccupancyDB:
                 # Handle area_prior - use DEFAULT_AREA_PRIOR as fallback if None
                 if area_data["area_prior"] is None:
                     _LOGGER.warning(
-                        "area_prior is None for area '%s', using DEFAULT_AREA_PRIOR (%s) as fallback",
+                        "Global prior missing for area '%s', using DEFAULT_AREA_PRIOR (%s) as fallback",
                         area_name_item,
                         DEFAULT_AREA_PRIOR,
                     )

--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -109,10 +109,13 @@ class PriorsSensor(AreaOccupancySensorBase):
             # For "All Areas", return aggregated priors from all areas
             if self._area_name == ALL_AREAS_IDENTIFIER:
                 area_names = self.coordinator.get_area_names()
-                return {
+                attrs = {
                     "areas": {
                         area_name: {
                             "global_prior": self.coordinator.areas[
+                                area_name
+                            ].prior.global_prior,
+                            "combined_prior": self.coordinator.areas[
                                 area_name
                             ].area_prior(),
                             "time_prior": self.coordinator.areas[
@@ -128,15 +131,19 @@ class PriorsSensor(AreaOccupancySensorBase):
                         for area_name in area_names
                     }
                 }
-            area = self.coordinator.get_area_or_default(self._area_name)
-            return {
-                "global_prior": area.area_prior(),
-                "time_prior": area.prior.time_prior,
-                "day_of_week": area.prior.day_of_week,
-                "time_slot": area.prior.time_slot,
-            }
+            else:
+                area = self.coordinator.get_area_or_default(self._area_name)
+                combined_prior = area.area_prior() if area else None
+                attrs = {
+                    "global_prior": area.prior.global_prior if area else None,
+                    "combined_prior": combined_prior,
+                    "time_prior": area.prior.time_prior if area else None,
+                    "day_of_week": area.prior.day_of_week if area else None,
+                    "time_slot": area.prior.time_slot if area else None,
+                }
         except (TypeError, AttributeError, KeyError):
             return {}
+        return attrs
 
 
 class ProbabilitySensor(AreaOccupancySensorBase):


### PR DESCRIPTION
## Summary
- persist the raw global prior (with default fallback) when saving areas so restarts don’t double-scale priors and expose the raw versus combined values to diagnostics
- update diagnostics (priors sensor) to report both raw and combined priors
- add regression coverage for the new persistence semantics and the priors sensor diagnostics

## Testing
- pytest tests/test_db.py::TestAreaOccupancyDBUtilities::test_load_data
- pytest tests/test_db.py::TestAreaOccupancyDBUtilities::test_save_area_data_uses_default_with_existing_prior_when_global_missing
- pytest tests/test_db.py::TestAreaOccupancyDBUtilities::test_save_area_data_uses_default_without_existing_prior
- pytest tests/test_db.py::TestAreaOccupancyDBUtilities::test_save_area_data_persists_raw_global_prior
- pytest tests/test_db.py::TestAreaOccupancyDBUtilities::test_prior_value_persists_through_reload
- pytest tests/test_sensor.py::TestSensorIntegration::test_priors_sensor_extra_attributes_include_combined_prior

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198d0d652c832fb7cd8d4f07f47675)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced sensor attributes now display detailed prior information including global prior, combined prior, time prior, day of week, and time slot per area in a consolidated structure.

* **Refactor**
  * Unified internal logic for prior retrieval and error handling with improved safety for missing data.
  * Prior persistence now captures raw global values without time adjustments for better consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->