### PR TITLE
Add multi-sensor sleep detection support

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -30,7 +30,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
 DEVICE_MANUFACTURER: Final = "Hankanman"
 DEVICE_MODEL: Final = "Area Occupancy Detector"
 DEVICE_SW_VERSION: Final = "2026.2.4"
-CONF_VERSION: Final = 16
+CONF_VERSION: Final = 17
 CONF_VERSION_MINOR: Final = 0
 HA_RECORDER_DAYS: Final = 10  # days
 
@@ -94,6 +94,7 @@ CONF_SLEEP_END: Final = "sleep_end"
 CONF_PEOPLE: Final = "people"
 CONF_PERSON_ENTITY: Final = "person_entity"
 CONF_PERSON_SLEEP_SENSOR: Final = "sleep_confidence_sensor"
+CONF_PERSON_SLEEP_SENSORS: Final = "sleep_sensors"
 CONF_PERSON_SLEEP_AREA: Final = "sleep_area_id"
 CONF_PERSON_CONFIDENCE_THRESHOLD: Final = "confidence_threshold"
 CONF_PERSON_DEVICE_TRACKER: Final = "device_tracker"
@@ -330,6 +331,7 @@ ATTR_VERIFICATION_PENDING: Final = "verification_pending"
 
 # Sleep Presence attributes
 ATTR_SLEEP_CONFIDENCE: Final = "sleep_confidence"
+ATTR_SLEEP_SENSORS: Final = "sleep_sensors"
 ATTR_PERSON_STATE: Final = "person_state"
 ATTR_SLEEP_THRESHOLD: Final = "sleep_threshold"
 ATTR_PEOPLE_SLEEPING: Final = "people_sleeping"

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -388,7 +388,7 @@
             "window_state_required": "Window active state is required when window sensors are configured.",
             "cover_states_required": "Cover active states are required when cover sensors are configured.",
             "person_entity_required": "A person entity is required.",
-            "sleep_sensor_required": "A sleep confidence sensor is required.",
+            "sleep_sensor_required": "At least one sleep sensor is required.",
             "sleep_area_required": "A sleep area is required.",
             "confidence_not_number": "Confidence threshold must be a number.",
             "invalid_selection": "Invalid selection. Please try again.",
@@ -800,19 +800,19 @@
             },
             "person_config": {
                 "title": "Configure Person",
-                "description": "Configure a person's sleep tracking. The person entity provides home/away state, and the sleep confidence sensor comes from the HA Companion App.",
+                "description": "Configure a person's sleep tracking. The person entity provides home/away state. Sleep sensors can be numeric (e.g., sleep confidence 0-100%) or binary (e.g., in-bed sensor).",
                 "data": {
                     "person_entity": "Person",
-                    "sleep_confidence_sensor": "Sleep Confidence Sensor",
+                    "sleep_sensors": "Sleep Sensors",
                     "sleep_area_id": "Sleep Area",
                     "confidence_threshold": "Sleep Confidence Threshold (%)",
                     "device_tracker": "Device Tracker"
                 },
                 "data_description": {
                     "person_entity": "Select the Home Assistant person entity. This provides home/not_home state.",
-                    "sleep_confidence_sensor": "Select the sleep confidence sensor from the HA Companion App (e.g., sensor.phone_sleep_confidence). Reports 0-100%.",
+                    "sleep_sensors": "Select one or more sleep detection sensors. Supports numeric sensors (e.g., sleep confidence 0-100%) and binary sensors (e.g., in-bed sensor, Sleep Focus). Any active sensor means the person is sleeping.",
                     "sleep_area_id": "Select the area where this person sleeps (e.g., bedroom).",
-                    "confidence_threshold": "Minimum sleep confidence percentage to consider the person as sleeping. Default: 75%.",
+                    "confidence_threshold": "Minimum percentage to consider the person as sleeping. Only applies to numeric sensors. Default: 75%.",
                     "device_tracker": "Home/away detection with a specific device tracker entity. When set, this is used instead of the person entity's state. Leave empty to use the person entity."
                 }
             }
@@ -833,7 +833,7 @@
             "window_state_required": "Window active state is required when window sensors are configured.",
             "cover_states_required": "Cover active states are required when cover sensors are configured.",
             "person_entity_required": "A person entity is required.",
-            "sleep_sensor_required": "A sleep confidence sensor is required.",
+            "sleep_sensor_required": "At least one sleep sensor is required.",
             "sleep_area_required": "A sleep area is required.",
             "confidence_not_number": "Confidence threshold must be a number.",
             "invalid_selection": "Invalid selection. Please try again.",

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -388,7 +388,7 @@
             "window_state_required": "Window active state is required when window sensors are configured.",
             "cover_states_required": "Cover active states are required when cover sensors are configured.",
             "person_entity_required": "A person entity is required.",
