### PR TITLE
fix: Auto-cleanup orphaned areas when HA area is deleted

### DIFF
--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 # Standard library imports
+import contextlib
 from datetime import datetime, timedelta
 import logging
 from typing import Any
@@ -142,16 +143,21 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _load_areas_from_config(
         self, target_dict: dict[str, Area] | None = None
-    ) -> None:
+    ) -> list[str]:
         """Load areas from config entry CONF_AREAS list.
 
         Reads area configurations from the merged data+options CONF_AREAS list.
 
         Args:
             target_dict: Optional dict to load areas into. If None, loads into self.areas.
+
+        Returns:
+            List of area_ids that were not found in the Home Assistant registry
+            (orphaned areas whose HA area was deleted).
         """
         # Use target_dict if provided, otherwise use self.areas
         areas_dict = target_dict if target_dict is not None else self.areas
+        orphaned_area_ids: list[str] = []
 
         area_reg = ar.async_get(self.hass)
 
@@ -175,6 +181,7 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "Area may have been deleted. Skipping.",
                     area_id,
                 )
+                orphaned_area_ids.append(area_id)
                 continue
 
             # Resolve area name from ID.
@@ -193,6 +200,8 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             )
             self.get_area_handle(area_name).attach(areas_dict[area_name])
             _LOGGER.debug("Loaded area: %s (ID: %s)", area_name, area_id)
+
+        return orphaned_area_ids
 
     def get_area_handle(self, area_name: str) -> AreaDeviceHandle:
         """Return a stable handle for the requested area."""
@@ -319,7 +328,12 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Initialize the coordinator and its components (fast startup mode)."""
         try:
             # Load areas from config entry
-            self._load_areas_from_config()
+            orphaned_area_ids = self._load_areas_from_config()
+
+            # Clean up areas whose HA area was deleted (removes config, device,
+            # entities, and database records so the user isn't left with orphans)
+            if orphaned_area_ids:
+                await self._cleanup_orphaned_areas(orphaned_area_ids)
 
             self._validate_areas_configured()
 
@@ -594,6 +608,143 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         _LOGGER.info("Cleaned up removed area: %s", area_name)
 
+    async def _cleanup_orphaned_areas(self, orphaned_area_ids: list[str]) -> None:
+        """Clean up areas whose Home Assistant area was deleted.
+
+        When a user deletes an area from Home Assistant, the AOD config still
+        references it. This method removes the orphaned config entries and
+        cleans up associated devices, entities, and database records.
+
+        Args:
+            orphaned_area_ids: List of area_ids no longer in the HA registry.
+        """
+        if not orphaned_area_ids:
+            return
+
+        _LOGGER.info(
+            "Cleaning up %d orphaned area(s) (HA area deleted): %s",
+            len(orphaned_area_ids),
+            ", ".join(orphaned_area_ids),
+        )
+
+        device_registry = dr.async_get(self.hass)
+        entity_registry = er.async_get(self.hass)
+
+        for area_id in orphaned_area_ids:
+            # Look up the area_name from the database (needed for DB cleanup)
+            area_name: str | None = None
+            try:
+                area_name = await self.hass.async_add_executor_job(
+                    self._get_area_name_from_db, area_id
+                )
+            except (HomeAssistantError, OSError, RuntimeError) as err:
+                _LOGGER.debug(
+                    "Could not look up area_name for area_id '%s' from DB: %s",
+                    area_id,
+                    err,
+                )
+
+            # Clean up device and entities from registries
+            device = device_registry.async_get_device(identifiers={(DOMAIN, area_id)})
+            if device:
+                # Remove entities belonging to this device
+                for entity_id, entity_entry in list(entity_registry.entities.items()):
+                    if (
+                        entity_entry.config_entry_id == self.entry_id
+                        and entity_entry.device_id == device.id
+                    ):
+                        with contextlib.suppress(ValueError, KeyError, AttributeError):
+                            entity_registry.async_remove(entity_id)
+
+                # Remove the device itself
+                try:
+                    device_registry.async_remove_device(device.id)
+                    _LOGGER.debug("Removed device for orphaned area_id '%s'", area_id)
+                except (ValueError, KeyError, AttributeError) as err:
+                    _LOGGER.warning(
+                        "Failed to remove device for orphaned area_id '%s': %s",
+                        area_id,
+                        err,
+                    )
+
+            # Clean up database records if we found the area_name
+            if area_name:
+                try:
+                    await self.hass.async_add_executor_job(
+                        self.db.delete_area_data, area_name
+                    )
+                    _LOGGER.debug(
+                        "Deleted database records for orphaned area '%s' (area_id: %s)",
+                        area_name,
+                        area_id,
+                    )
+                except (HomeAssistantError, OSError, RuntimeError) as err:
+                    _LOGGER.warning(
+                        "Failed to delete database records for orphaned area '%s': %s",
+                        area_name,
+                        err,
+                    )
+
+            _LOGGER.info(
+                "Cleaned up orphaned area (area_id: %s, name: %s)",
+                area_id,
+                area_name or "unknown",
+            )
+
+        # Remove orphaned areas from config entry to prevent repeated warnings
+        orphaned_set = set(orphaned_area_ids)
+        merged = dict(self.config_entry.data)
+        merged.update(self.config_entry.options)
+        areas_list = merged.get(CONF_AREAS, [])
+        updated_areas = [
+            a for a in areas_list if a.get(CONF_AREA_ID) not in orphaned_set
+        ]
+
+        if len(updated_areas) != len(areas_list):
+            try:
+                if CONF_AREAS in self.config_entry.options:
+                    new_options = dict(self.config_entry.options)
+                    new_options[CONF_AREAS] = updated_areas
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        options=new_options,
+                    )
+                else:
+                    new_data = dict(self.config_entry.data)
+                    new_data[CONF_AREAS] = updated_areas
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data=new_data,
+                    )
+                _LOGGER.info(
+                    "Removed %d orphaned area(s) from configuration",
+                    len(areas_list) - len(updated_areas),
+                )
+            except (ValueError, KeyError, AttributeError) as err:
+                _LOGGER.error(
+                    "Failed to update config entry after orphan cleanup: %s", err
+                )
+
+    def _get_area_name_from_db(self, area_id: str) -> str | None:
+        """Look up area_name from the database by area_id.
+
+        Args:
+            area_id: The Home Assistant area ID.
+
+        Returns:
+            The area_name if found, None otherwise.
+        """
+        try:
+            with self.db.get_session() as session:
+                result = (
+                    session.query(self.db.Areas.area_name)
+                    .filter_by(area_id=area_id)
+                    .first()
+                )
+                return result[0] if result else None
+        except (OSError, RuntimeError, HomeAssistantError):
+            return None
+
     async def async_update_options(self, options: dict[str, Any]) -> None:
         """Update coordinator options.
 
