### PR TITLE
fix: Reconcile entity state on startup to prevent stale occupancy

### DIFF
--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -663,6 +663,9 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Refresh cached correlations for new areas
         await self.async_refresh_correlations()
 
+        # Reconcile restored entity state with current HA reality
+        self._reconcile_entity_state()
+
         # Re-establish entity state tracking with new entity lists
         all_entity_ids = []
         for area in self.areas.values():


### PR DESCRIPTION
## Summary
- After integration update/reload, some rooms showed 100% occupancy even when empty
- Entity decay and evidence state was restored from the database without reconciling against current HA sensor states
- Added `_reconcile_entity_state()` method that runs during setup to immediately resolve expired decays and reconcile evidence

## Root Cause
On shutdown, entity state (decay timers, previous evidence) is saved to the database. On reload, this state is restored verbatim. If a sensor was active before the update, `previous_evidence=True` was restored but never compared against the current (now inactive) sensor state. Combined with high learned priors, this drove the probability to ~100%.

The fix:
1. **Ticks all decays** immediately after load to resolve any that expired while the integration was unloaded
2. **Calls `has_new_evidence()`** on every entity to reconcile stale `previous_evidence` with current HA sensor states, properly starting/stopping decay based on reality

## Test plan
- [x] All 1504 existing tests pass
- [ ] Update integration — verify empty rooms don't show 100% occupancy
- [ ] Verify rooms with actual occupancy still detect correctly after reload

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now synchronizes area occupancy with current sensor states to remove discrepancies from restored storage or offline periods.
  * Reconciles expired/decayed occupancy records and historical evidence with live sensor readings during initialization and after configuration updates.
  * Ensures restored state is aligned before further persistence or analysis, improving accuracy after boot or option changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->