### PR TITLE
fix(docs): unblock gh-pages deploy by bumping pymdown-extensions

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -8,6 +8,11 @@ dependencies = [
     "mkdocs-material>=9.5.0,<10.0.0",
     "mkdocs-minify-plugin>=0.8.0,<1.0.0",
     "mkdocs-include-markdown-plugin>=6.0.0",
+    # Pygments 2.20 dropped tolerance for filename=None in HtmlFormatter;
+    # pymdown-extensions 10.21.2 adds the compatibility fix. Pinned as a
+    # direct dep so the lock cannot regress below that version even though
+    # it is otherwise transitive via mkdocs-material.
+    "pymdown-extensions>=10.21.2",
 ]
 
 [build-system]

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -11,6 +11,7 @@ dependencies = [
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-minify-plugin" },
+    { name = "pymdown-extensions" },
 ]
 
 [package.metadata]
@@ -19,6 +20,7 @@ requires-dist = [
     { name = "mkdocs-include-markdown-plugin", specifier = ">=6.0.0" },
     { name = "mkdocs-material", specifier = ">=9.5.0,<10.0.0" },
     { name = "mkdocs-minify-plugin", specifier = ">=0.8.0,<1.0.0" },
+    { name = "pymdown-extensions", specifier = ">=10.21.2" },
 ]
 
 [[package]]
@@ -391,15 +393,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21"
+version = "10.21.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/63/06673d1eb6d8f83c0ea1f677d770e12565fb516928b4109c9e2055656a9e/pymdown_extensions-10.21.tar.gz", hash = "sha256:39f4a020f40773f6b2ff31d2cd2546c2c04d0a6498c31d9c688d2be07e1767d5", size = 853363, upload-time = "2026-02-15T20:44:06.748Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/2c/5b079febdc65e1c3fb2729bf958d18b45be7113828528e8a0b5850dd819a/pymdown_extensions-10.21-py3-none-any.whl", hash = "sha256:91b879f9f864d49794c2d9534372b10150e6141096c3908a455e45ca72ad9d3f", size = 268877, upload-time = "2026-02-15T20:44:05.464Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pin `pymdown-extensions>=10.21.2` in [`docs/pyproject.toml`](docs/pyproject.toml) and refresh `docs/uv.lock`

## Why

The docs deploy workflow has been failing on every push to `main` since the dependabot Pygments bumps (#426, #427) landed:

```
ERROR - Error reading page 'technical/global-prior-flow.md':
        'NoneType' object has no attribute 'replace'
...
File "pygments/formatters/html.py", line 434, in __init__
    self.filename = html.escape(self._decodeifneeded(options.get('filename', '')))
File "pymdownx/highlight.py", line 400, in highlight
    formatter = html_formatter(...)
AttributeError: 'NoneType' object has no attribute 'replace'
```

[Pygments 2.20](https://github.com/pygments/pygments) tightened `HtmlFormatter` so `filename=None` is no longer accepted; `pymdown-extensions` 10.21 passed `None` unconditionally. The upstream fix landed in [pymdown-extensions 10.21.2](https://github.com/facelessuser/pymdown-extensions/releases) (*"Highlight: Latest Pygments versions cannot handle a 'filename' for code block titles of `None`"*).

The package was already present transitively via `mkdocs-material`; I've added it as a direct constraint so the lockfile cannot regress below 10.21.2.

Failing run for reference: [docs run 24559451523](https://github.com/Hankanman/Area-Occupancy-Detection/actions/runs/24559451523).

## Test plan

- [x] `uv lock` resolves to `pymdown-extensions==10.21.2`
- [x] `uv run mkdocs build --strict` succeeds locally
- [ ] GitHub Actions `Build and Deploy Docs` workflow goes green on merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build dependencies to enhance markdown rendering capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->