### PR TITLE
Add export_config service

### DIFF
--- a/custom_components/area_occupancy/services.yaml
+++ b/custom_components/area_occupancy/services.yaml
@@ -1,3 +1,7 @@
 run_analysis:
   name: Run Analysis
   description: "Run the analysis for all areas in the area occupancy instance."
+
+export_config:
+  name: Export Config
+  description: "Export the complete integration configuration as YAML."


### PR DESCRIPTION
## Summary
- Adds a new `area_occupancy.export_config` HA service that returns the complete integration configuration (merged `config_entry.data` and `config_entry.options`) as a service response
- Area configs are reordered so `area_id` appears as the first key for readability
- Follows the same registration pattern as the existing `run_analysis` service

## Test plan
- [ ] Run `area_occupancy.export_config` from Developer Tools > Services and verify output contains the full config
- [ ] Verify `area_id` appears first in each area block
- [ ] Confirm existing `run_analysis` service still works

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Export Config" service that exports the complete integration configuration as YAML format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->