### PR TITLE
docs: prepare for Material for MkDocs maintenance mode

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -26,7 +26,9 @@
       "Bash(tail:*)",
       "Bash(uv run:*)",
       "WebFetch(domain:community.home-assistant.io)",
-      "Bash(git log:*)"
+      "Bash(git log:*)",
+      "WebFetch(domain:squidfunk.github.io)",
+      "WebFetch(domain:zensical.org)"
     ]
   }
 }

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,3 +28,9 @@ jobs:
         working-directory: ./docs
       - run: uv run mkdocs gh-deploy --force
         working-directory: ./docs
+        env:
+          # MkDocs 2.0 is intentionally incompatible with Material for MkDocs.
+          # We are pinned to mkdocs<2.0 in docs/pyproject.toml; silence the
+          # upstream build warning until we migrate (planned: Zensical, see
+          # docs/MIGRATION.md).
+          NO_MKDOCS_2_WARNING: "1"

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,48 @@
+# Documentation Migration Plan
+
+## Current stack
+
+- **MkDocs 1.x** + **Material for MkDocs 9.x** (pinned in [`pyproject.toml`](./pyproject.toml))
+- Plugins: `mkdocs-minify-plugin`, `mkdocs-include-markdown-plugin`
+- Deployed via `mkdocs gh-deploy` in [`.github/workflows/docs.yml`](../.github/workflows/docs.yml)
+
+## Why this page exists
+
+Two upstream announcements change the long-term picture:
+
+1. [Zensical announcement (2025-11-05)](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) — Material for MkDocs enters maintenance mode for ~12 months (through ~Nov 2026). Critical bug and security fixes only.
+2. [MkDocs 2.0 announcement (2026-02-18)](https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/) — MkDocs 2.0 is intentionally incompatible with Material for MkDocs (removes plugins, switches to TOML, pre-renders nav).
+
+The squidfunk-authored successor is **[Zensical](https://zensical.org/)**, which reads `mkdocs.yml` natively and offers a `classic` theme variant that matches Material's look and feel.
+
+## Decision: defensive pin + wait
+
+We are **staying on Material for MkDocs** for now. MkDocs 2.0 cannot accidentally be installed because `pyproject.toml` pins `mkdocs>=1.6.0,<2.0.0` and `mkdocs-material>=9.5.0,<10.0.0`. CI sets `NO_MKDOCS_2_WARNING=1` to silence the upstream deprecation banner.
+
+## Blockers for migrating to Zensical today
+
+Tracked so we know when to revisit:
+
+- `mkdocs-minify-plugin` — not yet in Zensical's committed plugin list.
+- `mkdocs-include-markdown-plugin` — not yet in Zensical's committed plugin list.
+- `mkdocs gh-deploy` equivalent — not documented in Zensical CLI (`build`, `serve`, `new` only).
+- Zensical version is `0.0.x` (pre-1.0); public Material→Zensical migration guide does not yet exist.
+- Navigation feature parity (`navigation.tabs`, `navigation.instant`, `navigation.footer`, etc.) is not confirmed.
+
+## Revisit criteria
+
+Re-evaluate when **all** of the following hold:
+
+- Zensical ships a `gh-deploy` equivalent (or a documented GitHub Pages workflow).
+- Both `mkdocs-minify-plugin` and `mkdocs-include-markdown-plugin` are supported, or acceptable replacements exist.
+- Zensical reaches a `1.0` or otherwise stable release.
+- A community migration guide from Material for MkDocs exists.
+
+Otherwise, revisit no later than **2026-08** to leave runway before the Material maintenance window closes.
+
+## Useful references
+
+- [Zensical — Get started](https://zensical.org/docs/get-started/)
+- [Zensical — Basics / config](https://zensical.org/docs/setup/basics/)
+- [Zensical — FAQ](https://zensical.org/docs/community/faqs/)
+- [Material for MkDocs discussion: Migration to Zensical](https://github.com/squidfunk/mkdocs-material/discussions/8524)


### PR DESCRIPTION
## Summary

- Silence MkDocs 2.0 deprecation warning in the docs deploy workflow via `NO_MKDOCS_2_WARNING=1` (we're already pinned to `mkdocs<2.0` in [`docs/pyproject.toml`](docs/pyproject.toml))
- Add [`docs/MIGRATION.md`](docs/MIGRATION.md) capturing the current stack, the concrete blockers preventing a move to Zensical today, and the criteria for revisiting

## Why

Two upstream announcements shift the long-term picture for the docs stack:

1. [Zensical announcement (2025-11-05)](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) — Material for MkDocs is in maintenance mode through ~Nov 2026 (critical fixes only).
2. [MkDocs 2.0 announcement (2026-02-18)](https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/) — MkDocs 2.0 is intentionally incompatible with Material for MkDocs.

We considered migrating to Zensical now, but ruled it out for this PR:

- `mkdocs-minify-plugin` and `mkdocs-include-markdown-plugin` are not yet in Zensical's committed plugin list.
- There is no documented `gh-deploy` equivalent in Zensical's CLI; our [docs workflow](.github/workflows/docs.yml) depends on it.
- Zensical is at `0.0.x` and no official Material→Zensical migration guide exists yet.

So we stay on Material for MkDocs, silence the warning, and document the revisit criteria.

## Test plan

- [ ] `docs` workflow still runs on push to `main` and deploys successfully
- [ ] Build output no longer contains MkDocs 2.0 deprecation warning lines
- [ ] `docs/MIGRATION.md` renders as expected on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration plan documentation outlining the project's documentation toolchain, documenting external factors affecting upgrades, identifying blockers for potential migrations, and establishing concrete criteria and timelines for future reassessment of documentation infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->