### PR TITLE
feat(diagnostics): add config entry diagnostics export

### DIFF
--- a/custom_components/area_occupancy/diagnostics.py
+++ b/custom_components/area_occupancy/diagnostics.py
@@ -15,6 +15,8 @@ from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Any
 
+from sqlalchemy.exc import SQLAlchemyError
+
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_VERSION, CONF_VERSION_MINOR, DEVICE_SW_VERSION
@@ -28,6 +30,15 @@ if TYPE_CHECKING:
     from .data.entity import Entity
 
 _LOGGER = logging.getLogger(__name__)
+
+# Canonical DB exception tuple used across db/queries.py and db/operations.py.
+_DB_EXCEPTIONS: tuple[type[BaseException], ...] = (
+    SQLAlchemyError,
+    ValueError,
+    TypeError,
+    RuntimeError,
+    OSError,
+)
 
 
 def _isoformat(value: datetime | None) -> str | None:
@@ -151,14 +162,29 @@ def _health_snapshot(area: Area) -> dict[str, Any]:
 def _area_snapshot(
     coordinator: AreaOccupancyCoordinator, area_name: str, area: Area
 ) -> dict[str, Any]:
-    """Capture a snapshot for a single area, defending each subsection."""
+    """Capture a snapshot for a single area, defending each subsection.
+
+    Each subsection is wrapped in a broad ``except Exception`` because the
+    underlying calls touch a wide surface (probability math, state lookups,
+    cache reads, sub-property access on lazily-initialized components) and
+    we don't want a single failure to discard the rest of the diagnostic.
+    Failures are surfaced both in the diagnostic dump (as a
+    ``<section>_error`` key) and in the HA log with a stack trace, so a
+    triager can act on them.
+    """
     snapshot: dict[str, Any] = {"area_name": area_name}
 
     try:
         snapshot["area_id"] = area.config.area_id
         snapshot["purpose"] = area.config.purpose
         snapshot["threshold"] = area.config.threshold
-    except Exception as err:  # noqa: BLE001 — diagnostic must not raise
+    except (AttributeError, KeyError) as err:
+        _LOGGER.warning(
+            "Diagnostics: failed to read area config for '%s': %s",
+            area_name,
+            err,
+            exc_info=True,
+        )
         snapshot["config_error"] = repr(err)
 
     try:
@@ -170,17 +196,35 @@ def _area_snapshot(
             "decaying_entity_count": len(area.entities.decaying_entities),
             "entity_count": len(area.entities.entities),
         }
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:  # noqa: BLE001 — see docstring
+        _LOGGER.warning(
+            "Diagnostics: failed to compute current state for '%s': %s",
+            area_name,
+            err,
+            exc_info=True,
+        )
         snapshot["current_error"] = repr(err)
 
     try:
         snapshot["prior"] = area.prior.diagnostic_snapshot()
     except Exception as err:  # noqa: BLE001
+        _LOGGER.warning(
+            "Diagnostics: failed to read prior snapshot for '%s': %s",
+            area_name,
+            err,
+            exc_info=True,
+        )
         snapshot["prior_error"] = repr(err)
 
     try:
         snapshot["config"] = _area_config_snapshot(area)
-    except Exception as err:  # noqa: BLE001
+    except (AttributeError, TypeError) as err:
+        _LOGGER.warning(
+            "Diagnostics: failed to capture config snapshot for '%s': %s",
+            area_name,
+            err,
+            exc_info=True,
+        )
         snapshot["config_snapshot_error"] = repr(err)
 
     try:
@@ -190,11 +234,23 @@ def _area_snapshot(
             for entity in area.entities.entities.values()
         ]
     except Exception as err:  # noqa: BLE001
+        _LOGGER.warning(
+            "Diagnostics: failed to capture entity snapshots for '%s': %s",
+            area_name,
+            err,
+            exc_info=True,
+        )
         snapshot["entities_error"] = repr(err)
 
     try:
         snapshot["health"] = _health_snapshot(area)
-    except Exception as err:  # noqa: BLE001
+    except (AttributeError, TypeError) as err:
+        _LOGGER.warning(
+            "Diagnostics: failed to capture health snapshot for '%s': %s",
+            area_name,
+            err,
+            exc_info=True,
+        )
         snapshot["health_error"] = repr(err)
 
     return snapshot
