### PR TITLE
Fix TypeError on naive vs aware datetime in health checks

### DIFF
--- a/custom_components/area_occupancy/data/entity.py
+++ b/custom_components/area_occupancy/data/entity.py
@@ -96,8 +96,11 @@ class Entity:
             raise ValueError("Either hass or state_provider must be provided")
         if self.hass is not None and self.state_provider is not None:
             raise ValueError("Cannot provide both hass and state_provider")
-        if self.last_updated is None:
-            self.last_updated = dt_util.utcnow()
+        self.last_updated = (
+            to_utc(self.last_updated)
+            if self.last_updated is not None
+            else dt_util.utcnow()
+        )
 
         # Store the static probability values in protected attributes
         # These are used as fallbacks when Gaussian calculation is not available

--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -254,7 +254,7 @@ class HealthMonitor:
         if entity.last_updated is None:
             return None
 
-        duration = now - entity.last_updated
+        duration = now - dt_util.as_utc(entity.last_updated)
         evidence = entity.evidence
 
         # Check stuck active
@@ -303,7 +303,7 @@ class HealthMonitor:
         if entity.last_updated is None:
             return None
 
-        duration = now - entity.last_updated
+        duration = now - dt_util.as_utc(entity.last_updated)
         if duration < UNAVAILABLE_THRESHOLD:
             return None
 

--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -254,7 +254,7 @@ class HealthMonitor:
         if entity.last_updated is None:
             return None
 
-        duration = now - dt_util.as_utc(entity.last_updated)
+        duration = now - entity.last_updated
         evidence = entity.evidence
 
         # Check stuck active
@@ -303,7 +303,7 @@ class HealthMonitor:
         if entity.last_updated is None:
             return None
 
-        duration = now - dt_util.as_utc(entity.last_updated)
+        duration = now - entity.last_updated
         if duration < UNAVAILABLE_THRESHOLD:
             return None
 

--- a/custom_components/area_occupancy/db/operations.py
+++ b/custom_components/area_occupancy/db/operations.py
@@ -32,7 +32,7 @@ from ..const import (
     TIME_PRIOR_MIN_BOUND,
 )
 from ..data.entity_type import CorrelationType, InputType
-from ..time_utils import to_db_utc
+from ..time_utils import to_db_utc, to_utc
 from . import maintenance, queries
 
 ar = helpers.area_registry
@@ -132,7 +132,9 @@ def _update_existing_entity(
                 entity_obj.entity_id,
                 err,
             )
-    existing_entity.last_updated = entity_obj.last_updated
+    existing_entity.last_updated = (
+        to_utc(entity_obj.last_updated) if entity_obj.last_updated is not None else None
+    )
     existing_entity.previous_evidence = entity_obj.evidence
 
     # Restore probabilities from database

--- a/tests/test_data_health.py
+++ b/tests/test_data_health.py
@@ -21,11 +21,20 @@ def _make_entity(
     *,
     state: str | None = "off",
     last_updated: datetime | None = None,
+    naive_last_updated: bool = False,
     evidence: bool | None = False,
 ) -> Entity:
-    """Create a minimal Entity for health testing."""
+    """Create a minimal Entity for health testing.
+
+    When ``naive_last_updated`` is True, the supplied ``last_updated`` is
+    stripped of tzinfo before being passed to the constructor. This mirrors
+    the SQLite DB-restore path, where ``DateTime(timezone=True)`` columns
+    return naive values; ``Entity.__post_init__`` is expected to normalize.
+    """
     if last_updated is None:
         last_updated = dt_util.utcnow()
+    if naive_last_updated:
+        last_updated = last_updated.replace(tzinfo=None)
 
     entity_type = EntityType(
         input_type=input_type,
@@ -600,3 +609,82 @@ class TestProperties:
             monitor.check_health({"motion_1": entity})
 
         assert monitor.last_check is not None
+
+
+# --- Naive last_updated regression tests (PR #446 / issue #445) ---
+
+
+class TestNaiveLastUpdatedRegression:
+    """Regression: naive last_updated must not break health checks.
+
+    Naive datetimes can leak in from SQLite-backed DB restoration —
+    ``DateTime(timezone=True)`` columns return naive values on SQLite. The
+    ``Entity`` contract is that ``last_updated`` is always tz-aware UTC, so
+    ``Entity.__post_init__`` normalizes any naive input via ``to_utc()``.
+    These tests pin both ends of that contract: the normalization itself,
+    and the consumer-side health checks correctly handling caller-supplied
+    naive timestamps.
+    """
+
+    def test_post_init_normalizes_naive_last_updated(self) -> None:
+        """Construction with a naive last_updated yields tz-aware UTC."""
+        entity = _make_entity(
+            "binary_sensor.motion_1",
+            InputType.MOTION,
+            last_updated=dt_util.utcnow(),
+            naive_last_updated=True,
+        )
+        assert entity.last_updated is not None
+        assert entity.last_updated.tzinfo is dt_util.UTC
+
+    def test_check_stuck_sensor_with_naive_input(self, monitor: HealthMonitor) -> None:
+        """Stuck-active fires for motion sensor whose caller supplied naive."""
+        entity = _make_entity(
+            "binary_sensor.motion_1",
+            InputType.MOTION,
+            state="on",
+            last_updated=dt_util.utcnow() - timedelta(hours=3),
+            naive_last_updated=True,
+            evidence=True,
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"motion_1": entity})
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == HealthIssueType.STUCK_ACTIVE
+
+    def test_check_unavailable_with_naive_input(self, monitor: HealthMonitor) -> None:
+        """Unavailable fires for entity whose caller supplied naive."""
+        entity = _make_entity(
+            "binary_sensor.motion_1",
+            InputType.MOTION,
+            state=None,
+            last_updated=dt_util.utcnow() - timedelta(hours=3),
+            naive_last_updated=True,
+            evidence=None,
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"motion_1": entity})
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == HealthIssueType.UNAVAILABLE
+
+    def test_check_never_triggered_with_naive_input(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """Never-triggered fires for appliance whose caller supplied naive."""
+        entity = _make_entity(
+            "binary_sensor.oven",
+            InputType.APPLIANCE,
+            state="off",
+            last_updated=dt_util.utcnow() - timedelta(days=10),
+            naive_last_updated=True,
+            evidence=False,
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"oven": entity})
+
+        never_triggered = [
+            i for i in issues if i.issue_type == HealthIssueType.NEVER_TRIGGERED
+        ]
+        assert len(never_triggered) == 1

