### PR TITLE
fix: Apply configured environmental weight to all env sensor sub-types

### DIFF
--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -700,7 +700,8 @@ class EntityFactory:
 
         weights = getattr(self.config, "weights", None)
         if weights:
-            weight_attr = getattr(weights, input_type.value, None)
+            weight_key = _WEIGHT_KEY_FOR_INPUT_TYPE.get(input_type, input_type.value)
+            weight_attr = getattr(weights, weight_key, None)
             if weight_attr is not None:
                 config_weight = weight_attr
 

--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -37,6 +37,23 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Environmental sensor sub-types share a single configurable weight
+# ("environmental") rather than having individual weight fields. This map
+# translates each sub-type's InputType to the Weights attribute name.
+_WEIGHT_KEY_FOR_INPUT_TYPE: dict[InputType, str] = {
+    InputType.TEMPERATURE: "environmental",
+    InputType.HUMIDITY: "environmental",
+    InputType.ILLUMINANCE: "environmental",
+    InputType.CO2: "environmental",
+    InputType.CO: "environmental",
+    InputType.SOUND_PRESSURE: "environmental",
+    InputType.PRESSURE: "environmental",
+    InputType.AIR_QUALITY: "environmental",
+    InputType.VOC: "environmental",
+    InputType.PM25: "environmental",
+    InputType.PM10: "environmental",
+}
+
 
 @dataclass
 class Entity:
@@ -806,7 +823,12 @@ class EntityFactory:
 
         weights = getattr(self.config, "weights", None)
         if weights:
-            weight_attr = getattr(weights, input_type_enum.value, None)
+            # Look up weight by input type, falling back to the shared
+            # "environmental" weight for environmental sensor sub-types
+            weight_key = _WEIGHT_KEY_FOR_INPUT_TYPE.get(
+                input_type_enum, input_type_enum.value
+            )
+            weight_attr = getattr(weights, weight_key, None)
             if weight_attr is not None:
                 weight = weight_attr
 

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -2083,6 +2083,41 @@ class TestEntityFactory:
         assert "sensor.co" in mapping
         assert mapping["sensor.co"] == "co"
 
+    @pytest.mark.parametrize(
+        ("input_type", "sensor_attr", "entity_id"),
+        [
+            ("temperature", "temperature", "sensor.temp"),
+            ("humidity", "humidity", "sensor.hum"),
+            ("illuminance", "illuminance", "sensor.lux"),
+            ("co2", "co2", "sensor.co2"),
+            ("pressure", "pressure", "sensor.press"),
+        ],
+    )
+    def test_environmental_weight_applied_to_subtypes(
+        self,
+        coordinator: AreaOccupancyCoordinator,
+        input_type: str,
+        sensor_attr: str,
+        entity_id: str,
+    ) -> None:
+        """Test that the environmental weight config applies to all env sensor sub-types."""
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+
+        # Set a non-default environmental weight
+        area.config.weights.environmental = 0.7
+
+        # Configure a sensor of the given type
+        setattr(area.config.sensors, sensor_attr, [entity_id])
+
+        factory = EntityFactory(coordinator, area_name=area_name)
+        entity = factory.create_from_config_spec(entity_id, input_type)
+
+        assert entity.weight == 0.7, (
+            f"Environmental weight 0.7 should apply to {input_type} sensor, "
+            f"got {entity.weight}"
+        )
+
 
 # ruff: noqa: SLF001
 @pytest.fixture

--- a/tests/test_data_entity.py
+++ b/tests/test_data_entity.py
@@ -2118,6 +2118,40 @@ class TestEntityFactory:
             f"got {entity.weight}"
         )
 
+    def test_create_from_db_environmental_weight(
+        self,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test that create_from_db applies the environmental weight to env sub-types."""
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+
+        # Set a non-default environmental weight
+        area.config.weights.environmental = 0.7
+
+        factory = EntityFactory(coordinator, area_name=area_name)
+
+        # Mock a DB entity for a temperature sensor with an invalid weight
+        # so the config weight is used as fallback
+        mock_db_entity = Mock()
+        mock_db_entity.to_dict = lambda: {
+            "entity_id": "sensor.db_temp",
+            "entity_type": "temperature",
+            "prob_given_true": 0.5,
+            "prob_given_false": 0.05,
+            "weight": -1.0,  # Invalid — should fall back to config
+            "is_decaying": False,
+            "decay_start": dt_util.utcnow(),
+            "last_updated": dt_util.utcnow(),
+            "evidence": None,
+        }
+
+        entity = factory.create_from_db(mock_db_entity)
+        assert entity.weight == 0.7, (
+            f"DB-loaded temperature sensor should use environmental config weight 0.7, "
+            f"got {entity.weight}"
+        )
+
 
 # ruff: noqa: SLF001
 @pytest.fixture


### PR DESCRIPTION
## Summary

Fixes #422

- The environmental weight setting was being ignored for all environmental sensor sub-types (temperature, humidity, illuminance, CO2, pressure, etc.)
- Root cause: weight lookup used `InputType.value` (e.g. `"temperature"`) as the `Weights` attribute name, but `Weights` only has a single `"environmental"` field shared across all env sub-types
- Added a mapping (`_WEIGHT_KEY_FOR_INPUT_TYPE`) that translates environmental sub-type `InputType` values to the correct `"environmental"` weight key

## Changes

- `data/entity.py`: Added `_WEIGHT_KEY_FOR_INPUT_TYPE` mapping and updated `create_from_config_spec()` to use it for weight lookups
- `tests/test_data_entity.py`: Added parametrized test covering 5 environmental sub-types

## Test plan

- [x] `test_environmental_weight_applied_to_subtypes` — parametrized across temperature, humidity, illuminance, CO2, pressure
- [x] Full test suite passes (1514 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded unified weight configuration for environmental sensors (temperature, humidity, illuminance, CO2, CO, sound pressure, pressure, air quality, VOC, PM2.5, PM10), simplifying sensor setup.

* **Tests**
  * Added tests to verify the unified weight is applied across all environmental sensor types and that invalid stored weights fall back to the configured value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->