### PR TITLE
Add energy sensors to configuration

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -61,6 +61,7 @@ from .const import (
     CONF_DECAY_HALF_LIFE,
     CONF_DOOR_ACTIVE_STATE,
     CONF_DOOR_SENSORS,
+    CONF_ENERGY_SENSORS,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
     CONF_MEDIA_ACTIVE_STATES,
@@ -86,6 +87,7 @@ from .const import (
     CONF_WASP_WEIGHT,
     CONF_WEIGHT_APPLIANCE,
     CONF_WEIGHT_DOOR,
+    CONF_WEIGHT_ENERGY,
     CONF_WEIGHT_ENVIRONMENTAL,
     CONF_WEIGHT_MEDIA,
     CONF_WEIGHT_MOTION,
@@ -109,6 +111,7 @@ from .const import (
     DEFAULT_WASP_WEIGHT,
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
+    DEFAULT_WEIGHT_ENERGY,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
@@ -575,6 +578,35 @@ def _create_environmental_section_schema(defaults: dict[str, Any]) -> vol.Schema
     )
 
 
+def _create_energy_section_schema(defaults: dict[str, Any]) -> vol.Schema:
+    """Create schema for the energy section."""
+    return vol.Schema(
+        {
+            vol.Optional(
+                CONF_ENERGY_SENSORS,
+                default=defaults.get(CONF_ENERGY_SENSORS, []),
+            ): EntitySelector(
+                EntitySelectorConfig(
+                    domain=Platform.SENSOR,
+                    device_class=SensorDeviceClass.ENERGY,
+                    multiple=True,
+                )
+            ),
+            vol.Optional(
+                CONF_WEIGHT_ENERGY,
+                default=defaults.get(CONF_WEIGHT_ENERGY, DEFAULT_WEIGHT_ENERGY),
+            ): NumberSelector(
+                NumberSelectorConfig(
+                    min=WEIGHT_MIN,
+                    max=WEIGHT_MAX,
+                    step=WEIGHT_STEP,
+                    mode=NumberSelectorMode.SLIDER,
+                )
+            ),
+        }
+    )
+
+
 def _create_parameters_section_schema(defaults: dict[str, Any]) -> vol.Schema:
     """Create schema for the parameters section."""
     # Get the purpose-based default for decay half-life
@@ -767,6 +799,9 @@ def create_schema(
     )
     schema_dict[vol.Required("environmental")] = section(
         _create_environmental_section_schema(defaults), {"collapsed": True}
+    )
+    schema_dict[vol.Required("energy")] = section(
+        _create_energy_section_schema(defaults), {"collapsed": True}
     )
     schema_dict[vol.Required("wasp_in_box")] = section(
         _create_wasp_in_box_section_schema(defaults), {"collapsed": True}

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -60,6 +60,7 @@ CONF_AIR_QUALITY_SENSORS: Final = "air_quality_sensors"
 CONF_VOC_SENSORS: Final = "voc_sensors"
 CONF_PM25_SENSORS: Final = "pm25_sensors"
 CONF_PM10_SENSORS: Final = "pm10_sensors"
+CONF_ENERGY_SENSORS: Final = "energy_sensors"
 CONF_DOOR_SENSORS: Final = "door_sensors"
 CONF_DOOR_ACTIVE_STATE: Final = "door_active_state"
 CONF_WINDOW_SENSORS: Final = "window_sensors"
@@ -83,6 +84,7 @@ CONF_WEIGHT_APPLIANCE: Final = "weight_appliance"
 CONF_WEIGHT_DOOR: Final = "weight_door"
 CONF_WEIGHT_WINDOW: Final = "weight_window"
 CONF_WEIGHT_ENVIRONMENTAL: Final = "weight_environmental"
+CONF_WEIGHT_ENERGY: Final = "weight_energy"
 CONF_WEIGHT_WASP: Final = "weight_wasp"
 
 # Default values
@@ -114,6 +116,7 @@ DEFAULT_WEIGHT_APPLIANCE: Final = 0.4
 DEFAULT_WEIGHT_DOOR: Final = 0.3
 DEFAULT_WEIGHT_WINDOW: Final = 0.2
 DEFAULT_WEIGHT_ENVIRONMENTAL: Final = 0.1
+DEFAULT_WEIGHT_ENERGY: Final = 0.3
 
 # Safety bounds
 MIN_PROBABILITY: Final = 0.01

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -24,6 +24,7 @@ from ..const import (
     CONF_DECAY_HALF_LIFE,
     CONF_DOOR_ACTIVE_STATE,
     CONF_DOOR_SENSORS,
+    CONF_ENERGY_SENSORS,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
     CONF_MEDIA_ACTIVE_STATES,
@@ -72,6 +73,7 @@ from ..const import (
     DEFAULT_WASP_WEIGHT,
     DEFAULT_WEIGHT_APPLIANCE,
     DEFAULT_WEIGHT_DOOR,
+    DEFAULT_WEIGHT_ENERGY,
     DEFAULT_WEIGHT_ENVIRONMENTAL,
     DEFAULT_WEIGHT_MEDIA,
     DEFAULT_WEIGHT_MOTION,
@@ -155,6 +157,7 @@ class Sensors:
     voc: list[str] = field(default_factory=list)
     pm25: list[str] = field(default_factory=list)
     pm10: list[str] = field(default_factory=list)
+    energy: list[str] = field(default_factory=list)
     door: list[str] = field(default_factory=list)
     window: list[str] = field(default_factory=list)
     _parent_config: "AreaConfig | None" = field(default=None, repr=False, compare=False)
@@ -226,6 +229,7 @@ class Weights:
     door: float = DEFAULT_WEIGHT_DOOR
     window: float = DEFAULT_WEIGHT_WINDOW
     environmental: float = DEFAULT_WEIGHT_ENVIRONMENTAL
+    energy: float = DEFAULT_WEIGHT_ENERGY
     wasp: float = DEFAULT_WASP_WEIGHT
 
 
@@ -350,6 +354,7 @@ class AreaConfig:
             voc=data.get(CONF_VOC_SENSORS, []),
             pm25=data.get(CONF_PM25_SENSORS, []),
             pm10=data.get(CONF_PM10_SENSORS, []),
+            energy=data.get(CONF_ENERGY_SENSORS, []),
             door=data.get(CONF_DOOR_SENSORS, []),
             window=data.get(CONF_WINDOW_SENSORS, []),
             _parent_config=self,
@@ -429,6 +434,7 @@ class AreaConfig:
             *self.sensors.voc,
             *self.sensors.pm25,
             *self.sensors.pm10,
+            *self.sensors.energy,
         ]
 
     def validate_entity_configuration(self) -> list[str]:

--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -476,6 +476,7 @@ class EntityFactory:
             "voc": InputType.VOC,
             "pm25": InputType.PM25,
             "pm10": InputType.PM10,
+            "energy": InputType.ENERGY,
         }
 
         # Process each sensor type using the mapping

--- a/custom_components/area_occupancy/data/entity_type.py
+++ b/custom_components/area_occupancy/data/entity_type.py
@@ -30,6 +30,7 @@ class InputType(StrEnum):
     VOC = "voc"
     PM25 = "pm25"
     PM10 = "pm10"
+    ENERGY = "energy"
     ENVIRONMENTAL = "environmental"
     UNKNOWN = "unknown"
 
@@ -236,6 +237,13 @@ DEFAULT_TYPES: dict[InputType, dict[str, Any]] = {
         "prob_given_false": 0.01,
         "active_states": None,
         "active_range": (55.0, 155.0),
+    },
+    InputType.ENERGY: {
+        "weight": 0.3,
+        "prob_given_true": 0.2,
+        "prob_given_false": 0.02,
+        "active_states": None,
+        "active_range": (0.1, 10.0),
     },
     InputType.ENVIRONMENTAL: {
         "weight": 0.1,

--- a/custom_components/area_occupancy/db/sync.py
+++ b/custom_components/area_occupancy/db/sync.py
@@ -37,6 +37,7 @@ _NUMERIC_INPUT_TYPES = {
     InputType.VOC,
     InputType.PM25,
     InputType.PM10,
+    InputType.ENERGY,
     InputType.ENVIRONMENTAL,
 }
 

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -145,6 +145,18 @@
                             "weight_environmental": "The weight given to environmental sensor inputs in the occupancy calculation."
                         }
                     },
+                    "energy": {
+                        "name": "Energy Sensors",
+                        "description": "Configure energy consumption sensors",
+                        "data": {
+                            "energy_sensors": "Energy Sensors",
+                            "weight_energy": "Energy Weight"
+                        },
+                        "data_description": {
+                            "energy_sensors": "Energy sensors that measure power consumption (kWh). When consumption is above baseline levels, it indicates active device usage and potential occupancy.",
+                            "weight_energy": "The weight given to energy sensor inputs in the occupancy calculation."
+                        }
+                    },
                     "parameters": {
                         "name": "Advanced Parameters",
                         "description": "Configure advanced parameters for occupancy detection",
@@ -315,6 +327,18 @@
                             "pm25_sensors": "PM2.5 particulate matter sensors that detect fine particles from human activity, indicating occupancy.",
                             "pm10_sensors": "PM10 particulate matter sensors that detect coarse particles from human activity, indicating occupancy.",
                             "weight_environmental": "The weight given to environmental sensor inputs in the occupancy calculation."
+                        }
+                    },
+                    "energy": {
+                        "name": "Energy Sensors",
+                        "description": "Configure energy consumption sensors",
+                        "data": {
+                            "energy_sensors": "Energy Sensors",
+                            "weight_energy": "Energy Weight"
+                        },
+                        "data_description": {
+                            "energy_sensors": "Energy sensors that measure power consumption (kWh). When consumption is above baseline levels, it indicates active device usage and potential occupancy.",
+                            "weight_energy": "The weight given to energy sensor inputs in the occupancy calculation."
                         }
                     },
                     "parameters": {

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -145,6 +145,18 @@
                             "weight_environmental": "The weight given to environmental sensor inputs in the occupancy calculation."
                         }
                     },