--- a/tests/test_db_operations.py
+++ b/tests/test_db_operations.py
@@ -207,6 +207,56 @@ class TestLoadData:
         assert reloaded_motion.prob_given_false == configured_pgf
 
     @pytest.mark.asyncio
+    async def test_load_data_normalizes_naive_last_updated_from_sqlite(
+        self, coordinator: AreaOccupancyCoordinator
+    ):
+        """Regression (PR #446): naive last_updated from DB is normalized to UTC.
+
+        SQLite returns naive datetimes for ``DateTime(timezone=True)`` columns,
+        and prior to the fix ``_update_existing_entity`` assigned that raw value
+        directly to ``Entity.last_updated``. Subsequent arithmetic in
+        ``HealthMonitor`` then raised ``TypeError: can't subtract offset-naive
+        and offset-aware datetimes``. Verify the restore path now hands back a
+        tz-aware UTC value even when the row is naive.
+        """
+        db = coordinator.db
+        db.init_db()
+        area_name = db.coordinator.get_area_names()[0]
+        area = db.coordinator.get_area(area_name)
+        save_area_data(db, area_name)
+
+        entity_id = "switch.test_appliance_naive"
+        try:
+            entity = area.entities.get_entity(entity_id)
+        except ValueError:
+            entity = area.factory.create_from_config_spec(
+                entity_id, InputType.APPLIANCE.value
+            )
+            area.entities.add_entity(entity)
+        save_entity_data(db)
+
+        # Force a *naive* last_updated value into the DB row to faithfully
+        # reproduce SQLite's behavior with DateTime(timezone=True) columns.
+        naive_ts = (dt_util.utcnow() - timedelta(hours=2)).replace(tzinfo=None)
+        with db.get_session() as session:
+            row = (
+                session.query(db.Entities)
+                .filter_by(area_name=area_name, entity_id=entity_id)
+                .one()
+            )
+            row.last_updated = naive_ts
+            session.commit()
+
+        # Drop the in-memory aware value so we can observe the restore.
+        entity.last_updated = None
+
+        await load_data(db)
+
+        reloaded = area.entities.get_entity(entity_id)
+        assert reloaded.last_updated is not None
+        assert reloaded.last_updated.tzinfo is dt_util.UTC
+
+    @pytest.mark.asyncio
     async def test_load_data_deletes_stale_entities(
         self, coordinator: AreaOccupancyCoordinator
     ):

--- a/tests/test_db_operations.py
+++ b/tests/test_db_operations.py
@@ -255,6 +255,8 @@ class TestLoadData:
         reloaded = area.entities.get_entity(entity_id)
         assert reloaded.last_updated is not None
         assert reloaded.last_updated.tzinfo is dt_util.UTC
+        # Wall-clock value must be preserved — only tzinfo should change.
+        assert reloaded.last_updated == naive_ts.replace(tzinfo=dt_util.UTC)
 
     @pytest.mark.asyncio
     async def test_load_data_deletes_stale_entities(


### PR DESCRIPTION
## Summary

`dt_util.utcnow()` returns a timezone-aware datetime, but `entity.last_updated` can be timezone-naive when restored from storage. Subtracting them raises:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

This affects two methods in `custom_components/area_occupancy/data/health.py`:
- `_check_stuck_sensor` (line 257)
- `_check_unavailable` (line 306)

The result is that `sensor_health_check` fails on every analysis run — ~87 failures over ~21 hours in my install.

## Fix

Normalize `last_updated` via `dt_util.as_utc()`, which passes timezone-aware datetimes through unchanged and treats naive ones as UTC — matching `dt_util.utcnow()`.

```python
duration = now - dt_util.as_utc(entity.last_updated)
```

## Tests

- [x] `_check_stuck_sensor` no longer raises on naive `last_updated`
- [x] `_check_unavailable` no longer raises on naive `last_updated`
- [x] Existing tz-aware behavior unchanged (`as_utc` is a no-op for aware datetimes)

Closes #445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed timestamp handling to ensure all entity timestamps are consistently normalized to UTC, both on creation and when restoring from the database.
  * Improved handling of timezone-naive datetimes by automatically converting them to UTC-aware timestamps.

* **Tests**
  * Added regression tests to verify proper timezone normalization for entity timestamps and database restore operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->