@@ -606,7 +757,9 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Load new areas into a temporary dict first to avoid race condition
         # where self.areas is empty while platform entities are still active
         new_areas: dict[str, Area] = {}
-        self._load_areas_from_config(target_dict=new_areas)
+        self._load_areas_from_config(
+            target_dict=new_areas
+        )  # orphans already cleaned at setup
 
         # Identify areas that will be removed by comparing old and new area names
         removed_area_names = set(self.areas.keys()) - set(new_areas.keys())

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1697,6 +1697,165 @@ class TestCoordinatorAreaRemoval:
             coordinator.config_entry.data = original_data
 
 
+class TestCoordinatorOrphanedAreaCleanup:
+    """Test cleanup of areas whose HA area was deleted."""
+
+    def test_load_areas_returns_orphaned_ids(
+        self,
+        hass: HomeAssistant,
+        mock_realistic_config_entry: Mock,
+    ) -> None:
+        """Test _load_areas_from_config returns orphaned area IDs."""
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+
+        # Add an orphaned area (area_id not in HA registry) to config
+        original_data = mock_realistic_config_entry.data.copy()
+        areas_list = list(original_data.get(CONF_AREAS, []))
+        areas_list.append({CONF_AREA_ID: "deleted_ha_area_id"})
+        mock_realistic_config_entry.data = {CONF_AREAS: areas_list}
+
+        try:
+            orphaned = coordinator._load_areas_from_config()
+            assert orphaned == ["deleted_ha_area_id"]
+            # Valid areas should still be loaded
+            assert len(coordinator.areas) > 0
+        finally:
+            mock_realistic_config_entry.data = original_data
+
+    async def test_cleanup_orphaned_areas_removes_config_and_device(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test _cleanup_orphaned_areas removes device, entities, and config entry."""
+        orphaned_area_id = "deleted_ha_area_id"
+
+        # Mock device registry with a device for the orphaned area
+        mock_device = Mock()
+        mock_device.id = "device_123"
+        mock_device_registry = Mock()
+        mock_device_registry.async_get_device.return_value = mock_device
+        mock_device_registry.async_remove_device = Mock()
+
+        # Mock entity registry with an entity belonging to that device
+        mock_entity_entry = Mock()
+        mock_entity_entry.config_entry_id = coordinator.entry_id
+        mock_entity_entry.device_id = "device_123"
+        mock_entity_registry = Mock()
+        mock_entity_registry.entities = {"sensor.orphaned_entity": mock_entity_entry}
+        mock_entity_registry.async_remove = Mock()
+
+        # Mock the DB lookup returning a name
+        mock_update_entry = Mock()
+        with (
+            patch(
+                "custom_components.area_occupancy.coordinator.dr.async_get",
+                return_value=mock_device_registry,
+            ),
+            patch(
+                "custom_components.area_occupancy.coordinator.er.async_get",
+                return_value=mock_entity_registry,
+            ),
+            patch.object(
+                coordinator,
+                "_get_area_name_from_db",
+                return_value="Deleted Room",
+            ),
+            patch.object(coordinator.db, "delete_area_data") as mock_db_delete,
+            patch.object(
+                hass.config_entries,
+                "async_update_entry",
+                mock_update_entry,
+            ),
+        ):
+            # Set up config entry with the orphaned area
+            original_data = coordinator.config_entry.data.copy()
+            areas_list = list(original_data.get(CONF_AREAS, []))
+            areas_list.append({CONF_AREA_ID: orphaned_area_id})
+            coordinator.config_entry.data = {CONF_AREAS: areas_list}
+
+            try:
+                await coordinator._cleanup_orphaned_areas([orphaned_area_id])
+
+                # Verify entity was removed
+                mock_entity_registry.async_remove.assert_called_once_with(
+                    "sensor.orphaned_entity"
+                )
+                # Verify device was removed
+                mock_device_registry.async_remove_device.assert_called_once_with(
+                    "device_123"
+                )
+                # Verify DB records were deleted
+                mock_db_delete.assert_called_once_with("Deleted Room")
+                # Verify config entry was updated (orphaned area removed)
+                mock_update_entry.assert_called_once()
+            finally:
+                coordinator.config_entry.data = original_data
+
+    async def test_cleanup_orphaned_areas_no_db_name(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test _cleanup_orphaned_areas when area_name can't be found in DB."""
+        orphaned_area_id = "deleted_ha_area_id"
+
+        mock_device_registry = Mock()
+        mock_device_registry.async_get_device.return_value = None
+
+        mock_entity_registry = Mock()
+        mock_entity_registry.entities = {}
+
+        mock_update_entry = Mock()
+        with (
+            patch(
+                "custom_components.area_occupancy.coordinator.dr.async_get",
+                return_value=mock_device_registry,
+            ),
+            patch(
+                "custom_components.area_occupancy.coordinator.er.async_get",
+                return_value=mock_entity_registry,
+            ),
+            patch.object(
+                coordinator,
+                "_get_area_name_from_db",
+                return_value=None,
+            ),
+            patch.object(coordinator.db, "delete_area_data") as mock_db_delete,
+            patch.object(
+                hass.config_entries,
+                "async_update_entry",
+                mock_update_entry,
+            ),
+        ):
+            original_data = coordinator.config_entry.data.copy()
+            areas_list = list(original_data.get(CONF_AREAS, []))
+            areas_list.append({CONF_AREA_ID: orphaned_area_id})
+            coordinator.config_entry.data = {CONF_AREAS: areas_list}
+
+            try:
+                await coordinator._cleanup_orphaned_areas([orphaned_area_id])
+
+                # DB delete should NOT be called when area_name is unknown
+                mock_db_delete.assert_not_called()
+                # Config should still be updated
+                mock_update_entry.assert_called_once()
+            finally:
+                coordinator.config_entry.data = original_data
+
+    async def test_cleanup_orphaned_areas_empty_list(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test _cleanup_orphaned_areas does nothing with empty list."""
+        mock_update_entry = Mock()
+        with patch.object(hass.config_entries, "async_update_entry", mock_update_entry):
+            await coordinator._cleanup_orphaned_areas([])
+            # No config updates should happen
+            mock_update_entry.assert_not_called()
+
+
 class TestCoordinatorFindAreaForEntity:
     """Test coordinator find_area_for_entity edge cases."""
 


### PR DESCRIPTION
## Summary

Fixes #421

- When a Home Assistant area is deleted, AOD now automatically cleans up the orphaned config, devices, entities, and database records on startup
- Previously, deleted HA areas left behind orphaned AOD devices/entities that couldn't be managed or removed through the UI
- Leverages the existing `delete_area_data()` cleanup infrastructure from #405

## Changes

- `_load_areas_from_config()` now returns orphaned area IDs (areas not found in HA registry)
- New `_cleanup_orphaned_areas()` method handles full cleanup: registry entries, DB records, and config entry update
- New `_get_area_name_from_db()` resolves area names from the DB when HA registry no longer has them
- `setup()` calls orphan cleanup after loading areas

## Test plan

- [x] `test_load_areas_returns_orphaned_ids` — verifies orphaned IDs are detected and returned
- [x] `test_cleanup_orphaned_areas_removes_config_and_device` — verifies full cleanup (entities, device, DB, config)
- [x] `test_cleanup_orphaned_areas_no_db_name` — graceful handling when area_name not in DB
- [x] `test_cleanup_orphaned_areas_empty_list` — no-op for empty list
- [x] Full test suite passes (1509 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved orphaned area handling with automatic detection and cleanup of stale device and entity registry entries, plus database records.
  * Configuration entries are now updated to prevent repeated warnings about orphaned areas.

* **Tests**
  * Added comprehensive test coverage for orphaned area cleanup functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->