### PR TITLE
fix: Trigger coordinator refresh on unknown→occupied transition

### DIFF
--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -566,6 +566,7 @@ class Entity:
             # Entity just became available - stop any lingering decay if active
             if current_evidence:
                 self.decay.stop_decay()
+                self.last_updated = dt_util.utcnow()
             self.previous_evidence = current_evidence
             # If entity became available with positive evidence (e.g. unknown→occupied
             # during startup), we must trigger a refresh so the coordinator recalculates

--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -563,12 +563,15 @@ class Entity:
 
         # Handle entity becoming available (previous was None, now has evidence)
         if previous_evidence is None:
-            # Entity just became available - update previous and don't trigger transition
-            # If it has positive evidence, stop any lingering decay
+            # Entity just became available - stop any lingering decay if active
             if current_evidence:
                 self.decay.stop_decay()
             self.previous_evidence = current_evidence
-            return False  # Entity just became available, not a true transition
+            # If entity became available with positive evidence (e.g. unknown→occupied
+            # during startup), we must trigger a refresh so the coordinator recalculates
+            # probability. Without this, sensors that go directly from unknown to active
+            # (common when Z2M loads after AOD) would be silently ignored.
+            return bool(current_evidence)
 
         # Fix inconsistent state: if evidence is True but decay is running, stop decay
         if current_evidence and self.decay.is_decaying:

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -523,6 +523,21 @@ class TestEntityPropertiesAndMethods:
         finally:
             object.__setattr__(coordinator.hass, "states", original_states)
 
+        # Test unknown→off (None→False) does NOT trigger refresh
+        entity2 = create_test_entity(
+            entity_type=mock_entity_type,
+            coordinator=coordinator,
+            previous_evidence=None,
+        )
+        mock_state_off = Mock()
+        mock_state_off.state = "off"
+        _set_states_get(coordinator.hass, lambda _: mock_state_off)
+        try:
+            assert not entity2.has_new_evidence()  # No refresh for unknown→clear
+            assert entity2.previous_evidence is False
+        finally:
+            object.__setattr__(coordinator.hass, "states", original_states)
+
     def test_entity_properties_comprehensive(
         self, coordinator: AreaOccupancyCoordinator
     ) -> None:
@@ -723,6 +738,19 @@ class TestEntityPropertiesAndMethods:
         finally:
             object.__setattr__(coordinator.hass, "states", original_states)
 
+        # Test with previous evidence None and current evidence False (unknown→clear)
+        mock_state_off = Mock()
+        mock_state_off.state = "off"
+        _set_states_get(coordinator.hass, lambda _: mock_state_off)
+        try:
+            assert not entity.has_new_evidence()  # No refresh for unknown→clear
+            assert entity.previous_evidence is False
+        finally:
+            object.__setattr__(coordinator.hass, "states", original_states)
+
+        # Reset to None for the next test
+        entity.previous_evidence = None
+
         # Test with previous evidence None but current evidence available (e.g. unknown→occupied)
         mock_state = Mock()
         mock_state.state = STATE_ON
@@ -866,6 +894,9 @@ class TestEntityPropertiesAndMethods:
         entity.decay.stop_decay = Mock()
         entity.decay.is_decaying = True  # Decay was running
 
+        # Record last_updated before the call
+        old_last_updated = entity.last_updated
+
         original_states = coordinator.hass.states
 
         # Test: Entity becomes available with evidence
@@ -883,6 +914,9 @@ class TestEntityPropertiesAndMethods:
 
             # previous_evidence should be updated to True
             assert entity.previous_evidence is True
+
+            # last_updated should be stamped (same as normal transition path)
+            assert entity.last_updated >= old_last_updated
         finally:
             object.__setattr__(coordinator.hass, "states", original_states)
 

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -504,12 +504,14 @@ class TestEntityPropertiesAndMethods:
         )
 
         original_states = coordinator.hass.states
-        # Test initial state (no transition)
+        # Test initial state: entity becomes available with positive evidence (unknown→on)
         mock_state = Mock()
         mock_state.state = STATE_ON
         _set_states_get(coordinator.hass, lambda _: mock_state)
         try:
-            assert not entity.has_new_evidence()  # No transition on first call
+            assert (
+                entity.has_new_evidence()
+            )  # Should trigger refresh for unknown→occupied
 
             # Test transition from True to False
             mock_state.state = "off"
@@ -721,12 +723,14 @@ class TestEntityPropertiesAndMethods:
         finally:
             object.__setattr__(coordinator.hass, "states", original_states)
 
-        # Test with previous evidence None but current evidence available
+        # Test with previous evidence None but current evidence available (e.g. unknown→occupied)
         mock_state = Mock()
         mock_state.state = STATE_ON
         _set_states_get(coordinator.hass, lambda _: mock_state)
         try:
-            assert not entity.has_new_evidence()  # No transition when previous is None
+            assert (
+                entity.has_new_evidence()
+            )  # Should trigger refresh for unknown→occupied
             assert entity.previous_evidence is True
         finally:
             object.__setattr__(coordinator.hass, "states", original_states)
@@ -843,7 +847,9 @@ class TestEntityPropertiesAndMethods:
     ) -> None:
         """Test has_new_evidence when unavailable entity becomes available with evidence.
 
-        When an entity becomes available with positive evidence, decay should stop.
+        When an entity becomes available with positive evidence (e.g. unknown→occupied
+        during startup), decay should stop AND a refresh should be triggered so the
+        coordinator recalculates probability.
         """
         mock_entity_type = Mock()
         mock_entity_type.active_states = [STATE_ON]
@@ -869,8 +875,8 @@ class TestEntityPropertiesAndMethods:
         try:
             result = entity.has_new_evidence()
 
-            # Should return False (entity just became available, not a transition)
-            assert result is False
+            # Should return True to trigger coordinator refresh (unknown→occupied)
+            assert result is True
 
             # Decay should be stopped since entity has positive evidence
             entity.decay.stop_decay.assert_called_once()


### PR DESCRIPTION
## Summary
- Fix sensors going from `unknown` to `occupied` not triggering a coordinator refresh
- Changed `has_new_evidence()` to return `True` when entity becomes available with positive evidence (`None → True`)
- Single line fix: `return False` → `return bool(current_evidence)`

Closes #419

## Test plan
- [x] All 1505 tests pass
- [x] Updated 3 existing test assertions to match corrected behavior
- [ ] Verify sensor going unknown→occupied triggers occupancy detection on HA restart
- [ ] Verify sensor going unknown→clear (inactive) does NOT trigger unnecessary refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Area occupancy now correctly treats an initial unknown state transitioning to occupied as a real change, prompting an immediate update so startup availability reflects occupancy.
  * Initial unknown→unoccupied transitions remain non-refreshing.

* **Tests**
  * Updated tests to cover startup transitions and ensure refresh/decay behavior matches the new semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->