@@ -215,7 +271,10 @@ def _collect_db_stats(coordinator: AreaOccupancyCoordinator) -> dict[str, Any]:
             stats["correlation_count"] = session.query(db.Correlations).count()
             stats["entity_count"] = session.query(db.Entities).count()
             stats["area_count"] = session.query(db.Areas).count()
-    except Exception as err:  # noqa: BLE001
+    except _DB_EXCEPTIONS as err:
+        _LOGGER.warning(
+            "Diagnostics: failed to read DB row counts: %s", err, exc_info=True
+        )
         stats["counts_error"] = repr(err)
 
     cache_status: dict[str, dict[str, Any]] = {}
@@ -224,7 +283,13 @@ def _collect_db_stats(coordinator: AreaOccupancyCoordinator) -> dict[str, Any]:
             cache_status[area_name] = {
                 "valid": queries.is_occupied_intervals_cache_valid(db, area_name),
             }
-        except Exception as err:  # noqa: BLE001
+        except _DB_EXCEPTIONS as err:
+            _LOGGER.warning(
+                "Diagnostics: failed to check cache validity for '%s': %s",
+                area_name,
+                err,
+                exc_info=True,
+            )
             cache_status[area_name] = {"error": repr(err)}
     stats["occupied_intervals_cache"] = cache_status
 
