### PR TITLE
fix: preserve custom decay half-life that matches another purpose's default (#439)

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -1574,8 +1574,10 @@ def _apply_purpose_based_decay_default(
         return
 
     user_set_decay = flattened_input.get(CONF_DECAY_HALF_LIFE)
-    if user_set_decay is None or Purpose.is_purpose_half_life(user_set_decay):
-        # Set to 0 to indicate "use purpose value"
+    if user_set_decay is None or Purpose.is_purpose_half_life(user_set_decay, purpose):
+        # Normalise to 0 ("use purpose value") when the user left the field
+        # empty or entered exactly the selected purpose's default. Any other
+        # custom value is preserved so it persists across reloads (#439).
         flattened_input[CONF_DECAY_HALF_LIFE] = 0
 
 

--- a/custom_components/area_occupancy/data/purpose.py
+++ b/custom_components/area_occupancy/data/purpose.py
@@ -122,18 +122,35 @@ class Purpose:
             return purpose.replace("_", " ").title()
 
     @staticmethod
-    def is_purpose_half_life(value: float) -> bool:
-        """Check whether a half-life value matches any purpose default.
+    def is_purpose_half_life(value: float, purpose: str | None = None) -> bool:
+        """Check whether a half-life value matches the purpose's default.
+
+        When ``purpose`` is provided, the value is compared only against that
+        purpose's built-in half-life. This is the correct check when deciding
+        whether a user-entered override should be normalised to 0 (auto), so
+        that switching purpose later picks up the new default.
+
+        When ``purpose`` is ``None``, only the ``0`` sentinel returns True.
+        The legacy behaviour of matching against *any* purpose's default was
+        removed because it silently overwrote valid custom half-lives that
+        happened to equal another purpose's default (see issue #439).
 
         Args:
             value: Half-life value to check.
+            purpose: Purpose string to compare against. Optional.
 
         Returns:
-            True if the value is a built-in purpose half-life or 0 (auto).
+            True if the value is 0 (auto) or equals the selected purpose's
+            built-in half-life.
         """
         if value == 0:
             return True
-        return any(p.half_life == value for p in PURPOSE_DEFINITIONS.values())
+        if purpose is None:
+            return False
+        try:
+            return PURPOSE_DEFINITIONS[AreaPurpose(purpose)].half_life == value
+        except (ValueError, KeyError):
+            return False
 
     def cleanup(self) -> None:
         """Clean up the purpose (no-op for compatibility)."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1462,6 +1462,31 @@ class TestNewHelperFunctions:
         else:
             assert CONF_DECAY_HALF_LIFE not in flattened_input
 
+    def test_apply_purpose_based_decay_default_preserves_custom_value(self):
+        """Custom half-life must persist when it doesn't equal the selected purpose default.
+
+        Regression test for #439: values matching *another* purpose's default
+        (e.g. 600s = Office default) were silently overwritten to 0 when the
+        selected purpose was different (e.g. Social/Living Room = 520s).
+        """
+        # "social" purpose default is 520s; 600s is the Office default.
+        flattened_input = {CONF_PURPOSE: "social", CONF_DECAY_HALF_LIFE: 600}
+        _apply_purpose_based_decay_default(flattened_input, "social")
+        assert flattened_input[CONF_DECAY_HALF_LIFE] == 600
+
+    def test_apply_purpose_based_decay_default_normalises_matching_value(self):
+        """Entering the current purpose's default must normalise to 0 (auto)."""
+        # "social" purpose default is 520s.
+        flattened_input = {CONF_PURPOSE: "social", CONF_DECAY_HALF_LIFE: 520}
+        _apply_purpose_based_decay_default(flattened_input, "social")
+        assert flattened_input[CONF_DECAY_HALF_LIFE] == 0
+
+    def test_apply_purpose_based_decay_default_preserves_arbitrary_value(self):
+        """Arbitrary custom values must be preserved verbatim."""
+        flattened_input = {CONF_PURPOSE: "social", CONF_DECAY_HALF_LIFE: 777}
+        _apply_purpose_based_decay_default(flattened_input, "social")
+        assert flattened_input[CONF_DECAY_HALF_LIFE] == 777
+
     def test_flatten_sectioned_input(self):
         """Test flattening sectioned input."""
         user_input = {

--- a/tests/test_data_purpose.py
+++ b/tests/test_data_purpose.py
@@ -173,3 +173,44 @@ class TestGetDefaultDecayHalfLife:
         half_life = get_default_decay_half_life(invalid_purpose)
         expected_half_life = PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL].half_life
         assert half_life == expected_half_life
+
+
+class TestIsPurposeHalfLife:
+    """Test Purpose.is_purpose_half_life static helper."""
+
+    def test_zero_is_auto(self):
+        """Zero is the sentinel meaning "use purpose value"."""
+        assert Purpose.is_purpose_half_life(0) is True
+        assert Purpose.is_purpose_half_life(0, "social") is True
+
+    def test_matches_selected_purpose_default(self):
+        """Value equal to the selected purpose's default returns True."""
+        # Social/Living Room default is 520s.
+        social_default = PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL].half_life
+        assert Purpose.is_purpose_half_life(social_default, "social") is True
+
+    def test_ignores_other_purpose_defaults(self):
+        """Value equal to a *different* purpose's default returns False.
+
+        Regression test for #439: the previous implementation matched any
+        purpose default regardless of the area's selected purpose, which
+        silently clobbered custom half-life values.
+        """
+        # Office default is 600s, Social default is 520s.
+        office_default = PURPOSE_DEFINITIONS[AreaPurpose.WORKING].half_life
+        assert office_default != PURPOSE_DEFINITIONS[AreaPurpose.SOCIAL].half_life
+        assert Purpose.is_purpose_half_life(office_default, "social") is False
+
+    def test_arbitrary_value_returns_false(self):
+        """Arbitrary values never match."""
+        assert Purpose.is_purpose_half_life(777, "social") is False
+        assert Purpose.is_purpose_half_life(777) is False
+
+    def test_none_purpose_only_matches_zero(self):
+        """Without a purpose, only the 0 sentinel is treated as auto."""
+        assert Purpose.is_purpose_half_life(520) is False
+        assert Purpose.is_purpose_half_life(0) is True
+
+    def test_invalid_purpose_returns_false(self):
+        """Unknown purpose strings cause False for any non-zero value."""
+        assert Purpose.is_purpose_half_life(520, "not_a_real_purpose") is False