-            "sleep_sensor_required": "A sleep confidence sensor is required.",
+            "sleep_sensor_required": "At least one sleep sensor is required.",
             "sleep_area_required": "A sleep area is required.",
             "confidence_not_number": "Confidence threshold must be a number.",
             "invalid_selection": "Invalid selection. Please try again.",
@@ -800,19 +800,19 @@
             },
             "person_config": {
                 "title": "Configure Person",
-                "description": "Configure a person's sleep tracking. The person entity provides home/away state, and the sleep confidence sensor comes from the HA Companion App.",
+                "description": "Configure a person's sleep tracking. The person entity provides home/away state. Sleep sensors can be numeric (e.g., sleep confidence 0-100%) or binary (e.g., in-bed sensor).",
                 "data": {
                     "person_entity": "Person",
-                    "sleep_confidence_sensor": "Sleep Confidence Sensor",
+                    "sleep_sensors": "Sleep Sensors",
                     "sleep_area_id": "Sleep Area",
                     "confidence_threshold": "Sleep Confidence Threshold (%)",
                     "device_tracker": "Device Tracker"
                 },
                 "data_description": {
                     "person_entity": "Select the Home Assistant person entity. This provides home/not_home state.",
-                    "sleep_confidence_sensor": "Select the sleep confidence sensor from the HA Companion App (e.g., sensor.phone_sleep_confidence). Reports 0-100%.",
+                    "sleep_sensors": "Select one or more sleep detection sensors. Supports numeric sensors (e.g., sleep confidence 0-100%) and binary sensors (e.g., in-bed sensor, Sleep Focus). Any active sensor means the person is sleeping.",
                     "sleep_area_id": "Select the area where this person sleeps (e.g., bedroom).",
-                    "confidence_threshold": "Minimum sleep confidence percentage to consider the person as sleeping. Default: 75%.",
+                    "confidence_threshold": "Minimum percentage to consider the person as sleeping. Only applies to numeric sensors. Default: 75%.",
                     "device_tracker": "Home/away detection with a specific device tracker entity. When set, this is used instead of the person entity's state. Leave empty to use the person entity."
                 }
             }
@@ -833,7 +833,7 @@
             "window_state_required": "Window active state is required when window sensors are configured.",
             "cover_states_required": "Cover active states are required when cover sensors are configured.",
             "person_entity_required": "A person entity is required.",
-            "sleep_sensor_required": "A sleep confidence sensor is required.",
+            "sleep_sensor_required": "At least one sleep sensor is required.",
             "sleep_area_required": "A sleep area is required.",
             "confidence_not_number": "Confidence threshold must be a number.",
             "invalid_selection": "Invalid selection. Please try again.",


### PR DESCRIPTION
## Summary
- Support multiple sleep sensors per person (both `sensor` and `binary_sensor` domains)
- Auto-detect sensor type: binary sensors use `on`/`off`, numeric sensors compare against threshold
- Any active sensor triggers sleep detection (OR logic)
- Backward-compatible config migration (v16→v17) converts existing single-sensor configs to list format
- Updated config flow with multi-select entity picker for both sensor domains

Closes #374

## Changes
- **`const.py`**: Bump `CONF_VERSION` 16→17, add `CONF_PERSON_SLEEP_SENSORS` and `ATTR_SLEEP_SENSORS`
- **`data/config.py`**: `PersonConfig.sleep_sensors: list[str]`, parser with backward compat fallback
- **`binary_sensor.py`**: Multi-sensor evaluation with binary/numeric auto-detection, per-sensor attribute breakdown
- **`config_flow.py`**: Multi-select `EntitySelector` with `domain=["sensor", "binary_sensor"]`, edit-mode migration
- **`strings.json` + `translations/en.json`**: Updated labels and descriptions
- **`migrations.py`**: `_migrate_sleep_sensor_to_list()` + v16→v17 migration block (no DB reset)
- **Tests**: `TestIntegrationConfigPeople` (3 tests), `TestMigrateSleepSensorToList` (5 tests)

## Test plan
- [x] `scripts/lint` passes
- [x] `scripts/test` passes (1504 tests, 87.33% coverage)
- [ ] Manual: Options flow → Manage People → Add Person shows multi-select with sensor + binary_sensor
- [ ] Manual: Binary sensor (e.g. Withings in-bed) triggers sleep on `on` state
- [ ] Manual: Numeric sensor (e.g. Android sleep confidence) uses threshold comparison
- [ ] Manual: Existing single-sensor config migrates and loads correctly in edit form

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sleep detection now supports multiple sensors per person (binary or numeric with thresholds); any qualifying sensor marks the person as sleeping.
  * Sleep presence sensors expose per-sensor details in state attributes for clearer diagnostics.
  * Configuration UI allows selecting multiple sleep sensors.

* **Chores**
  * Integration config version bumped to v17 with automatic migration from single-sensor settings; existing setups remain supported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->