### PR TITLE
Fix issue where new entries named wrong

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -83,6 +83,7 @@ from .const import (
     CONF_SOUND_PRESSURE_SENSORS,
     CONF_TEMPERATURE_SENSORS,
     CONF_THRESHOLD,
+    CONF_VERSION,
     CONF_VOC_SENSORS,
     CONF_WASP_ENABLED,
     CONF_WASP_MAX_DURATION,
@@ -1504,9 +1505,34 @@ class AreaOccupancyConfigFlow(ConfigFlow, BaseOccupancyFlow, domain=DOMAIN):
                 raise
 
             config_data = {CONF_AREAS: self._areas}
-            return self.async_create_entry(
+            result = self.async_create_entry(
                 title="Area Occupancy Detection", data=config_data
             )
+
+            # Set version immediately after creation to prevent migration trigger
+            # Home Assistant defaults new entries to version 1, but fresh entries should have current version
+            entries = self.hass.config_entries.async_entries(DOMAIN)
+            entry = next((e for e in entries if e.unique_id == DOMAIN), None)
+            if entry:
+                try:
+                    self.hass.config_entries.async_update_entry(
+                        entry, version=CONF_VERSION
+                    )
+                except (ValueError, RuntimeError, HomeAssistantError) as err:
+                    _LOGGER.warning(
+                        "Failed to set version for entry %s: %s. "
+                        "Version will be set during async_setup_entry instead.",
+                        entry.entry_id,
+                        err,
+                    )
+            else:
+                # Entry not found - this should not happen, but safety net in __init__.py will handle it
+                _LOGGER.warning(
+                    "Could not find newly created entry to set version. "
+                    "Version will be set during async_setup_entry instead."
+                )
+
+            return result  # noqa: TRY300
         except AbortFlow:
             raise
         except HomeAssistantError as err:

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -348,10 +348,24 @@ class AreaConfig:
                 "Area config missing area_id for area '%s'.",
                 self.area_name,
             )
-        # The canonical name is normally resolved from area_id via the coordinator,
-        # but we store the provided area_name from the constructor as the local
-        # name/fallback (for legacy or initial display) rather than resolving it here.
-        self.name = self.area_name  # Use area_name passed to constructor
+        # Resolve area name from area_id (canonical source)
+        # This ensures the device name matches the Home Assistant area name
+        if self.area_id:
+            area_reg = ar.async_get(self.hass)
+            area_entry = area_reg.async_get_area(self.area_id)
+            if area_entry:
+                self.name = area_entry.name
+            else:
+                # Fallback to area_name if area_id not found in registry
+                _LOGGER.warning(
+                    "Area ID '%s' not found in registry for area '%s', using fallback name.",
+                    self.area_id,
+                    self.area_name,
+                )
+                self.name = self.area_name or "Unknown Area"
+        else:
+            # Fallback to area_name if area_id not available
+            self.name = self.area_name or "Unknown Area"
         self.threshold = threshold
 
         self.sensors = Sensors(


### PR DESCRIPTION
…ration

- Updated migration checks to handle fresh entries with new format (CONF_AREAS) without unnecessary migration.
- Improved version setting during entry creation to prevent migration triggers for new entries.
- Enhanced area name resolution from area_id to ensure consistency with Home Assistant area names, including fallback mechanisms for missing entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration entry versioning and migration handling for both fresh and legacy configurations.
  * Fixed area name resolution to use Home Assistant's area registry with proper fallback behavior.

* **Refactor**
  * Enhanced error handling and logging throughout the configuration setup process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->