### PR DESCRIPTION
## Summary

- Fixes [#439](https://github.com/Hankanman/Area-Occupancy-Detection/issues/439) (reported in [discussion #433](https://github.com/Hankanman/Area-Occupancy-Detection/discussions/433)) — custom decay half-life appearing to save but not persisting.
- `Purpose.is_purpose_half_life` previously returned True whenever the entered value matched *any* purpose's built-in half-life. `_apply_purpose_based_decay_default` then normalised the value to `0` ("use purpose default"), silently discarding legitimate custom values such as `600s` on a Living Room (equals the Office purpose default).
- The helper now accepts the selected purpose and compares only against that purpose's default. Arbitrary custom values are preserved; entering exactly the current purpose's default still normalises to `0` so changing purpose later picks up the new default (legacy behaviour retained for that specific path).

## Why

The 12 purpose defaults span the most "natural" round values a user is likely to pick (45, 60, 90, 180, 240, 360, 450, 480, 520, 600, 620, 1200 seconds). Any user who typed one of them — intentionally or by coincidence — would see the form complete without error, then reopen to find the previous value, with runtime decay using the purpose default instead.

## Changes

- [`custom_components/area_occupancy/data/purpose.py`](custom_components/area_occupancy/data/purpose.py) — `is_purpose_half_life(value, purpose=None)`, checks only the selected purpose's default. Without a purpose, only `0` is treated as auto.
- [`custom_components/area_occupancy/config_flow.py`](custom_components/area_occupancy/config_flow.py) — passes the selected purpose into the check.
- Regression tests in [`tests/test_data_purpose.py`](tests/test_data_purpose.py) (new `TestIsPurposeHalfLife` class) and [`tests/test_config_flow.py`](tests/test_config_flow.py) (three new cases covering preserve / normalise / arbitrary value).

## Test plan

- [x] `uv run pytest tests/test_data_purpose.py tests/test_config_flow.py tests/test_data_config.py tests/test_data_decay.py` — 305 passed
- [x] `uv run ruff format` + `uv run ruff check` — clean
- [ ] Manual UI verification: set a Living Room (purpose = Social, default 520s) half-life to 600s, save, reopen — value persists.
- [ ] Manual UI verification: set half-life to 520s (matches current purpose default), save, reopen — shows `0` (auto), runtime decay uses 520s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved decay half-life normalization logic to properly account for the selected area purpose when applying configuration defaults and distinguishing between custom and purpose-specific values.

* **Tests**
  * Added comprehensive test coverage for purpose-based decay settings, including scenarios for custom value preservation, default normalization, and cross-purpose value handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->