@@ -257,7 +322,10 @@ async def async_get_config_entry_diagnostics(
         integration_section["sleep_start"] = integration_config.sleep_start
         integration_section["sleep_end"] = integration_config.sleep_end
         integration_section["people_count"] = len(integration_config.people)
-    except Exception as err:  # noqa: BLE001
+    except (AttributeError, TypeError, KeyError) as err:
+        _LOGGER.warning(
+            "Diagnostics: failed to read integration config: %s", err, exc_info=True
+        )
         integration_section["config_error"] = repr(err)
 
     areas_section = [
@@ -269,7 +337,12 @@ async def async_get_config_entry_diagnostics(
         database_section = await hass.async_add_executor_job(
             _collect_db_stats, coordinator
         )
-    except Exception as err:  # noqa: BLE001
+    except Exception as err:  # noqa: BLE001 — executor failure is opaque
+        _LOGGER.warning(
+            "Diagnostics: failed to dispatch DB stats collection: %s",
+            err,
+            exc_info=True,
+        )
         database_section = {"error": repr(err)}
 
     return {

--- a/custom_components/area_occupancy/diagnostics.py
+++ b/custom_components/area_occupancy/diagnostics.py
@@ -1,0 +1,279 @@
+"""Diagnostics support for Area Occupancy Detection.
+
+Exposes a structured, JSON-serializable snapshot of the integration's
+runtime state so users (and triagers) can inspect priors, per-entity
+weights/likelihoods, current evidence, decay state, learned correlations,
+sensor health, and database row counts without enabling DEBUG logging.
+
+Each section is captured defensively — a failure in one area must not
+prevent the rest of the diagnostic from being produced.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+import logging
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.core import HomeAssistant
+
+from .const import CONF_VERSION, CONF_VERSION_MINOR, DEVICE_SW_VERSION
+from .db import queries
+
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+
+    from .area.area import Area
+    from .coordinator import AreaOccupancyCoordinator
+    from .data.entity import Entity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _isoformat(value: datetime | None) -> str | None:
+    """Return an ISO-8601 string for a datetime, or None."""
+    return value.isoformat() if value is not None else None
+
+
+def _entity_snapshot(entity: Entity, correlation: float | None) -> dict[str, Any]:
+    """Capture a JSON-friendly snapshot of an Entity's diagnostic fields."""
+    decay = entity.decay
+    gaussian = entity.learned_gaussian_params
+    return {
+        "entity_id": entity.entity_id,
+        "input_type": entity.type.input_type.value,
+        "weight": entity.type.weight,
+        "prob_given_true": entity.prob_given_true,
+        "prob_given_false": entity.prob_given_false,
+        "evidence": entity.evidence,
+        "previous_evidence": entity.previous_evidence,
+        "last_updated": _isoformat(entity.last_updated),
+        "analysis_error": entity.analysis_error,
+        "correlation_type": entity.correlation_type,
+        "correlation_strength": correlation,
+        "learned_active_range": (
+            list(entity.learned_active_range)
+            if entity.learned_active_range is not None
+            else None
+        ),
+        "learned_gaussian_params": (
+            {
+                "mean_occupied": gaussian.mean_occupied,
+                "std_occupied": gaussian.std_occupied,
+                "mean_unoccupied": gaussian.mean_unoccupied,
+                "std_unoccupied": gaussian.std_unoccupied,
+            }
+            if gaussian is not None
+            else None
+        ),
+        "decay": {
+            "is_decaying": decay.is_decaying,
+            "half_life": decay.half_life,
+            "decay_start": _isoformat(decay.decay_start),
+            "decay_factor": decay.decay_factor,
+        },
+    }
+
+
+def _area_config_snapshot(area: Area) -> dict[str, Any]:
+    """Capture the area's configuration shape (counts, not entity IDs)."""
+    config = area.config
+    sensors = config.sensors
+    weights = config.weights
+    decay = config.decay
+    wasp = config.wasp_in_box
+    sensor_counts = {
+        "motion": len(sensors.motion),
+        "media": len(sensors.media),
+        "appliance": len(sensors.appliance),
+        "door": len(sensors.door),
+        "window": len(sensors.window),
+        "cover": len(sensors.cover),
+        "power": len(sensors.power),
+        "illuminance": len(sensors.illuminance),
+        "humidity": len(sensors.humidity),
+        "temperature": len(sensors.temperature),
+        "co2": len(sensors.co2),
+        "co": len(sensors.co),
+        "sound_pressure": len(sensors.sound_pressure),
+        "pressure": len(sensors.pressure),
+        "air_quality": len(sensors.air_quality),
+        "voc": len(sensors.voc),
+        "pm25": len(sensors.pm25),
+        "pm10": len(sensors.pm10),
+    }
+    return {
+        "decay": {"enabled": decay.enabled, "half_life": decay.half_life},
+        "wasp_in_box": {
+            "enabled": wasp.enabled,
+            "motion_timeout": wasp.motion_timeout,
+            "weight": wasp.weight,
+            "max_duration": wasp.max_duration,
+            "verification_delay": wasp.verification_delay,
+        },
+        "weights": {
+            "motion": weights.motion,
+            "media": weights.media,
+            "appliance": weights.appliance,
+            "door": weights.door,
+            "window": weights.window,
+            "cover": weights.cover,
+            "environmental": weights.environmental,
+            "power": weights.power,
+            "wasp": weights.wasp,
+        },
+        "min_prior_override": getattr(config, "min_prior_override", None),
+        "motion_timeout": sensors.motion_timeout,
+        "sensor_counts": sensor_counts,
+    }
+
+
+def _health_snapshot(area: Area) -> dict[str, Any]:
+    """Capture cached health issues without re-running checks."""
+    monitor = area.health_monitor
+    return {
+        "issue_count": len(monitor.issues),
+        "last_check": _isoformat(monitor.last_check),
+        "issues": [
+            {
+                "entity_id": issue.entity_id,
+                "issue_type": issue.issue_type.value,
+                "input_type": issue.input_type.value,
+                "since": _isoformat(issue.since),
+                "duration_hours": issue.duration_hours,
+                "details": issue.details,
+            }
+            for issue in monitor.issues
+        ],
+    }
+
+
+def _area_snapshot(
+    coordinator: AreaOccupancyCoordinator, area_name: str, area: Area
+) -> dict[str, Any]:
+    """Capture a snapshot for a single area, defending each subsection."""
+    snapshot: dict[str, Any] = {"area_name": area_name}
+
+    try:
+        snapshot["area_id"] = area.config.area_id
+        snapshot["purpose"] = area.config.purpose
+        snapshot["threshold"] = area.config.threshold
+    except Exception as err:  # noqa: BLE001 — diagnostic must not raise
+        snapshot["config_error"] = repr(err)
+
+    try:
+        snapshot["current"] = {
+            "probability": area.probability(),
+            "occupied": area.occupied(),
+            "decay_factor": area.decay(),
+            "active_entity_count": len(area.entities.active_entities),
+            "decaying_entity_count": len(area.entities.decaying_entities),
+            "entity_count": len(area.entities.entities),
+        }
+    except Exception as err:  # noqa: BLE001
+        snapshot["current_error"] = repr(err)
+
+    try:
+        snapshot["prior"] = area.prior.diagnostic_snapshot()
+    except Exception as err:  # noqa: BLE001
+        snapshot["prior_error"] = repr(err)
+
+    try:
+        snapshot["config"] = _area_config_snapshot(area)
+    except Exception as err:  # noqa: BLE001
+        snapshot["config_snapshot_error"] = repr(err)
+
+    try:
+        correlations = coordinator.get_cached_correlations(area_name)
+        snapshot["entities"] = [
+            _entity_snapshot(entity, correlations.get(entity.entity_id))
+            for entity in area.entities.entities.values()
+        ]
+    except Exception as err:  # noqa: BLE001
+        snapshot["entities_error"] = repr(err)
+
+    try:
+        snapshot["health"] = _health_snapshot(area)
+    except Exception as err:  # noqa: BLE001
+        snapshot["health_error"] = repr(err)
+
+    return snapshot
+
+
+def _collect_db_stats(coordinator: AreaOccupancyCoordinator) -> dict[str, Any]:
+    """Collect database row counts and per-area cache freshness.
+
+    Runs on the executor pool — caller must wrap with async_add_executor_job.
+    """
+    db = coordinator.db
+    stats: dict[str, Any] = {}
+
+    try:
+        with db.get_session() as session:
+            stats["interval_count"] = session.query(db.Intervals).count()
+            stats["prior_count"] = session.query(db.Priors).count()
+            stats["correlation_count"] = session.query(db.Correlations).count()
+            stats["entity_count"] = session.query(db.Entities).count()
+            stats["area_count"] = session.query(db.Areas).count()
+    except Exception as err:  # noqa: BLE001
+        stats["counts_error"] = repr(err)
+
+    cache_status: dict[str, dict[str, Any]] = {}
+    for area_name in coordinator.areas:
+        try:
+            cache_status[area_name] = {
+                "valid": queries.is_occupied_intervals_cache_valid(db, area_name),
+            }
+        except Exception as err:  # noqa: BLE001
+            cache_status[area_name] = {"error": repr(err)}
+    stats["occupied_intervals_cache"] = cache_status
+
+    return stats
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return a diagnostic snapshot of integration runtime state."""
+    coordinator: AreaOccupancyCoordinator | None = getattr(entry, "runtime_data", None)
+    if coordinator is None:
+        return {
+            "error": "coordinator_not_initialized",
+            "entry_id": entry.entry_id,
+            "entry_state": str(entry.state),
+        }
+
+    integration_section: dict[str, Any] = {
+        "version": DEVICE_SW_VERSION,
+        "config_version": CONF_VERSION,
+        "config_version_minor": CONF_VERSION_MINOR,
+        "entry_id": entry.entry_id,
+        "entry_title": entry.title,
+        "setup_complete": coordinator.setup_complete,
+        "area_count": len(coordinator.areas),
+    }
+    try:
+        integration_config = coordinator.integration_config
+        integration_section["sleep_start"] = integration_config.sleep_start
+        integration_section["sleep_end"] = integration_config.sleep_end
+        integration_section["people_count"] = len(integration_config.people)
+    except Exception as err:  # noqa: BLE001
+        integration_section["config_error"] = repr(err)
+
+    areas_section = [
+        _area_snapshot(coordinator, area_name, area)
+        for area_name, area in coordinator.areas.items()
+    ]
+
+    try:
+        database_section = await hass.async_add_executor_job(
+            _collect_db_stats, coordinator
+        )
+    except Exception as err:  # noqa: BLE001
+        database_section = {"error": repr(err)}
+
+    return {
+        "integration": integration_section,
+        "areas": areas_section,
+        "database": database_section,
+    }

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -23,6 +23,7 @@ Area Occupancy Detection aims to improve occupancy accuracy beyond single motion
 - **[Sensor Likelihoods](features/likelihood.md)**: Learns how reliable each sensor is for occupancy detection
 - **[Purpose-Based Configuration](features/purpose.md)**: Automatic configuration based on room purpose
 - **[Sensor Health Monitoring](features/sensor-health.md)**: Flags stuck, offline, or silently misconfigured sensors through Home Assistant Repairs so degraded occupancy detection doesn't go unnoticed
+- **[Diagnostics Export](technical/diagnostics.md)**: One-click JSON snapshot of priors, weights, evidence, decay state, correlations, and health for fast triage and bug reports
 
 ### User Interface
 

--- a/docs/docs/technical/debug.md
+++ b/docs/docs/technical/debug.md
@@ -1,8 +1,12 @@
 Below are the instructions for debugging the integration.
 
+## Diagnostics Export
+
+For most "why does occupancy look wrong?" questions, **download diagnostics first** — it captures every prior, weight, evidence value, decay state, learned correlation, and health issue in a single JSON file without any logging configuration. Open the integration card in **Settings → Devices & Services**, click the **⋮** menu, and choose **Download diagnostics**. See [Diagnostics](diagnostics.md) for what's in the file and how to read it.
+
 ## Sensor Health Repairs
 
-The integration automatically monitors sensor health and creates repair entries in **Settings → System → Repairs** when issues are detected. Check there first if occupancy detection seems inaccurate — a stuck or offline sensor may be the cause. See [Sensor Health Monitoring](../features/sensor-health.md) for details.
+The integration automatically monitors sensor health and creates repair entries in **Settings → System → Repairs** when issues are detected. Check there if occupancy detection seems inaccurate — a stuck or offline sensor may be the cause. See [Sensor Health Monitoring](../features/sensor-health.md) for details.
 
 ## Debug Logging
 

--- a/docs/docs/technical/diagnostics.md
+++ b/docs/docs/technical/diagnostics.md
@@ -1,0 +1,115 @@
+# Diagnostics
+
+The integration ships with Home Assistant's standard **diagnostics** export so you can capture a complete snapshot of its runtime state without enabling DEBUG logging. This is the fastest way to figure out why occupancy "looks wrong" — and the right thing to attach when opening a GitHub issue.
+
+## How to download
+
+1. Go to **Settings → Devices & Services**.
+2. Click **Area Occupancy Detection**.
+3. Open the **⋮** menu next to the integration card and choose **Download diagnostics**.
+
+You'll get a JSON file you can open in any text editor.
+
+## What's in it
+
+The export is grouped into three sections.
+
+### `integration`
+
+Metadata about the integration itself — useful for confirming versions when reporting bugs.
+
+| Field | Meaning |
+|---|---|
+| `version` | Integration software version (matches `manifest.json`) |
+| `config_version` / `config_version_minor` | Schema version of your stored config |
+| `entry_id` / `entry_title` | The HA config entry identifier and label |
+| `setup_complete` | `true` once the coordinator finished its first analysis cycle |
+| `area_count` | Number of configured areas |
+| `sleep_start` / `sleep_end` | Configured sleep window |
+| `people_count` | Number of configured people for sleep tracking |
+
+### `areas`
+
+One entry per configured area. Each entry has these subsections — and if any subsection fails to capture, you'll see a sibling `<section>_error` field so the rest of the dump still comes through.
+
+#### `current`
+
+The live calculation snapshot at the moment the diagnostic ran.
+
+| Field | Meaning |
+|---|---|
+| `probability` | Computed occupancy probability (0.0–1.0) |
+| `occupied` | Whether `probability >= threshold` |
+| `decay_factor` | Average decay multiplier across all entities |
+| `active_entity_count` | How many sensors are currently in their "active" state |
+| `decaying_entity_count` | How many sensors are currently mid-decay |
+| `entity_count` | Total sensors configured for the area |
+
+#### `prior`
+
+The learned prior breakdown — surfaces *which term* is driving the occupancy probability, especially useful when an area appears stuck without active evidence.
+
+| Field | Meaning |
+|---|---|
+| `prior_value` | Effective prior used in the current calculation |
+| `global_prior` | Long-term learned probability for the area (`null` if not learned yet) |
+| `time_prior` | Day-of-week + time-slot specific prior |
+| `min_prior_floor_applied` | One of `none`, `purpose`, `override` — which floor (if any) raised the learned prior |
+| `threshold` | Configured occupancy threshold for the area |
+
+#### `config`
+
+The shape of how the area is configured — sensor counts (not entity IDs), weights, decay, and wasp-in-box settings.
+
+#### `entities`
+
+One row per configured sensor. The most useful fields when debugging:
+
+| Field | Meaning |
+|---|---|
+| `entity_id` | The HA entity |
+| `input_type` | `motion`, `media`, `door`, `temperature`, etc. |
+| `weight` | Effective weight applied during calculation |
+| `prob_given_true` / `prob_given_false` | Likelihoods used in the Bayesian update |
+| `evidence` | Current state contribution (`true` / `false` / `null` if unavailable) |
+| `previous_evidence` | What it was before the last transition |
+| `last_updated` | When evidence last changed (ISO-8601 UTC) |
+| `correlation_strength` | Cached learned correlation with occupancy (`null` if not learned) |
+| `correlation_type` | `correlation` or `binary_likelihood` |
+| `analysis_error` | Why correlation analysis was skipped (e.g. `not_analyzed`, `motion_excluded`, `too_few_samples`) |
+| `decay` | Current decay state — `is_decaying`, `half_life`, `decay_factor`, `decay_start` |
+
+#### `health`
+
+The cached output of the [Sensor Health Monitoring](../features/sensor-health.md) checks — no re-check is triggered to capture them, so you see exactly what the user sees in **Repairs**.
+
+### `database`
+
+| Field | Meaning |
+|---|---|
+| `interval_count` | Total occupancy-state intervals stored |
+| `prior_count` | Time-prior rows (1 per day-of-week × time-slot × area) |
+| `correlation_count` | Stored sensor-correlation rows |
+| `entity_count` / `area_count` | Persisted entity / area row totals |
+| `occupied_intervals_cache` | Per-area cache freshness — `{ "area": { "valid": true } }`. A stale cache means the next analysis cycle will rebuild it. |
+
+## What questions diagnostics can answer
+
+- **"Why is the area stuck occupied?"** → check `current.probability`, `current.decay_factor`, and the `entities` list for any sensor with `evidence: true` you didn't expect, or a high `correlation_strength` paired with a frozen `last_updated`. Also look at `prior.min_prior_floor_applied` — a floor (`purpose` or `override`) might be holding the value above the threshold.
+- **"Has the integration finished learning?"** → `prior.global_prior` is `null` until enough history is collected; `prior.time_prior` populates per slot. Compare `database.prior_count` against your area count × 168 (24h × 7 days × 1 slot/hour).
+- **"Is correlation analysis working for sensor X?"** → find the entity in `entities` and read `analysis_error`. `not_analyzed` means it hasn't run yet; `too_few_samples` means there isn't enough data; `motion_excluded` is by design (motion sensors always use configured priors).
+- **"Is my health repair stale?"** → `health.last_check` shows when the last check ran (hourly).
+- **"Is the cache fresh?"** → `database.occupied_intervals_cache.<area>.valid` — if `false`, the next analysis cycle will rebuild it.
+
+## Privacy
+
+The export contains:
+
+- :material-check: HA entity IDs, current sensor evidence states, learned priors and weights, configuration shape (sensor counts, thresholds, decay), area names.
+- :material-close: No HA access tokens, no user account info, no raw recorder history.
+
+Entity IDs and area names are descriptive labels for *your* installation. Review the JSON before attaching it to a public issue if you're sensitive about either.
+
+## When to share it
+
+When opening an issue about wrong probabilities, stuck areas, or unexpected calculation results, attach the diagnostic file. It saves a round-trip of "can you turn on debug logging and reproduce" — the snapshot already contains every field a triager would otherwise have to ask for.

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -131,5 +131,6 @@ nav:
       - Likelihood Calculation: technical/likelihood-calculation.md
       - Database Schema: technical/database-schema.md
       - Pre-Releases: technical/prerelease.md
+      - Diagnostics: technical/diagnostics.md
       - Debugging: technical/debug.md
   - Simulator: simulator/index.md

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,199 @@
+"""Tests for diagnostics export."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
+from custom_components.area_occupancy.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+
+
+@pytest.fixture
+def entry_with_runtime_data(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """Wire the autouse coordinator into the config entry's runtime_data.
+
+    Mirrors what __init__.async_setup_entry does in production so the
+    diagnostics entry point can resolve the coordinator from the entry.
+    """
+    entry = coordinator.config_entry
+    entry.runtime_data = coordinator
+    return entry
+
+
+class TestDiagnosticsExport:
+    """Cover the public async_get_config_entry_diagnostics entry point."""
+
+    @pytest.mark.asyncio
+    async def test_returns_full_snapshot(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        entry_with_runtime_data,
+    ) -> None:
+        """Happy path: snapshot has integration, areas, database sections."""
+        result = await async_get_config_entry_diagnostics(hass, entry_with_runtime_data)
+
+        assert "integration" in result
+        assert "areas" in result
+        assert "database" in result
+
+        integration = result["integration"]
+        assert integration["entry_id"] == entry_with_runtime_data.entry_id
+        assert integration["area_count"] == len(coordinator.areas)
+        assert "version" in integration
+        assert "config_version" in integration
+        assert "setup_complete" in integration
+
+    @pytest.mark.asyncio
+    async def test_snapshot_is_json_serializable(
+        self,
+        hass: HomeAssistant,
+        entry_with_runtime_data,
+    ) -> None:
+        """HA core serializes diagnostics as JSON; nothing exotic must leak."""
+        result = await async_get_config_entry_diagnostics(hass, entry_with_runtime_data)
+
+        # json.dumps will raise TypeError on datetimes, enums, dataclasses, etc.
+        json.dumps(result)
+
+    @pytest.mark.asyncio
+    async def test_returns_error_when_coordinator_missing(
+        self, hass: HomeAssistant, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Diagnostics must degrade gracefully when called pre-setup."""
+        entry = coordinator.config_entry
+        entry.runtime_data = None
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        assert result["error"] == "coordinator_not_initialized"
+        assert result["entry_id"] == entry.entry_id
+
+    @pytest.mark.asyncio
+    async def test_each_area_has_expected_sections(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        entry_with_runtime_data,
+    ) -> None:
+        """Per-area snapshot exposes config, current state, prior, entities, health."""
+        result = await async_get_config_entry_diagnostics(hass, entry_with_runtime_data)
+
+        assert len(result["areas"]) == len(coordinator.areas)
+        for area in result["areas"]:
+            assert "area_name" in area
+            assert "purpose" in area
+            assert "threshold" in area
+            assert "current" in area
+            assert "prior" in area
+            assert "config" in area
+            assert "entities" in area
+            assert "health" in area
+
+            current = area["current"]
+            assert "probability" in current
+            assert "occupied" in current
+            assert "decay_factor" in current
+            assert "entity_count" in current
+
+            prior = area["prior"]
+            assert "prior_value" in prior
+            assert "global_prior" in prior
+            assert "time_prior" in prior
+            assert "min_prior_floor_applied" in prior
+
+    @pytest.mark.asyncio
+    async def test_entity_snapshot_shape(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        entry_with_runtime_data,
+    ) -> None:
+        """Each entity entry surfaces likelihoods, evidence, and decay state."""
+        result = await async_get_config_entry_diagnostics(hass, entry_with_runtime_data)
+
+        for area in result["areas"]:
+            for entity in area["entities"]:
+                assert "entity_id" in entity
+                assert "input_type" in entity
+                assert "weight" in entity
+                assert "prob_given_true" in entity
+                assert "prob_given_false" in entity
+                assert "evidence" in entity
+                assert "decay" in entity
+
+                decay = entity["decay"]
+                assert "is_decaying" in decay
+                assert "half_life" in decay
+                assert "decay_factor" in decay
+
+    @pytest.mark.asyncio
+    async def test_health_section_present_with_no_issues(
+        self,
+        hass: HomeAssistant,
+        entry_with_runtime_data,
+    ) -> None:
+        """Fresh coordinator has no health issues but still exports the section."""
+        result = await async_get_config_entry_diagnostics(hass, entry_with_runtime_data)
+
+        for area in result["areas"]:
+            health = area["health"]
+            assert "issue_count" in health
+            assert health["issue_count"] == len(health["issues"])
+
+    @pytest.mark.asyncio
+    async def test_database_section_includes_counts(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        entry_with_runtime_data,
+    ) -> None:
+        """Database section reports row counts and per-area cache freshness."""
+        coordinator.db.init_db()
+
+        result = await async_get_config_entry_diagnostics(hass, entry_with_runtime_data)
+
+        database = result["database"]
+        assert "interval_count" in database
+        assert "prior_count" in database
+        assert "correlation_count" in database
+        assert "occupied_intervals_cache" in database
+
+        cache = database["occupied_intervals_cache"]
+        for area_name in coordinator.areas:
+            assert area_name in cache
+
+    @pytest.mark.asyncio
+    async def test_resilient_to_per_area_failure(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        entry_with_runtime_data,
+    ) -> None:
+        """A failure in one section must not poison the whole diagnostic."""
+        # Force area.probability() to raise; the other sections must still come back.
+        with patch(
+            "custom_components.area_occupancy.area.area.Area.probability",
+            side_effect=RuntimeError("boom"),
+        ):
+            result = await async_get_config_entry_diagnostics(
+                hass, entry_with_runtime_data
+            )
+
+        assert "areas" in result
+        for area in result["areas"]:
+            # The area entry exists and captured the failure of the failing section.
+            assert "area_name" in area
+            assert "current_error" in area
+            # Other sections still populated.
+            assert "prior" in area
+            assert "entities" in area
+            assert "health" in area


### PR DESCRIPTION
## Summary

Adds Home Assistant core's `async_get_config_entry_diagnostics` so users can capture a structured snapshot of integration runtime state without enabling DEBUG logging. Today, when a user reports "occupancy looks wrong" or "stuck at detected" (e.g. #435, #444, #445), the only debug surface is module-level DEBUG logs — there's no inspectable state. This change exposes that state through HA's standard \"Download Diagnostics\" button on the integration card.

## What's exported

- **Integration** — version, config version, entry id, `setup_complete`, sleep window, configured people count, area count.
- **Per-area** — purpose, threshold, current probability/occupied/decay, active and decaying entity counts, the prior \`diagnostic_snapshot\` (global_prior, time_prior, applied floor, threshold), config shape (weights, decay, wasp-in-box, sensor counts), and cached health issues without triggering a re-check.
- **Per-entity** — input type, weight, likelihoods, evidence, last_updated, decay state (\`is_decaying\`, \`half_life\`, \`decay_factor\`, \`decay_start\`), learned correlation strength (from the coordinator's existing cache), learned Gaussian params, \`analysis_error\`, \`correlation_type\`.
- **Database** — row counts (intervals, priors, correlations, entities, areas) and per-area occupied-intervals-cache validity.

Each section is captured defensively — a failure in one area or subsection records the error in the output and the rest still produces useful data. The DB stat collection is dispatched via \`async_add_executor_job\` to avoid blocking the event loop.

## Why now

This is the smallest-effort, highest-leverage observability win and lays groundwork for surfacing pipeline health through the same channel later (failed correlations, low-sample priors, stale caches). It directly addresses the most common triage friction: I had to read the calculation chain by hand to investigate #445.

## Tests

8 tests in \`tests/test_diagnostics.py\`:
- Full snapshot shape (\`integration\` + \`areas\` + \`database\` sections)
- JSON-serializability (catches stray datetimes, enums, dataclasses)
- Graceful degradation when called pre-setup (\`runtime_data is None\`)
- Per-area sections present (\`current\`, \`prior\`, \`config\`, \`entities\`, \`health\`)
- Entity snapshot fields (likelihoods, evidence, decay)
- Health section present with no issues
- Database counts + per-area cache map
- Resilience when one section raises (other sections still populated)

## Test plan

- [x] \`scripts/lint\` clean
- [x] \`uv run pytest tests/test_diagnostics.py -v\` — all 8 pass
- [x] Full suite — 1578 passed
- [ ] Manual: in devcontainer, click \"Download Diagnostics\" on the integration card and confirm JSON renders with non-empty \`integration\`, \`areas\`, and \`database\` sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a diagnostics export: JSON snapshot of integration metadata, runtime configuration, per-area snapshots (current, prior, config, entities, health) and database statistics; resilient to partial failures.

* **Tests**
  * Added tests for diagnostics structure, JSON serializability, error handling, database stats, per-area schema, and resilience to runtime errors.

* **Documentation**
  * Added user-facing docs and troubleshooting guidance describing the diagnostics export and how to obtain and interpret it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->