### PR TITLE
fix: Preserve people config when saving area changes

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -2596,7 +2596,9 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
         self._area_config_draft = {}
 
         # Store updated areas in options; the update listener handles the reload
-        return self.async_create_entry(title="", data={CONF_AREAS: areas})
+        config_data = dict(self.config_entry.options)
+        config_data[CONF_AREAS] = areas
+        return self.async_create_entry(title="", data=config_data)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -2716,7 +2718,9 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
             return self.async_abort(reason="cannot_remove_last_area")
 
         self._area_to_remove = None
-        return self.async_create_entry(title="", data={CONF_AREAS: updated_areas})
+        config_data = dict(self.config_entry.options)
+        config_data[CONF_AREAS] = updated_areas
+        return self.async_create_entry(title="", data=config_data)
 
     async def async_step_cancel_remove_area(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary
- Area add/edit/remove operations were overwriting `config_entry.options` with only `{CONF_AREAS: areas}`, dropping `CONF_PEOPLE` and any other options keys
- This caused configured people (and their sleep sensors) to silently disappear after any area configuration change
- Now preserves the full options dict before updating the areas key, matching the pattern already used by people and global settings flows

## Root Cause
`_on_area_config_complete()` and `async_step_confirm_remove_area()` both called `self.async_create_entry(title="", data={CONF_AREAS: areas})` which **replaces** `config_entry.options` entirely, losing `CONF_PEOPLE`.

## Test plan
- [x] All 1504 existing tests pass
- [ ] Configure people with sleep sensors, then edit an area — verify people persist
- [ ] Remove an area — verify people persist

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed area occupancy configuration to properly preserve existing settings when updating or removing areas, ensuring no configuration data is lost during these operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->