+                    "energy": {
+                        "name": "Energy Sensors",
+                        "description": "Configure energy consumption sensors",
+                        "data": {
+                            "energy_sensors": "Energy Sensors",
+                            "weight_energy": "Energy Weight"
+                        },
+                        "data_description": {
+                            "energy_sensors": "Energy sensors that measure power consumption (kWh). When consumption is above baseline levels, it indicates active device usage and potential occupancy.",
+                            "weight_energy": "The weight given to energy sensor inputs in the occupancy calculation."
+                        }
+                    },
                     "parameters": {
                         "name": "Advanced Parameters",
                         "description": "Configure advanced parameters for occupancy detection",
@@ -315,6 +327,18 @@
                             "pm25_sensors": "PM2.5 particulate matter sensors that detect fine particles from human activity, indicating occupancy.",
                             "pm10_sensors": "PM10 particulate matter sensors that detect coarse particles from human activity, indicating occupancy.",
                             "weight_environmental": "The weight given to environmental sensor inputs in the occupancy calculation."
+                        }
+                    },
+                    "energy": {
+                        "name": "Energy Sensors",
+                        "description": "Configure energy consumption sensors",
+                        "data": {
+                            "energy_sensors": "Energy Sensors",
+                            "weight_energy": "Energy Weight"
+                        },
+                        "data_description": {
+                            "energy_sensors": "Energy sensors that measure power consumption (kWh). When consumption is above baseline levels, it indicates active device usage and potential occupancy.",
+                            "weight_energy": "The weight given to energy sensor inputs in the occupancy calculation."
                         }
                     },
                     "parameters": {

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -299,7 +299,7 @@ Stores calculated correlations between numeric sensor values and occupancy.
 
 **Retention:** Last 10 correlation analyses per sensor are retained.
 
-**Purpose:** Identifies which numeric sensors (temperature, humidity, illuminance, CO2, sound pressure, atmospheric pressure, air quality, VOC, PM2.5, PM10, etc.) correlate with occupancy, enabling them to be used as occupancy indicators.
+**Purpose:** Identifies which numeric sensors (temperature, humidity, illuminance, CO2, sound pressure, atmospheric pressure, air quality, VOC, PM2.5, PM10, energy, etc.) correlate with occupancy, enabling them to be used as occupancy indicators.
 
 ### `entity_statistics`
 

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -52,6 +52,7 @@ You will be prompted to select entities for various categories. You only need to
 | VOC Sensors                         | `sensor`                            | Volatile organic compound sensors measuring VOC levels (ppb)                                                                      | `200.0 - 1000.0`     |
 | PM2.5 Sensors                       | `sensor`                            | Particulate matter sensors measuring PM2.5 levels (µg/m³)                                                                          | `12.0 - 55.0`        |
 | PM10 Sensors                        | `sensor`                            | Particulate matter sensors measuring PM10 levels (µg/m³)                                                                         | `55.0 - 155.0`       |
+| Energy Sensors                      | `sensor`                            | Energy sensors measuring power consumption (kWh)                                                                                   | `0.1 - 10.0`         |
 
 ### Available States
 
@@ -116,6 +117,7 @@ Adjust the influence of different _types_ of sensors on the final probability ca
 | Media Device         | 0.70           |
 | Appliance            | 0.40           |
 | Door Sensor          | 0.30           |
+| Energy Sensor        | 0.30           |
 | Window Sensor        | 0.20           |
 | Environmental Sensor | 0.10           |
 | Wasp in Box          | 0.80           |

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -55,6 +55,7 @@ The integration supports multiple sensor types with different default weights:
 - **Media Devices** (0.70): Good indicator of active use
 - **Appliances** (0.40): Moderate reliability
 - **Door Sensors** (0.30): Lower reliability, but useful for entry/exit
+- **Energy Sensors** (0.30): Power consumption indicating active device usage
 - **Window Sensors** (0.20): Minimal influence
 - **Environmental Sensors** (0.10): Very low influence (temperature, humidity, illuminance, CO2, sound pressure, atmospheric pressure, air quality, VOC, PM2.5, PM10)
 
@@ -95,7 +96,7 @@ This integration provides enhanced room occupancy detection for Home Assistant b
 
 ## Key Features
 
-- **Multi-Sensor Fusion:** Combines inputs from motion/occupancy sensors, media players, doors, windows, appliances and environmental sensors (temperature, humidity, illuminance, CO2, sound pressure, atmospheric pressure, air quality, VOC, PM2.5, PM10).
+- **Multi-Sensor Fusion:** Combines inputs from motion/occupancy sensors, media players, doors, windows, appliances, energy sensors, and environmental sensors (temperature, humidity, illuminance, CO2, sound pressure, atmospheric pressure, air quality, VOC, PM2.5, PM10).
 - **Bayesian Inference:** Calculates the probability of occupancy based on the current state of configured sensors and their individual learned likelihoods.
 - **Prior Probability Learning:** Automatically learns how sensor states relate to actual occupancy (using motion sensors as ground truth) over a configurable history period.
 - **Configurable Weights:** Assign weights to different sensor _types_ to influence their impact on the overall probability.


### PR DESCRIPTION
- Introduced configuration options for energy sensors, allowing users to select energy consumption sensors and set their weights in the occupancy calculation.
- Updated the configuration flow, constants, and data models to accommodate the new energy sensor type, enhancing the integration's flexibility.
- Enhanced documentation and user interface strings to reflect the addition of energy sensors, ensuring clarity in configuration.
- Improved tests to validate the integration of energy sensors and their impact on occupancy calculations.

These changes enhance the area occupancy integration by providing a more comprehensive analysis of energy consumption as a factor in occupancy detection.