### PR TITLE
feat(config-flow): "Reset Learning" button in area options

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -2567,6 +2567,7 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
         super().__init__()
         self._area_being_edited: str | None = None
         self._area_to_remove: str | None = None
+        self._area_to_reset: str | None = None  # area_id pending learning reset
         self._area_config_draft: dict[str, Any] = {}
         self._person_being_edited: int | None = None  # Index into people list
         self._person_to_remove: int | None = None  # Index into people list for removal
@@ -2683,7 +2684,12 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
 
         return self.async_show_menu(
             step_id="area_action",
-            menu_options=["edit_area", "remove_area_confirm", "cancel_area_action"],
+            menu_options=[
+                "edit_area",
+                "reset_learning_confirm",
+                "remove_area_confirm",
+                "cancel_area_action",
+            ],
             description_placeholders=description_placeholders,
         )
 
@@ -2701,6 +2707,13 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
         """Initiate area removal."""
         self._prepare_area_action_remove()
         return await self.async_step_remove_area()
+
+    async def async_step_reset_learning_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Initiate learning reset for the area being edited."""
+        self._area_to_reset = self._area_being_edited
+        return await self.async_step_reset_learning()
 
     async def async_step_cancel_area_action(
         self, user_input: dict[str, Any] | None = None
@@ -2745,6 +2758,86 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
     ) -> ConfigFlowResult:
         """Cancel area removal."""
         self._area_to_remove = None
+        return await self.async_step_init()
+
+    async def async_step_reset_learning(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Yes/no menu confirming learning reset for the selected area."""
+        if not self._area_to_reset:
+            return await self.async_step_init()
+
+        return self.async_show_menu(
+            step_id="reset_learning",
+            menu_options=["confirm_reset_learning", "cancel_reset_learning"],
+        )
+
+    async def async_step_confirm_reset_learning(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Execute the per-area learning reset.
+
+        Wipes the area's learned history (intervals, priors, correlations,
+        cache) without removing the area from the configuration. Returns to
+        the area_action menu so the user can continue editing.
+        """
+        # Lazy import to avoid pulling service.py into the config-flow load path.
+        from .service import (  # noqa: PLC0415
+            _find_area_by_area_id,
+            async_purge_area_data,
+        )
+
+        area_id = self._area_to_reset
+        if not area_id:
+            return await self.async_step_init()
+
+        coordinator = getattr(self.config_entry, "runtime_data", None)
+        if coordinator is None:
+            _LOGGER.warning(
+                "Reset learning aborted for area_id '%s': coordinator not loaded",
+                area_id,
+            )
+            self._area_to_reset = None
+            return self.async_abort(reason="reset_learning_failed")
+
+        area_name, area = _find_area_by_area_id(coordinator, area_id)
+        if area_name is None or area is None:
+            _LOGGER.warning(
+                "Reset learning aborted: no configured area found for area_id '%s'",
+                area_id,
+            )
+            self._area_to_reset = None
+            return self.async_abort(reason="reset_learning_failed")
+
+        _LOGGER.info(
+            "Resetting learned history for area '%s' (area_id=%s) via options flow",
+            area_name,
+            area_id,
+        )
+
+        try:
+            await async_purge_area_data(self.hass, coordinator, area_name, area)
+        except HomeAssistantError:
+            _LOGGER.exception(
+                "Reset learning failed for area '%s' (area_id=%s)", area_name, area_id
+            )
+            self._area_to_reset = None
+            return self.async_abort(reason="reset_learning_failed")
+
+        self._area_to_reset = None
+        # Stay scoped to the same area so the user lands back in its menu.
+        self._area_being_edited = area_id
+        return await self.async_step_area_action()
+
+    async def async_step_cancel_reset_learning(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Cancel the learning reset and return to the area_action menu."""
+        area_id = self._area_to_reset
+        self._area_to_reset = None
+        if area_id:
+            self._area_being_edited = area_id
+            return await self.async_step_area_action()
         return await self.async_step_init()
 
     async def async_step_global_settings(

--- a/custom_components/area_occupancy/service.py
+++ b/custom_components/area_occupancy/service.py
@@ -18,6 +18,7 @@ from .utils import get_coordinator
 
 if TYPE_CHECKING:
     from .area.area import Area
+    from .coordinator import AreaOccupancyCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -236,31 +237,29 @@ def _find_area_by_area_id(
     return None, None
 
 
-async def _purge_area_history(hass: HomeAssistant, call: ServiceCall) -> dict[str, Any]:
-    """Purge learned history for a single configured area.
+async def async_purge_area_data(
+    hass: HomeAssistant,
+    coordinator: "AreaOccupancyCoordinator",
+    area_name: str,
+    area: "Area",
+) -> dict[str, Any]:
+    """Purge DB rows + in-memory state for a single configured area.
 
     Deletes all database rows for the area (intervals, priors, correlations,
     caches, etc.) without removing the area from configuration. The area's
     in-memory prior cache is cleared and a coordinator refresh is requested so
     the UI immediately reflects the purge.
+
+    Shared by the public ``purge_area_history`` service and the options-flow
+    "Reset learning" action — both want the same effect (data wiped, area
+    config preserved). Caller is responsible for the area-id → name lookup
+    and any user-facing validation messaging; this helper assumes the area
+    exists in the coordinator.
+
+    Returns the same result dict the service handler exposes:
+    ``{"area_id", "area_name", "entities_deleted", "shell_repersisted",
+    "purged_at"}``. Raises ``HomeAssistantError`` on hard DB failure.
     """
-    coordinator = get_coordinator(hass)
-    area_id = call.data[CONF_AREA_ID]
-
-    area_name, area = _find_area_by_area_id(coordinator, area_id)
-    if area_name is None or area is None:
-        known = sorted(a.config.area_id for a in coordinator.areas.values())
-        raise ServiceValidationError(
-            f"No configured area found for area_id '{area_id}'. "
-            f"Known area_ids: {', '.join(known) if known else '(none)'}"
-        )
-
-    _LOGGER.info(
-        "Purging learned history for area '%s' (area_id=%s) on user request",
-        area_name,
-        area_id,
-    )
-
     try:
         deleted = await hass.async_add_executor_job(
             coordinator.db.delete_area_data, area_name
@@ -313,12 +312,40 @@ async def _purge_area_history(hass: HomeAssistant, call: ServiceCall) -> dict[st
         )
 
     return {
-        "area_id": area_id,
+        "area_id": area.config.area_id,
         "area_name": area_name,
         "entities_deleted": int(deleted),
         "shell_repersisted": shell_repersisted,
         "purged_at": dt_util.utcnow().isoformat(),
     }
+
+
+async def _purge_area_history(hass: HomeAssistant, call: ServiceCall) -> dict[str, Any]:
+    """Service handler: purge learned history for a single configured area.
+
+    Resolves the caller-supplied ``area_id`` and delegates to
+    ``async_purge_area_data``. The service-call layer owns the user-facing
+    validation messaging; the helper is kept ServiceCall-free so the
+    options-flow "Reset learning" action can reuse it.
+    """
+    coordinator = get_coordinator(hass)
+    area_id = call.data[CONF_AREA_ID]
+
+    area_name, area = _find_area_by_area_id(coordinator, area_id)
+    if area_name is None or area is None:
+        known = sorted(a.config.area_id for a in coordinator.areas.values())
+        raise ServiceValidationError(
+            f"No configured area found for area_id '{area_id}'. "
+            f"Known area_ids: {', '.join(known) if known else '(none)'}"
+        )
+
+    _LOGGER.info(
+        "Purging learned history for area '%s' (area_id=%s) on user request",
+        area_name,
+        area_id,
+    )
+
+    return await async_purge_area_data(hass, coordinator, area_name, area)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:

--- a/custom_components/area_occupancy/service.py
+++ b/custom_components/area_occupancy/service.py
@@ -333,7 +333,11 @@ async def _purge_area_history(hass: HomeAssistant, call: ServiceCall) -> dict[st
 
     area_name, area = _find_area_by_area_id(coordinator, area_id)
     if area_name is None or area is None:
-        known = sorted(a.config.area_id for a in coordinator.areas.values())
+        known = sorted(
+            a.config.area_id
+            for a in coordinator.areas.values()
+            if isinstance(a.config.area_id, str)
+        )
         raise ServiceValidationError(
             f"No configured area found for area_id '{area_id}'. "
             f"Known area_ids: {', '.join(known) if known else '(none)'}"

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -37,6 +37,7 @@
                 "description": "Choose an action for this area.",
                 "menu_options": {
                     "edit_area": "Edit Area",
+                    "reset_learning_confirm": "Reset Learning",
                     "remove_area_confirm": "Remove Area",
                     "cancel_area_action": "Cancel"
                 }
@@ -399,7 +400,8 @@
     },
     "options": {
         "abort": {
-            "cannot_remove_last_area": "Cannot remove the last area. At least one area must remain configured."
+            "cannot_remove_last_area": "Cannot remove the last area. At least one area must remain configured.",
+            "reset_learning_failed": "Failed to reset the area's learned history. Check the Home Assistant log for details."
         },
         "step": {
             "init": {
@@ -430,6 +432,7 @@
                 "description": "Choose an action for this area.",
                 "menu_options": {
                     "edit_area": "Edit Area",
+                    "reset_learning_confirm": "Reset Learning",
                     "remove_area_confirm": "Remove Area",
                     "cancel_area_action": "Cancel"
                 }
@@ -764,6 +767,14 @@
                 "menu_options": {
                     "confirm_remove_area": "Yes, remove area",
                     "cancel_remove_area": "Cancel"
+                }
+            },
+            "reset_learning": {
+                "title": "Reset learned history?",
+                "description": "This wipes the area's learned occupancy history (priors, correlations, intervals, and caches) without removing the area or any of its sensor configuration. The next analysis cycle will start rebuilding from current Home Assistant recorder data.\n\nUse this if the area's behavior has gone stale (e.g. the room's usage pattern changed, or you reconfigured sensors and the old learning is interfering).",
+                "menu_options": {
+                    "confirm_reset_learning": "Yes, reset learning",
+                    "cancel_reset_learning": "Cancel"
                 }
             },
             "global_settings": {

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -37,6 +37,7 @@
                 "description": "Choose an action for this area.",
                 "menu_options": {
                     "edit_area": "Edit Area",
+                    "reset_learning_confirm": "Reset Learning",
                     "remove_area_confirm": "Remove Area",
                     "cancel_area_action": "Cancel"
                 }
@@ -400,7 +401,8 @@
     },
     "options": {
         "abort": {
-            "cannot_remove_last_area": "Cannot remove the last area. At least one area must remain configured."
+            "cannot_remove_last_area": "Cannot remove the last area. At least one area must remain configured.",
+            "reset_learning_failed": "Failed to reset the area's learned history. Check the Home Assistant log for details."
         },
         "step": {
             "init": {
@@ -431,6 +433,7 @@
                 "description": "Choose an action for this area.",
                 "menu_options": {
                     "edit_area": "Edit Area",
+                    "reset_learning_confirm": "Reset Learning",
                     "remove_area_confirm": "Remove Area",
                     "cancel_area_action": "Cancel"
                 }
@@ -765,6 +768,14 @@
                 "menu_options": {
                     "confirm_remove_area": "Yes, remove area",
                     "cancel_remove_area": "Cancel"
+                }
+            },
+            "reset_learning": {
+                "title": "Reset learned history?",
+                "description": "This wipes the area's learned occupancy history (priors, correlations, intervals, and caches) without removing the area or any of its sensor configuration. The next analysis cycle will start rebuilding from current Home Assistant recorder data.\n\nUse this if the area's behavior has gone stale (e.g. the room's usage pattern changed, or you reconfigured sensors and the old learning is interfering).",
+                "menu_options": {
+                    "confirm_reset_learning": "Yes, reset learning",
+                    "cancel_reset_learning": "Cancel"
                 }
             },
             "global_settings": {

--- a/docs/docs/features/services.md
+++ b/docs/docs/features/services.md
@@ -112,3 +112,7 @@ data:
 
 !!! tip "Resetting everything"
     To wipe learned history for *every* area, remove the integration entirely (which now also deletes the database file — see the [2026.4.1 release notes](https://github.com/Hankanman/Area-Occupancy-Detection/releases/tag/2026.4.1)) and reinstall. Use `purge_area_history` when you only want to reset one area.
+
+### Resetting from the UI
+
+The same purge is available without writing a service call. Open the integration's options (**Settings → Devices & Services → Area Occupancy Detection → Configure**), pick **Manage Areas**, choose the area, and click **Reset Learning**. A yes/no confirmation appears before anything is deleted, and you'll land back on the area's management menu when it's done. Same destructive behaviour — same trade-offs as the service call above.

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1372,6 +1372,160 @@ class TestAreaOccupancyOptionsFlow:
         assert result_data[CONF_SLEEP_START] == "23:00:00"
         assert result_data[CONF_SLEEP_END] == "08:00:00"
 
+    async def test_options_flow_area_action_menu_includes_reset_learning(
+        self,
+        config_flow_options_flow,
+        config_flow_mock_config_entry_with_areas,
+    ) -> None:
+        """area_action menu surfaces ``reset_learning_confirm`` alongside edit/remove."""
+        flow = config_flow_options_flow
+        flow.config_entry = config_flow_mock_config_entry_with_areas
+
+        areas = flow._get_areas_from_config()
+        assert areas, "fixture should have at least one configured area"
+        flow._area_being_edited = areas[0][CONF_AREA_ID]
+
+        result = await flow.async_step_area_action()
+        assert result.get("type") == FlowResultType.MENU
+        assert result.get("step_id") == "area_action"
+        menu_options = result.get("menu_options", [])
+        assert "edit_area" in menu_options
+        assert "reset_learning_confirm" in menu_options
+        assert "remove_area_confirm" in menu_options
+
+    async def test_options_flow_reset_learning_confirm_shows_yes_no(
+        self,
+        config_flow_options_flow,
+        config_flow_mock_config_entry_with_areas,
+    ) -> None:
+        """``reset_learning_confirm`` advances to the yes/no menu."""
+        flow = config_flow_options_flow
+        flow.config_entry = config_flow_mock_config_entry_with_areas
+
+        areas = flow._get_areas_from_config()
+        flow._area_being_edited = areas[0][CONF_AREA_ID]
+
+        result = await flow.async_step_reset_learning_confirm()
+        assert result.get("type") == FlowResultType.MENU
+        assert result.get("step_id") == "reset_learning"
+        menu_options = result.get("menu_options", [])
+        assert "confirm_reset_learning" in menu_options
+        assert "cancel_reset_learning" in menu_options
+        # State has moved from "being_edited" to "to_reset"
+        assert flow._area_to_reset == areas[0][CONF_AREA_ID]
+
+    async def test_options_flow_cancel_reset_learning_returns_to_area_action(
+        self,
+        config_flow_options_flow,
+        config_flow_mock_config_entry_with_areas,
+    ) -> None:
+        """Cancelling the reset returns to the area_action menu and clears state."""
+        flow = config_flow_options_flow
+        flow.config_entry = config_flow_mock_config_entry_with_areas
+
+        areas = flow._get_areas_from_config()
+        area_id = areas[0][CONF_AREA_ID]
+        flow._area_to_reset = area_id
+
+        result = await flow.async_step_cancel_reset_learning()
+        assert result.get("type") == FlowResultType.MENU
+        assert result.get("step_id") == "area_action"
+        assert flow._area_to_reset is None
+        # The user should land back on the same area they were managing.
+        assert flow._area_being_edited == area_id
+
+    async def test_options_flow_confirm_reset_learning_calls_purge_helper(
+        self,
+        config_flow_options_flow,
+        config_flow_mock_config_entry_with_areas,
+    ) -> None:
+        """Confirm step delegates to async_purge_area_data and returns to area_action."""
+        flow = config_flow_options_flow
+        flow.config_entry = config_flow_mock_config_entry_with_areas
+
+        areas = flow._get_areas_from_config()
+        area_id = areas[0][CONF_AREA_ID]
+        flow._area_to_reset = area_id
+
+        # Stub coordinator + area lookup; the helper itself is mocked so we
+        # don't need a real DB. Only the orchestration in the step matters.
+        fake_area = Mock()
+        fake_area.config.area_id = area_id
+        fake_coordinator = Mock()
+        fake_coordinator.areas = {"Living Room": fake_area}
+        flow.config_entry.runtime_data = fake_coordinator
+
+        with (
+            patch(
+                "custom_components.area_occupancy.service._find_area_by_area_id",
+                return_value=("Living Room", fake_area),
+            ),
+            patch(
+                "custom_components.area_occupancy.service.async_purge_area_data",
+                new=AsyncMock(return_value={"area_id": area_id, "entities_deleted": 7}),
+            ) as mock_purge,
+        ):
+            result = await flow.async_step_confirm_reset_learning()
+
+        mock_purge.assert_awaited_once()
+        # Returns the user to the area_action menu (still managing the area).
+        assert result.get("type") == FlowResultType.MENU
+        assert result.get("step_id") == "area_action"
+        assert flow._area_to_reset is None
+        assert flow._area_being_edited == area_id
+
+    async def test_options_flow_confirm_reset_learning_aborts_when_no_coordinator(
+        self,
+        config_flow_options_flow,
+        config_flow_mock_config_entry_with_areas,
+    ) -> None:
+        """If runtime_data isn't loaded, the reset aborts cleanly."""
+        flow = config_flow_options_flow
+        flow.config_entry = config_flow_mock_config_entry_with_areas
+
+        areas = flow._get_areas_from_config()
+        flow._area_to_reset = areas[0][CONF_AREA_ID]
+        flow.config_entry.runtime_data = None
+
+        result = await flow.async_step_confirm_reset_learning()
+        assert result.get("type") == FlowResultType.ABORT
+        assert result.get("reason") == "reset_learning_failed"
+        assert flow._area_to_reset is None
+
+    async def test_options_flow_confirm_reset_learning_aborts_when_purge_raises(
+        self,
+        config_flow_options_flow,
+        config_flow_mock_config_entry_with_areas,
+    ) -> None:
+        """A HomeAssistantError from the helper aborts the flow without raising."""
+        flow = config_flow_options_flow
+        flow.config_entry = config_flow_mock_config_entry_with_areas
+
+        areas = flow._get_areas_from_config()
+        area_id = areas[0][CONF_AREA_ID]
+        flow._area_to_reset = area_id
+
+        fake_area = Mock()
+        fake_area.config.area_id = area_id
+        fake_coordinator = Mock()
+        flow.config_entry.runtime_data = fake_coordinator
+
+        with (
+            patch(
+                "custom_components.area_occupancy.service._find_area_by_area_id",
+                return_value=("Living Room", fake_area),
+            ),
+            patch(
+                "custom_components.area_occupancy.service.async_purge_area_data",
+                new=AsyncMock(side_effect=HomeAssistantError("simulated")),
+            ),
+        ):
+            result = await flow.async_step_confirm_reset_learning()
+
+        assert result.get("type") == FlowResultType.ABORT
+        assert result.get("reason") == "reset_learning_failed"
+        assert flow._area_to_reset is None
+
 
 class TestHelperFunctionEdgeCases:
     """Test edge cases for helper functions."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1467,7 +1467,12 @@ class TestAreaOccupancyOptionsFlow:
         ):
             result = await flow.async_step_confirm_reset_learning()
 
-        mock_purge.assert_awaited_once()
+        mock_purge.assert_awaited_once_with(
+            flow.hass,
+            fake_coordinator,
+            "Living Room",
+            fake_area,
+        )
         # Returns the user to the area_action menu (still managing the area).
         assert result.get("type") == FlowResultType.MENU
         assert result.get("step_id") == "area_action"


### PR DESCRIPTION
## Summary

Item #4 from the post-perf roadmap was \"area lifecycle hygiene — auto-purge on removal + visible reset learning.\" Verifying the code shows **Goal A is already implemented**: ``coordinator._cleanup_removed_area`` (coordinator.py:611-626) already calls ``db.delete_area_data`` when an area is removed via the options flow, and issues #434 / #436 that the audit cited are CLOSED. So this PR ships only Goal B — surfacing the existing ``purge_area_history`` service as a one-click button inside the area's management menu.

### Why

The service has existed for over a year, but discovering it requires reading the docs + writing a YAML service call. Most users never find it, so when a room's learned behaviour goes stale (sensors swapped, layout changed, room repurposed) the workaround has been creating throwaway test areas. Surfacing the reset inline in the options menu makes the workflow one click + one confirmation.

### What changed

- **service.py**: extracted ``async_purge_area_data(hass, coordinator, area_name, area)`` from inside ``_purge_area_history``. ServiceCall-free, so the options flow can reuse it. The service-call layer keeps owning user-facing area_id resolution + validation messaging.
- **config_flow.py**: added ``reset_learning_confirm`` menu option to the OptionsFlow ``area_action`` step, sandwiched between Edit and Remove. Three new steps wire the confirmation flow:
  - ``reset_learning_confirm`` → transitional, sets ``_area_to_reset``.
  - ``reset_learning`` → yes/no menu.
  - ``confirm_reset_learning`` → calls ``async_purge_area_data`` and lands the user back on ``area_action`` (area config unchanged — only learned data is wiped).
  - ``cancel_reset_learning`` → returns to ``area_action`` with state cleared.
- **strings.json**: ``reset_learning`` step block, ``reset_learning_confirm`` menu label, ``reset_learning_failed`` abort reason.
- **docs**: services.md gains a \"Resetting from the UI\" subsection.

### Tests

6 new in ``TestAreaOccupancyOptionsFlow``:
- ``area_action`` menu surfaces the new option.
- Transitional step advances to the yes/no menu.
- Cancel returns to ``area_action`` with state cleared.
- Confirm delegates to ``async_purge_area_data`` and lands on ``area_action``.
- Abort path when ``runtime_data`` isn't loaded.
- Abort path when the helper raises ``HomeAssistantError``.

The existing 19 service tests pass unchanged — the helper extraction is purely a refactor of the inner steps.

### Test plan

- [x] \`scripts/lint\` clean
- [x] \`uv run pytest tests/test_config_flow.py::TestAreaOccupancyOptionsFlow tests/test_service.py -v\` — all pass
- [x] Full suite — 1614 passed
- [x] \`mkdocs build --strict\` — clean
- [ ] Manual: in devcontainer, navigate Settings → Devices & Services → Area Occupancy → Configure → Manage Areas → pick area → confirm \"Reset Learning\" appears, walk through the flow, verify learned data is gone but area config is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Reset Learning" option in area settings to wipe learned occupancy history (with confirmation) and return to the same area menu.

* **Tests**
  * Added unit tests covering confirm, cancel and abort flows for the reset learning option.

* **Documentation**
  * Updated docs to show the UI path and confirmation behaviour for the reset-learning action.

* **Translations**
  * Added localisation strings for reset-learning UI and error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->