### PR TITLE
fix: cap prior floors below threshold and expose prior diagnostics (#435)

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -172,6 +172,11 @@ MAX_PRIOR: Final[float] = 0.99
 MIN_WEIGHT: Final[float] = 0.01
 MAX_WEIGHT: Final[float] = 0.99
 
+# Margin kept between a prior *floor* (purpose min_prior, min_prior_override)
+# and the area's occupancy threshold. Floors alone must not be able to
+# hold an area above the threshold with no active evidence — see issue #435.
+PRIOR_FLOOR_THRESHOLD_MARGIN: Final[float] = 0.01
+
 # Time Prior Bounds
 TIME_PRIOR_MIN_BOUND: Final[float] = 0.03
 TIME_PRIOR_MAX_BOUND: Final[float] = 0.9

--- a/custom_components/area_occupancy/data/prior.py
+++ b/custom_components/area_occupancy/data/prior.py
@@ -16,6 +16,7 @@ from ..const import (
     DEFAULT_TIME_PRIOR,
     MAX_PRIOR,
     MIN_PRIOR,
+    PRIOR_FLOOR_THRESHOLD_MARGIN,
     TIME_PRIOR_MAX_BOUND,
     TIME_PRIOR_MIN_BOUND,
 )
@@ -81,39 +82,82 @@ class Prior:
         The prior is calculated by combining global_prior and time_prior,
         applying PRIOR_FACTOR boost, and clamping to [MIN_PRIOR, MAX_PRIOR].
 
+        Floors (purpose.min_prior, config.min_prior_override) can raise the
+        learned prior, but they are capped strictly below the configured
+        occupancy threshold so that a floor alone cannot hold an area above
+        the threshold with no active evidence (see issue #435). Learned
+        priors — which reflect real historical occupancy — are allowed to
+        exceed the threshold.
+
         Returns:
-            Prior probability in range [MIN_PRIOR, MAX_PRIOR]
+            Prior probability in range [MIN_PRIOR, MAX_PRIOR].
         """
-        # Initialize result to MIN_PRIOR if global_prior is None
-        # This allows min_prior_override to be applied even when prior hasn't been calculated
+        return self._compute_value_and_floor()[0]
+
+    def _compute_value_and_floor(self) -> tuple[float, str]:
+        """Compute prior.value and report which floor (if any) applied.
+
+        Returns:
+            Tuple of (prior value, floor label). Floor label is one of
+            ``"none"``, ``"purpose"``, ``"override"``. The label reflects the
+            floor responsible for raising the value above the learned prior,
+            or ``"none"`` if the learned prior is already at or above every
+            floor.
+        """
         if self.global_prior is None:
-            result = MIN_PRIOR
+            learned = MIN_PRIOR
         else:
-            # Use global_prior directly if time_prior is None, otherwise combine them
-            # Both global_prior (via set_global_prior) and combine_priors output
-            # are already clamped to [MIN_PROBABILITY, MAX_PROBABILITY]
             if self.time_prior is None:
                 prior = self.global_prior
             else:
                 prior = combine_priors(self.global_prior, self.time_prior)
 
-            # Apply PRIOR_FACTOR boost and clamp to [MIN_PRIOR, MAX_PRIOR]
-            # The boost rewards areas with learned occupancy patterns
             adjusted_prior = prior * PRIOR_FACTOR
-            result = max(MIN_PRIOR, min(MAX_PRIOR, adjusted_prior))
+            learned = max(MIN_PRIOR, min(MAX_PRIOR, adjusted_prior))
 
-        # Apply purpose-based minimum prior. Transit spaces have duration-biased
-        # learned priors that are unrealistically low because people don't linger.
+        purpose_floor = 0.0
         area = self.coordinator.areas.get(self.area_name)
         if area is not None and area.purpose.min_prior > 0.0:
-            result = max(result, area.purpose.min_prior)
+            purpose_floor = area.purpose.min_prior
 
-        # Apply minimum prior override if configured (user override takes precedence)
-        # This check must run for all code paths, including when global_prior is None
+        override_floor = 0.0
         if self.config.min_prior_override > 0.0:
-            result = max(result, self.config.min_prior_override)
+            override_floor = self.config.min_prior_override
 
-        return result
+        floor_cap = max(MIN_PRIOR, self.config.threshold - PRIOR_FLOOR_THRESHOLD_MARGIN)
+        capped_purpose = min(purpose_floor, floor_cap)
+        capped_override = min(override_floor, floor_cap)
+
+        result = learned
+        applied = "none"
+        if capped_purpose > result:
+            result = capped_purpose
+            applied = "purpose"
+        if capped_override > result:
+            result = capped_override
+            applied = "override"
+
+        return result, applied
+
+    def diagnostic_snapshot(self) -> dict[str, float | str | None]:
+        """Return a snapshot of the prior's current inputs and output.
+
+        Exposed to users via the probability sensor's extra_state_attributes
+        so they can see which term is driving the prior — especially useful
+        when an area appears "stuck" occupied with no active evidence.
+
+        Returns:
+            Dict with learned components, the floor that was applied (if
+            any), the effective prior value, and the configured threshold.
+        """
+        value, applied = self._compute_value_and_floor()
+        return {
+            "prior_value": value,
+            "global_prior": self.global_prior,
+            "time_prior": self.time_prior,
+            "min_prior_floor_applied": applied,
+            "threshold": self.config.threshold,
+        }
 
     @property
     def time_prior(self) -> float:

--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -194,6 +194,35 @@ class ProbabilitySensor(AreaOccupancySensorBase):
             return None
         return format_float(area.probability() * 100)
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return diagnostic attributes exposing what drives the probability.
+
+        Surfaces the prior's learned components and the floor (if any) that
+        was applied, plus lists of currently active and decaying entities
+        with their decay factors. Helps users diagnose "stuck" occupancy
+        reports without needing debug logging.
+        """
+        if self._all_areas is not None:
+            return {}
+        area = self._get_area()
+        if area is None:
+            return {}
+        try:
+            snapshot = area.prior.diagnostic_snapshot()
+            active_entities = [e.entity_id for e in area.entities.active_entities]
+            decaying_entities = [
+                {"entity_id": e.entity_id, "decay_factor": e.decay.decay_factor}
+                for e in area.entities.decaying_entities
+            ]
+        except (AttributeError, KeyError, TypeError):
+            return {}
+        return {
+            **snapshot,
+            "active_entities": active_entities,
+            "decaying_entities": decaying_entities,
+        }
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -11,6 +11,7 @@ from custom_components.area_occupancy.const import (
     MAX_PROBABILITY,
     MIN_PRIOR,
     MIN_PROBABILITY,
+    PRIOR_FLOOR_THRESHOLD_MARGIN,
     TIME_PRIOR_MAX_BOUND,
     TIME_PRIOR_MIN_BOUND,
 )
@@ -624,3 +625,121 @@ def test_purpose_min_prior_does_not_override_higher_value(
         result = prior.value
 
     assert result == 0.5
+
+
+def test_min_prior_override_capped_below_threshold(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """A min_prior_override above the threshold is clamped below it (#435)."""
+    area_name = coordinator.get_area_names()[0]
+    area = coordinator.get_area(area_name)
+    prior = Prior(coordinator, area_name=area_name)
+
+    area.config.threshold = 0.5
+    area.config.min_prior_override = 0.9
+    prior.global_prior = 0.01
+
+    with patch.object(
+        Prior, "time_prior", new_callable=PropertyMock, return_value=None
+    ):
+        result = prior.value
+
+    expected_cap = 0.5 - PRIOR_FLOOR_THRESHOLD_MARGIN
+    assert result == pytest.approx(expected_cap)
+    assert result < area.config.threshold
+
+
+def test_purpose_min_prior_capped_below_threshold(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """A purpose min_prior above the threshold is clamped below it (#435)."""
+    area_name = coordinator.get_area_names()[0]
+    area = coordinator.get_area(area_name)
+    prior = Prior(coordinator, area_name=area_name)
+
+    area.config.threshold = 0.05
+    area._purpose = Purpose(purpose=AreaPurpose.PASSAGEWAY)
+    prior.global_prior = 0.01
+
+    with patch.object(
+        Prior, "time_prior", new_callable=PropertyMock, return_value=None
+    ):
+        result = prior.value
+
+    expected_cap = max(MIN_PRIOR, 0.05 - PRIOR_FLOOR_THRESHOLD_MARGIN)
+    assert result == pytest.approx(expected_cap)
+    assert result < area.config.threshold
+
+
+def test_learned_prior_above_threshold_passes_through(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """Learned priors above the threshold are not capped (#435).
+
+    Only floors (purpose min_prior, min_prior_override) are capped.
+    A learned global_prior reflects real historical occupancy and is
+    allowed to exceed the threshold.
+    """
+    area_name = coordinator.get_area_names()[0]
+    area = coordinator.get_area(area_name)
+    prior = Prior(coordinator, area_name=area_name)
+
+    area.config.threshold = 0.5
+    area.config.min_prior_override = 0.0
+    prior.global_prior = 0.8
+
+    with patch.object(
+        Prior, "time_prior", new_callable=PropertyMock, return_value=None
+    ):
+        result = prior.value
+
+    assert result == pytest.approx(0.8)
+
+
+def test_diagnostic_snapshot_contents(coordinator: AreaOccupancyCoordinator):
+    """diagnostic_snapshot surfaces the terms that drive prior.value."""
+    area_name = coordinator.get_area_names()[0]
+    area = coordinator.get_area(area_name)
+    prior = Prior(coordinator, area_name=area_name)
+
+    area.config.threshold = 0.5
+    area.config.min_prior_override = 0.9  # triggers override floor (capped)
+    prior.global_prior = 0.2
+
+    with patch.object(
+        Prior, "time_prior", new_callable=PropertyMock, return_value=None
+    ):
+        snapshot = prior.diagnostic_snapshot()
+
+    assert set(snapshot.keys()) == {
+        "prior_value",
+        "global_prior",
+        "time_prior",
+        "min_prior_floor_applied",
+        "threshold",
+    }
+    assert snapshot["min_prior_floor_applied"] == "override"
+    assert snapshot["threshold"] == 0.5
+    assert snapshot["global_prior"] == 0.2
+    assert snapshot["prior_value"] == pytest.approx(0.5 - PRIOR_FLOOR_THRESHOLD_MARGIN)
+
+
+def test_diagnostic_snapshot_reports_no_floor_when_learned_dominates(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """When the learned prior dominates, snapshot reports floor 'none'."""
+    area_name = coordinator.get_area_names()[0]
+    area = coordinator.get_area(area_name)
+    prior = Prior(coordinator, area_name=area_name)
+
+    area.config.threshold = 0.5
+    area.config.min_prior_override = 0.0
+    prior.global_prior = 0.7
+
+    with patch.object(
+        Prior, "time_prior", new_callable=PropertyMock, return_value=None
+    ):
+        snapshot = prior.diagnostic_snapshot()
+
+    assert snapshot["min_prior_floor_applied"] == "none"
+    assert snapshot["prior_value"] == pytest.approx(0.7)


### PR DESCRIPTION
Fixes #435.

## Summary

- With a single inactive sensor, `sigmoid_probability` reduces to `P ≈ prior.value`, so a floor (`purpose.min_prior` or `config.min_prior_override`) at or above the occupancy threshold pinned the area "detected" with zero active evidence.
- Cap both floors at `threshold - PRIOR_FLOOR_THRESHOLD_MARGIN` (0.01). Learned priors (`global × time`, after `PRIOR_FACTOR`) bypass the cap — they reflect real historical occupancy.
- Add `Prior.diagnostic_snapshot()` returning `prior_value`, `global_prior`, `time_prior`, `min_prior_floor_applied` (`"none" | "purpose" | "override"`), `threshold`.
- Expose the snapshot plus `active_entities` and `decaying_entities` (each with `decay_factor`) as `extra_state_attributes` on `ProbabilitySensor`, so users can diagnose "stuck" reports from Developer Tools → States.

`_compute_value_and_floor` is the single source of truth — `value` and `diagnostic_snapshot` both call it, so they can't drift.

## Test plan

- [x] `uv run pytest tests/test_data_prior.py` — 43 passed (5 new).
- [x] `uv run pytest` (full suite) — 1547 passed.
- [x] `uv run ruff check` + `uv run ruff format` — clean.
- [ ] Manual: in HA, set `min_prior_override` to 0.9 with threshold 0.5 on an empty area → probability sensor stays below threshold and `min_prior_floor_applied` attribute reads `"override"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sensors now display diagnostic state attributes, including lists of active entities, decay factors, and prior computation details for enhanced visibility and troubleshooting.

* **Improvements**
  * Refined prior floor handling mechanism to maintain a margin between the prior floor and area threshold, improving threshold stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->