### PR TITLE
fix: Allow Shelly Door/Window sensors as door sensors

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -372,7 +372,7 @@ def _get_include_entities(hass: HomeAssistant) -> dict[str, list[str]]:
 
             if is_window_candidate:
                 include_window_entities.append(entry.entity_id)
-            elif is_door_candidate:
+            if is_door_candidate:
                 include_door_entities.append(entry.entity_id)
 
             # Exclude our own integration's sensors from motion selection

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -532,13 +532,15 @@ class TestHelperFunctions:
         assert "door" in result
         assert "binary_sensor.test_contact_sensor_2" in result["door"]
 
-    def test_get_include_entities_prioritize_window_in_name_over_door(
+    def test_get_include_entities_ambiguous_door_window_appears_in_both(
         self, hass, entity_registry
     ):
-        """Test that window keyword in name takes precedence over door classification.
+        """Test that ambiguous sensors appear in both door and window lists.
 
-        When an entity has 'window' in its friendly name, it should be categorized as
-        a window sensor even if it has door-like device class.
+        When an entity has 'window' in its friendly name but door-like device class,
+        it should appear in both lists so the user can choose the correct category.
+        This fixes issues with Shelly Door/Window sensors that could only be added
+        as window sensors.
         """
         # Register a sensor with door device class
         entity_registry.async_get_or_create(
@@ -557,11 +559,9 @@ class TestHelperFunctions:
 
         result = _get_include_entities(hass)
 
-        # The entity should appear in window list due to name, not door list
-        assert "window" in result
+        # The entity should appear in both lists since it matches both criteria
         assert "binary_sensor.test_contact_3" in result["window"]
-        # Should NOT be in door list
-        assert "binary_sensor.test_contact_3" not in result.get("door", [])
+        assert "binary_sensor.test_contact_3" in result["door"]
 
     def test_get_include_entities_door_with_door_keyword_in_opening(
         self, hass, entity_registry


### PR DESCRIPTION
## Summary
- Shelly Door/Window sensors (device_class=opening) could only be added as window sensors, not door sensors
- The entity classification used an `if/elif` structure that exclusively placed sensors in one list
- Changed to independent `if/if` checks so ambiguous sensors appear in **both** door and window selector lists, letting the user choose

## Root Cause
`_get_include_entities()` in `config_flow.py` used `if is_window_candidate: ... elif is_door_candidate:` — once classified as a window candidate, the entity was never evaluated for door candidacy. Shelly sensors with `device_class=opening` and "window" in their name matched the window heuristic first.

## Test plan
- [x] All 1504 existing tests pass
- [x] Test updated to verify ambiguous sensors appear in both lists
- [ ] Add a Shelly Door/Window sensor — verify it appears in both door and window dropdowns

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed entity classification logic to correctly include ambiguous sensors in both window and door entity lists when they match multiple criteria, rather than limiting them to a single category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->