### PR TITLE
fix(analysis): cancellable, bisect-indexed correlation pipeline (#450)

### DIFF
--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -1153,6 +1153,13 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             if self._analysis_timer is not None:
                 self._analysis_timer()
                 self._analysis_timer = None
+            # Don't re-arm if shutdown has been signalled while another
+            # analysis is in flight — the EVENT_HOMEASSISTANT_STOP listener
+            # already cancelled the timer slot, and a callback we know
+            # will hit the stop_requested guard is just a registry leak
+            # until ``async_shutdown`` cleans it up.
+            if self._stop_requested:
+                return
             # Reschedule to try again later
             next_update = _now + timedelta(minutes=5)
             self._analysis_timer = async_track_point_in_time(
@@ -1178,6 +1185,15 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _failed = True
         finally:
             self._analysis_running = False
+            # If shutdown was signalled DURING the await above, the
+            # EVENT_HOMEASSISTANT_STOP listener has already cancelled
+            # the timer slot and set ``_stop_requested``. Re-arming
+            # here would register a fresh callback that immediately
+            # no-ops in the guard at the top of this method — and
+            # would only be cleaned up later by ``async_shutdown``.
+            # Skip the re-arm entirely.
+            if self._stop_requested:
+                return
             # Always reschedule — retry sooner on failure
             if _failed:
                 next_update = _now + timedelta(minutes=15)

--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -330,10 +330,14 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def _on_homeassistant_stop(self, _event: Event) -> None:
         """Handle HA's ``EVENT_HOMEASSISTANT_STOP``.
 
-        Setting the flag is enough — long-running pipeline work polls it
-        and unwinds. Cancelling timers here too means a stop event that
-        races a scheduled analysis tick can't kick off a fresh run while
-        ``async_shutdown`` is on its way.
+        Setting the flag is enough for the analysis pipeline (which polls
+        it inside long-running sync work). Cancelling timers here too
+        prevents a fresh callback from kicking off DB / decay work after
+        HA has already entered shutdown but before ``async_shutdown``
+        runs. The ``_handle_*_timer`` handlers also poll the flag — that
+        catches the race where a callback is already in-flight when this
+        runs (we can't yank it from the loop, but we can stop it from
+        rearming and from starting new executor work).
         """
         self._stop_requested = True
         if self._analysis_timer is not None:
@@ -342,6 +346,14 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if self._global_decay_timer is not None:
             self._global_decay_timer()
             self._global_decay_timer = None
+        # ``_save_timer`` was missed in the original wiring. ``db.save_data``
+        # runs in the executor pool, so a save callback in flight during
+        # shutdown reproduces the "Thread is still running at shutdown"
+        # warning the analysis pipeline used to trigger. Cancel here AND
+        # have ``_handle_save_timer`` return early on the flag.
+        if self._save_timer is not None:
+            self._save_timer()
+            self._save_timer = None
 
     # --- Public Methods ---
     def _validate_areas_configured(self) -> None:
@@ -1045,6 +1057,14 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Handle periodic save timer firing - save data and reschedule."""
         self._save_timer = None
 
+        # Bail before kicking off executor work if shutdown has been
+        # signalled. ``db.save_data`` runs in the executor pool and
+        # would otherwise reproduce the "Thread is still running at
+        # shutdown" warning. ``async_shutdown`` does its own final
+        # save, so skipping this tick is safe.
+        if self._stop_requested:
+            return
+
         try:
             await self.hass.async_add_executor_job(self.db.save_data)
             _LOGGER.debug(
@@ -1058,7 +1078,12 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 err,
             )
 
-        # Reschedule the timer
+        # Reschedule the timer — but not if shutdown was signalled
+        # while ``save_data`` was running in the executor. Otherwise we
+        # leak a registered callback that ``async_shutdown`` will then
+        # have to clean up.
+        if self._stop_requested:
+            return
         self._start_save_timer()
 
     # --- Decay Timer Handling ---
@@ -1079,6 +1104,13 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Handle decay timer firing - refresh coordinator and always reschedule."""
         self._global_decay_timer = None
 
+        # Skip the tick + refresh if shutdown was signalled. The
+        # work itself is in-process and quick (no executor), but
+        # ``async_refresh`` can fan out to listeners that don't
+        # expect to be called once the integration is unwinding.
+        if self._stop_requested:
+            return
+
         # Tick decay for all areas to update state (e.g., stop decay when factor reaches zero)
         # This must be done before refresh to ensure state transitions happen
         for area in self.areas.values():
@@ -1090,7 +1122,11 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if decay_enabled:
             await self.async_refresh()
 
-        # Reschedule the timer
+        # Reschedule the timer — but not if shutdown was signalled
+        # during ``async_refresh``. Same rearm-leak avoidance as the
+        # save and analysis timers.
+        if self._stop_requested:
+            return
         self._start_decay_timer()
 
     # --- Analysis Timer Handling ---

--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -10,7 +10,8 @@ from typing import Any
 
 # Home Assistant imports
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import (
     area_registry as ar,
@@ -79,6 +80,14 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # data.analysis.run_full_analysis at the end of each pipeline run.
         # Read by HealthMonitor.check_pipeline_health to flag slow analysis.
         self._last_analysis_duration_ms: float | None = None
+        # Set to True by the EVENT_HOMEASSISTANT_STOP listener so the
+        # in-flight analysis pipeline (and the sync correlation work it
+        # dispatches to the executor) can bail at the next loop boundary
+        # instead of riding through HA's "final writes shutdown stage".
+        # Read by data.analysis.run_full_analysis and the per-area /
+        # per-entity loops in db.correlation.
+        self._stop_requested: bool = False
+        self._stop_listener_remove: CALLBACK_TYPE | None = None
 
     async def async_init_database(self) -> None:
         """Initialize the database asynchronously to avoid blocking the event loop.
@@ -307,6 +316,33 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Return the most recent full-analysis duration in milliseconds, if any."""
         return self._last_analysis_duration_ms
 
+    @property
+    def stop_requested(self) -> bool:
+        """Return whether HA has signalled shutdown.
+
+        The analysis pipeline and the sync correlation loops poll this so
+        they can bail at the next loop boundary instead of riding through
+        HA's "final writes shutdown stage" and tripping its
+        ``Thread … is still running at shutdown`` warning.
+        """
+        return self._stop_requested
+
+    def _on_homeassistant_stop(self, _event: Event) -> None:
+        """Handle HA's ``EVENT_HOMEASSISTANT_STOP``.
+
+        Setting the flag is enough — long-running pipeline work polls it
+        and unwinds. Cancelling timers here too means a stop event that
+        races a scheduled analysis tick can't kick off a fresh run while
+        ``async_shutdown`` is on its way.
+        """
+        self._stop_requested = True
+        if self._analysis_timer is not None:
+            self._analysis_timer()
+            self._analysis_timer = None
+        if self._global_decay_timer is not None:
+            self._global_decay_timer()
+            self._global_decay_timer = None
+
     # --- Public Methods ---
     def _validate_areas_configured(self) -> None:
         """Validate that at least one area is configured.
@@ -410,6 +446,16 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             # Analysis timer is async and runs in background
             await self._start_analysis_timer()
 
+            # Wire up an early shutdown signal so an in-flight analysis
+            # pipeline can bail before HA's "final writes shutdown stage"
+            # rather than after, which is what triggered the
+            # ``Task … was still running after final writes shutdown stage``
+            # warning users were seeing on restart.
+            if self._stop_listener_remove is None:
+                self._stop_listener_remove = self.hass.bus.async_listen_once(
+                    EVENT_HOMEASSISTANT_STOP, self._on_homeassistant_stop
+                )
+
             # Build floor-based aggregators from area floor assignments
             self._build_floor_aggregators()
 
@@ -466,6 +512,20 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "Starting coordinator shutdown for areas: %s",
             format_area_names(self),
         )
+
+        # Mark stop requested so any analysis run that races shutdown bails
+        # at the next loop boundary. Idempotent with the EVENT_HOMEASSISTANT_STOP
+        # listener — config-entry unloads (e.g. options-flow reload) reach this
+        # path without ever firing the bus event.
+        self._stop_requested = True
+
+        # Step 0: Drop the EVENT_HOMEASSISTANT_STOP listener if it's still
+        # registered. ``async_listen_once`` self-removes when fired, so this
+        # is the unload-without-shutdown case (options reload, integration
+        # remove). Dropping it prevents a leaked listener after reload.
+        if self._stop_listener_remove is not None:
+            self._stop_listener_remove()
+            self._stop_listener_remove = None
 
         # Step 1: Cancel periodic save timer before cleanup and perform final save
         if self._save_timer is not None:
@@ -1078,6 +1138,13 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """
         if _now is None:
             _now = dt_util.utcnow()
+
+        # Don't start a new pipeline if HA is shutting down. The
+        # EVENT_HOMEASSISTANT_STOP listener already cancelled the timer,
+        # but a previously-fired timer's callback can still land here
+        # before the listener runs.
+        if self._stop_requested:
+            return
 
         # Prevent concurrent analysis runs
         if self._analysis_running:

--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -62,16 +62,23 @@ async def run_full_analysis(
 
     analysis_start_time = time.perf_counter()
     failed_steps: list[str] = []
+    cancelled = False
     total_steps = 12
 
     async def _run_step(step_num: int, step_name: str, coro: Awaitable[None]) -> None:
         """Run a single analysis step with timing and error tracking."""
+        nonlocal cancelled
         # Skip remaining steps once HA has signalled shutdown — the inner
         # awaitable would still create the coroutine object so we close it
         # to avoid a "coroutine was never awaited" warning. We don't append
         # to ``failed_steps`` because a clean cancellation isn't a failure
-        # the caller should back off on.
+        # the caller should back off on, but we *do* set ``cancelled`` so
+        # the summary path can suppress the misleading "12/12 succeeded"
+        # log line and skip writing ``_last_analysis_duration_ms`` (which
+        # otherwise pollutes the slow-analysis health threshold with a
+        # near-zero fast-skip duration).
         if coordinator.stop_requested:
+            cancelled = True
             coro.close()
             _LOGGER.debug(
                 "Step %d: %s skipped — shutdown in progress", step_num, step_name
@@ -174,7 +181,18 @@ async def run_full_analysis(
     finally:
         succeeded = total_steps - len(failed_steps)
         final_elapsed_ms = (time.perf_counter() - analysis_start_time) * 1000
-        if failed_steps:
+        if cancelled:
+            # Cancelled mid-run by EVENT_HOMEASSISTANT_STOP. Report the
+            # outcome distinctly (the per-step debug logs already record
+            # which steps were skipped) and skip both the success log
+            # line and the duration write — a fast-skip duration would
+            # mask a previously-slow successful cycle in the
+            # slow-analysis health check.
+            _LOGGER.info(
+                "Analysis cancelled mid-run after %.2f ms — shutdown in progress",
+                final_elapsed_ms,
+            )
+        elif failed_steps:
             _LOGGER.warning(
                 "Analysis completed: %d/%d steps succeeded (FAILED: %s) in %.2f ms",
                 succeeded,

--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -66,6 +66,17 @@ async def run_full_analysis(
 
     async def _run_step(step_num: int, step_name: str, coro: Awaitable[None]) -> None:
         """Run a single analysis step with timing and error tracking."""
+        # Skip remaining steps once HA has signalled shutdown — the inner
+        # awaitable would still create the coroutine object so we close it
+        # to avoid a "coroutine was never awaited" warning. We don't append
+        # to ``failed_steps`` because a clean cancellation isn't a failure
+        # the caller should back off on.
+        if coordinator.stop_requested:
+            coro.close()
+            _LOGGER.debug(
+                "Step %d: %s skipped — shutdown in progress", step_num, step_name
+            )
+            return
         start = time.perf_counter()
         try:
             await coro

--- a/custom_components/area_occupancy/db/correlation.py
+++ b/custom_components/area_occupancy/db/correlation.py
@@ -31,7 +31,8 @@ from ..time_utils import from_db_utc, to_db_utc, to_local, to_utc
 from ..utils import clamp_probability, map_binary_state_to_semantic
 from .utils import (
     get_occupied_intervals_for_analysis,
-    is_timestamp_occupied,
+    is_timestamp_in_prepared_intervals,
+    prepare_occupied_intervals,
     validate_sample_count,
 )
 
@@ -66,6 +67,16 @@ CORRELATION_FAILURE_ERRORS: frozenset[str] = frozenset(
         "zero_samples_after_filtering",
     }
 )
+
+
+class AnalysisCancelled(RuntimeError):
+    """Raised when the analysis pipeline is cancelled mid-run.
+
+    Distinct from ``CORRELATION_FAILURE_ERRORS`` so the pipeline-health
+    monitor doesn't count a clean shutdown as a correlation failure when
+    computing the failure ratio. The per-area helper catches this and
+    short-circuits the rest of its work.
+    """
 
 
 def calculate_pearson_correlation(
@@ -446,6 +457,12 @@ def analyze_binary_likelihoods(
             unique_states = set()
 
             for interval in binary_intervals:
+                # Coarse cancellation check on the outer loop. The inner
+                # overlap loop is bounded by the number of occupied
+                # intervals (typically tens to low hundreds) so per-interval
+                # granularity is enough to keep shutdown latency bounded.
+                if db.coordinator.stop_requested:
+                    raise AnalysisCancelled  # noqa: TRY301
                 interval_start = from_db_utc(interval.start_time)
                 interval_end = from_db_utc(interval.end_time)
                 # Clamp to analysis period
@@ -595,6 +612,12 @@ def analyze_binary_likelihoods(
             )
             return base_result
 
+    except AnalysisCancelled:
+        # Propagate so ``_analyze_area_sensors`` can break out cleanly.
+        # Without this re-raise the wider ``RuntimeError`` clause below
+        # would swallow it and the caller would treat the cancellation
+        # as a missing result.
+        raise
     except SQLAlchemyError as e:
         _LOGGER.error(
             "Database error analyzing binary likelihoods for %s: %s",
@@ -740,9 +763,17 @@ def analyze_correlation(  # noqa: C901
                 base_result.update(error)
                 return base_result
 
-            # Get occupied intervals for the area
+            # Get occupied intervals for the area, then build a sorted UTC
+            # index once. The per-chunk / per-sample membership checks below
+            # were the analysis cycle's hot loop — with the unindexed helper,
+            # each check did an O(N) scan plus two ``astimezone`` calls per
+            # scanned interval, compounding into tens of millions of
+            # conversions per cycle on areas with many intervals.
             occupied_intervals = get_occupied_intervals_for_analysis(
                 db, area_name, period_start, period_end
+            )
+            occupied_starts, occupied_ends = prepare_occupied_intervals(
+                occupied_intervals
             )
 
             # Initialize diagnostic counters (used for both binary and numeric)
@@ -778,6 +809,11 @@ def analyze_correlation(  # noqa: C901
                 chunk_duration_seconds = 60.0
 
                 for interval in binary_intervals:
+                    # Coarse cancellation check at the per-interval boundary.
+                    # The inner per-chunk loop is fast post-perf-fix (bisect
+                    # over a prepared index) so checking here is sufficient.
+                    if db.coordinator.stop_requested:
+                        raise AnalysisCancelled  # noqa: TRY301
                     interval_start = from_db_utc(interval.start_time)
                     interval_end = from_db_utc(interval.end_time)
                     # Clamp to analysis period
@@ -809,8 +845,8 @@ def analyze_correlation(  # noqa: C901
                         chunk_midpoint = current_time + (chunk_end - current_time) / 2
 
                         # Check if chunk midpoint falls within any occupied interval
-                        is_occupied = is_timestamp_occupied(
-                            chunk_midpoint, occupied_intervals
+                        is_occupied = is_timestamp_in_prepared_intervals(
+                            chunk_midpoint, occupied_starts, occupied_ends
                         )
 
                         # Create one sample per chunk with unambiguous occupancy flag
@@ -855,10 +891,16 @@ def analyze_correlation(  # noqa: C901
                 inactive_samples_in_occupied = 0
                 inactive_samples_in_unoccupied = 0
 
-                for sample in samples:
+                for sample_idx, sample in enumerate(samples):
+                    # Periodic cancellation check. With the bisect-based
+                    # membership test the per-sample cost is microseconds,
+                    # so checking every 1024 samples bounds shutdown
+                    # latency without measurable overhead in the steady state.
+                    if sample_idx & 1023 == 0 and db.coordinator.stop_requested:
+                        raise AnalysisCancelled  # noqa: TRY301
                     # Check if sample timestamp falls within any occupied interval
-                    is_occupied = is_timestamp_occupied(
-                        sample.timestamp, occupied_intervals
+                    is_occupied = is_timestamp_in_prepared_intervals(
+                        sample.timestamp, occupied_starts, occupied_ends
                     )
 
                     sample_value = float(sample.value)
@@ -1059,6 +1101,12 @@ def analyze_correlation(  # noqa: C901
 
             return result
 
+    except AnalysisCancelled:
+        # Propagate so ``_analyze_area_sensors`` can break out cleanly.
+        # Without this re-raise the wider ``RuntimeError`` clause below
+        # would swallow it and the caller would treat the cancellation
+        # as a missing result.
+        raise
     except (
         SQLAlchemyError,
         ValueError,
@@ -1673,6 +1721,17 @@ async def _analyze_area_sensors(
     """
     results: list[dict[str, Any]] = []
     for entity_id, entity_info in entities.items():
+        # Per-entity loop boundary: bail if HA is shutting down so the
+        # async layer doesn't dispatch another sync block that the
+        # executor will refuse to abandon. The current entity (if any)
+        # is already mid-flight in the executor; we can't yank it, but
+        # we stop *adding* to the work queue from here on.
+        if coordinator.stop_requested:
+            _LOGGER.debug(
+                "Skipping remaining entities for area '%s' — shutdown in progress",
+                area_name,
+            )
+            break
         try:
             if entity_info["is_binary"]:
                 # Binary sensors: Use duration-based likelihood analysis
@@ -1765,6 +1824,17 @@ async def _analyze_area_sensors(
                             and correlation_result.get("analysis_error") is None,
                         }
                     )
+        except AnalysisCancelled:
+            # Clean shutdown signal — break out of the per-entity loop
+            # without logging or recording a failure. A cancelled run
+            # mustn't poison ``correlation_failure_count`` in the
+            # pipeline-health monitor on the next start-up.
+            _LOGGER.debug(
+                "Sensor analysis cancelled mid-entity for area '%s' (%s)",
+                area_name,
+                entity_id,
+            )
+            break
         except (
             SQLAlchemyError,
             ValueError,

--- a/custom_components/area_occupancy/db/utils.py
+++ b/custom_components/area_occupancy/db/utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import bisect
 from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta
 import logging
@@ -305,6 +306,63 @@ def is_timestamp_occupied(
         to_utc(start) <= timestamp_utc < to_utc(end)
         for start, end in occupied_intervals
     )
+
+
+def prepare_occupied_intervals(
+    intervals: list[tuple[datetime, datetime]],
+) -> tuple[list[datetime], list[datetime]]:
+    """Build an indexed view of occupied intervals for repeated lookups.
+
+    Pair with ``is_timestamp_in_prepared_intervals``. Each endpoint is
+    converted to UTC-aware *once* and the intervals are sorted by start
+    so a subsequent membership check is O(log N) instead of the O(N)
+    scan ``is_timestamp_occupied`` performs (with two ``astimezone``
+    calls per scanned element). Use this whenever the same interval set
+    is checked against many timestamps — see ``analyze_correlation``'s
+    per-chunk loop, where the unindexed path was issuing tens of
+    millions of ``astimezone`` calls per analysis cycle on an RPi.
+
+    Assumes intervals are non-overlapping; the occupied-intervals cache
+    populated by the analysis pipeline merges adjacent intervals before
+    persisting, so this holds for all in-tree callers. With overlapping
+    inputs ``bisect`` only sees the latest-starting interval per
+    timestamp, which is still a correct ``contains`` answer when intervals
+    overlap fully or nest, but loses coverage of points that lie inside
+    an earlier interval that ends after a later one's start. Callers that
+    cannot guarantee non-overlap should fall back to ``is_timestamp_occupied``.
+
+    Returns:
+        Parallel ``(starts, ends)`` arrays sorted by start time.
+    """
+    if not intervals:
+        return [], []
+    normalised = sorted(
+        ((to_utc(start), to_utc(end)) for start, end in intervals),
+        key=lambda iv: iv[0],
+    )
+    starts = [s for s, _ in normalised]
+    ends = [e for _, e in normalised]
+    return starts, ends
+
+
+def is_timestamp_in_prepared_intervals(
+    timestamp: datetime,
+    starts: list[datetime],
+    ends: list[datetime],
+) -> bool:
+    """O(log N) membership test against a prepared interval index.
+
+    Pair with ``prepare_occupied_intervals``. End times are exclusive,
+    matching ``is_timestamp_occupied``'s semantics so the two helpers are
+    interchangeable for non-overlapping interval sets.
+    """
+    if not starts:
+        return False
+    ts = to_utc(timestamp)
+    idx = bisect.bisect_right(starts, ts) - 1
+    if idx < 0:
+        return False
+    return ts < ends[idx]
 
 
 def validate_sample_count(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -749,6 +749,64 @@ class TestAreaOccupancyCoordinator:
         # async_shutdown isn't asked to cancel a stale callback.
         assert coordinator._analysis_timer is None
 
+    async def test_run_analysis_does_not_rearm_timer_if_stop_during_run(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """Mid-run shutdown must not cause the finally block to re-arm.
+
+        The race: ``run_analysis`` enters with ``stop_requested=False``,
+        starts the pipeline, and during the long ``await`` the
+        EVENT_HOMEASSISTANT_STOP listener flips the flag and clears the
+        timer slot. Without an extra guard the finally block calls
+        ``async_track_point_in_time`` again — registering a callback we
+        already know will hit the stop guard and no-op, leaking the
+        registration until ``async_shutdown`` cleans it up.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+
+        async def _fake_pipeline(*_args, **_kwargs):
+            # Simulate the EVENT_HOMEASSISTANT_STOP listener firing
+            # mid-await — flag flips while we're inside run_full_analysis.
+            coordinator._stop_requested = True
+
+        with (
+            patch(
+                "custom_components.area_occupancy.coordinator.run_full_analysis",
+                side_effect=_fake_pipeline,
+            ),
+            patch(
+                "custom_components.area_occupancy.coordinator.async_track_point_in_time",
+                return_value=Mock(),
+            ) as mock_track_time,
+        ):
+            await coordinator.run_analysis()
+
+        mock_track_time.assert_not_called()
+        assert coordinator._analysis_timer is None
+
+    async def test_run_analysis_concurrent_guard_does_not_rearm_when_stopped(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """Concurrent-guard branch must also honour stop_requested.
+
+        If a timer callback fires WHILE another analysis is in-flight
+        AND shutdown has been signalled, the existing
+        ``self._analysis_running`` short-path used to schedule a
+        five-minute retry. With shutdown active that retry is just a
+        leak. Same reasoning as the main finally guard.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        coordinator._analysis_running = True
+        coordinator._stop_requested = True
+
+        with patch(
+            "custom_components.area_occupancy.coordinator.async_track_point_in_time",
+            return_value=Mock(),
+        ) as mock_track_time:
+            await coordinator.run_analysis()
+
+        mock_track_time.assert_not_called()
+
     async def test_track_entity_state_changes_with_existing_listener(
         self, hass: HomeAssistant, mock_realistic_config_entry: Mock
     ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -690,6 +690,65 @@ class TestAreaOccupancyCoordinator:
             # Flag should be reset to False even after error (via finally block)
             assert coordinator._analysis_running is False
 
+    async def test_stop_requested_default_false(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """Fresh coordinator should not be in stop-requested state.
+
+        Guards against a regression where the flag is mistakenly initialised
+        ``True`` and the analysis pipeline silently no-ops on every run.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        assert coordinator.stop_requested is False
+
+    async def test_on_homeassistant_stop_sets_flag_and_cancels_timers(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """The stop listener flips the flag and tears down scheduled work.
+
+        Without this the analysis timer can fire mid-shutdown and reach
+        ``run_analysis`` before the flag check kicks in — exactly the
+        race that produced the ``Task … was still running after final
+        writes shutdown stage`` warning users reported on issue #450.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        analysis_cancel = Mock()
+        decay_cancel = Mock()
+        coordinator._analysis_timer = analysis_cancel
+        coordinator._global_decay_timer = decay_cancel
+
+        coordinator._on_homeassistant_stop(Mock())
+
+        assert coordinator.stop_requested is True
+        analysis_cancel.assert_called_once()
+        decay_cancel.assert_called_once()
+        assert coordinator._analysis_timer is None
+        assert coordinator._global_decay_timer is None
+
+    async def test_run_analysis_skips_when_stop_requested(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """``run_analysis`` must no-op once shutdown is signalled.
+
+        Catches the timer-callback race: the EVENT_HOMEASSISTANT_STOP
+        listener cancels the timer, but a callback already in flight at
+        that moment can still land here. The check inside ``run_analysis``
+        is the second line of defence.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        coordinator._stop_requested = True
+
+        with patch(
+            "custom_components.area_occupancy.coordinator.run_full_analysis",
+            new=AsyncMock(),
+        ) as mock_full_analysis:
+            await coordinator.run_analysis()
+
+        mock_full_analysis.assert_not_called()
+        # No reschedule either — the timer reference must stay None so
+        # async_shutdown isn't asked to cancel a stale callback.
+        assert coordinator._analysis_timer is None
+
     async def test_track_entity_state_changes_with_existing_listener(
         self, hass: HomeAssistant, mock_realistic_config_entry: Mock
     ) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -710,20 +710,76 @@ class TestAreaOccupancyCoordinator:
         ``run_analysis`` before the flag check kicks in — exactly the
         race that produced the ``Task … was still running after final
         writes shutdown stage`` warning users reported on issue #450.
+
+        Cancels all three scheduled-work slots: analysis, decay, and
+        save. The save slot was missed in the original wiring; without
+        cancelling it, an in-flight ``_handle_save_timer`` callback
+        would still fire ``db.save_data`` in the executor pool and
+        reproduce the same shutdown-warning pathway.
         """
         coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
         analysis_cancel = Mock()
         decay_cancel = Mock()
+        save_cancel = Mock()
         coordinator._analysis_timer = analysis_cancel
         coordinator._global_decay_timer = decay_cancel
+        coordinator._save_timer = save_cancel
 
         coordinator._on_homeassistant_stop(Mock())
 
         assert coordinator.stop_requested is True
         analysis_cancel.assert_called_once()
         decay_cancel.assert_called_once()
+        save_cancel.assert_called_once()
         assert coordinator._analysis_timer is None
         assert coordinator._global_decay_timer is None
+        assert coordinator._save_timer is None
+
+    async def test_handle_save_timer_skips_executor_work_when_stopped(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """Save handler must not dispatch ``db.save_data`` after stop.
+
+        The cancellation in ``_on_homeassistant_stop`` covers the
+        scheduled-but-not-fired case. This guard covers the "callback
+        already in-flight when stop fires" race — without it, the
+        executor would still run ``db.save_data`` and trip the
+        ``Thread is still running at shutdown`` warning.
+        ``async_shutdown`` does its own final save, so this is safe.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        coordinator._stop_requested = True
+
+        with (
+            patch.object(coordinator.hass, "async_add_executor_job") as mock_executor,
+            patch.object(coordinator, "_start_save_timer") as mock_rearm,
+        ):
+            await coordinator._handle_save_timer(dt_util.utcnow())
+
+        mock_executor.assert_not_called()
+        mock_rearm.assert_not_called()
+
+    async def test_handle_decay_timer_skips_refresh_and_rearm_when_stopped(
+        self, hass: HomeAssistant, mock_realistic_config_entry: Mock
+    ) -> None:
+        """Decay handler must not refresh listeners or rearm after stop.
+
+        ``async_refresh`` fans out to subscribed listeners that don't
+        expect to be called while the integration is unwinding;
+        rearming the timer leaks a callback that ``async_shutdown``
+        then has to clean up.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        coordinator._stop_requested = True
+
+        with (
+            patch.object(coordinator, "async_refresh", new=AsyncMock()) as mock_refresh,
+            patch.object(coordinator, "_start_decay_timer") as mock_rearm,
+        ):
+            await coordinator._handle_decay_timer(dt_util.utcnow())
+
+        mock_refresh.assert_not_called()
+        mock_rearm.assert_not_called()
 
     async def test_run_analysis_skips_when_stop_requested(
         self, hass: HomeAssistant, mock_realistic_config_entry: Mock

--- a/tests/test_data_analysis.py
+++ b/tests/test_data_analysis.py
@@ -941,6 +941,65 @@ class TestRunFullAnalysisCancellation:
         mock_sync.assert_not_called()
         mock_executor.assert_not_called()
 
+    async def test_cancelled_run_does_not_pollute_last_analysis_duration(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Cancelled cycles must not write ``_last_analysis_duration_ms``.
+
+        Otherwise a fast-skip duration (microseconds, since no work runs)
+        masks a previously-slow successful cycle in
+        ``HealthMonitor.check_pipeline_health``'s slow-analysis check —
+        the user could have an actual 5-minute analysis problem hidden
+        behind a recent shutdown-cancelled cycle's near-zero duration.
+        """
+        # Seed a previously-recorded slow run so we can verify it survives.
+        coordinator._last_analysis_duration_ms = 250_000.0
+        coordinator._stop_requested = True
+
+        with (
+            patch.object(coordinator.db, "sync_states", new=AsyncMock()),
+            patch.object(
+                coordinator.hass,
+                "async_add_executor_job",
+                new=AsyncMock(),
+            ),
+        ):
+            await run_full_analysis(coordinator)
+
+        # The seeded value must survive — cancelled runs are not
+        # comparable to real cycles.
+        assert coordinator._last_analysis_duration_ms == 250_000.0
+
+    async def test_cancelled_run_logs_cancellation_not_success(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Cancelled cycles log distinctly from a "12/12 succeeded" cycle.
+
+        Without this branching the operator sees ``Full analysis
+        completed: 12/12 steps succeeded`` on every shutdown-cancelled
+        cycle — it looks like the integration is healthy when it
+        actually did no work.
+        """
+        coordinator._stop_requested = True
+
+        with (
+            patch.object(coordinator.db, "sync_states", new=AsyncMock()),
+            patch.object(
+                coordinator.hass,
+                "async_add_executor_job",
+                new=AsyncMock(),
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis._LOGGER"
+            ) as mock_logger,
+        ):
+            await run_full_analysis(coordinator)
+
+        # Only the cancellation message, never a "12/12 succeeded".
+        info_messages = [call.args[0] for call in mock_logger.info.call_args_list]
+        assert any("cancelled mid-run" in msg for msg in info_messages), info_messages
+        assert not any("succeeded" in msg for msg in info_messages), info_messages
+
 
 class TestMergeOverlappingIntervals:
     """Test merge_overlapping_intervals function."""

--- a/tests/test_data_analysis.py
+++ b/tests/test_data_analysis.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from zoneinfo import ZoneInfo
 
 import pytest
@@ -16,6 +16,7 @@ from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinato
 from custom_components.area_occupancy.data.analysis import (
     PriorAnalyzer,
     ensure_occupied_intervals_cache,
+    run_full_analysis,
     run_interval_aggregation,
     run_numeric_aggregation,
     start_prior_analysis,
@@ -899,6 +900,46 @@ class TestOrchestrationFunctions:
             # Should not raise
             await start_prior_analysis(coordinator, area_name, area.prior)
             mock_logger.error.assert_called()
+
+
+class TestRunFullAnalysisCancellation:
+    """``run_full_analysis`` must respect ``coordinator.stop_requested``.
+
+    The stop signal is set by the EVENT_HOMEASSISTANT_STOP listener; the
+    pipeline polls between steps so an in-flight cycle can unwind before
+    HA's "final writes shutdown stage" — the bug behind issue #450's
+    ``Task … was still running after final writes shutdown stage``
+    warning.
+    """
+
+    async def test_no_steps_run_when_stop_requested_at_start(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Stop requested before the pipeline starts → nothing runs.
+
+        Patches the per-step DB calls so we can assert *none* of them
+        were invoked. ``run_full_analysis`` must also not raise — clean
+        cancellation isn't a failure that should trigger backoff.
+        """
+        coordinator._stop_requested = True
+
+        with (
+            patch.object(coordinator.db, "sync_states", new=AsyncMock()) as mock_sync,
+            patch.object(
+                coordinator.hass,
+                "async_add_executor_job",
+                new=AsyncMock(),
+            ) as mock_executor,
+        ):
+            # Pipeline raises only on step-level *failures*; cancellation
+            # is silent. Just await and verify no work happened.
+            await run_full_analysis(coordinator)
+
+        # Step 1 (``sync_states``) and step 2 (``periodic_health_check`` via
+        # executor) both gate behind ``_run_step``'s stop-requested check.
+        # If either fired, ``_run_step`` failed to honour the flag.
+        mock_sync.assert_not_called()
+        mock_executor.assert_not_called()
 
 
 class TestMergeOverlappingIntervals:

--- a/tests/test_db_utils.py
+++ b/tests/test_db_utils.py
@@ -1,12 +1,18 @@
 """Tests for database utility functions."""
 
 from contextlib import contextmanager
-from datetime import timedelta
+from datetime import UTC, timedelta, timezone
 
 from sqlalchemy.exc import SQLAlchemyError
 
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
-from custom_components.area_occupancy.db.utils import is_intervals_empty, is_valid_state
+from custom_components.area_occupancy.db.utils import (
+    is_intervals_empty,
+    is_timestamp_in_prepared_intervals,
+    is_timestamp_occupied,
+    is_valid_state,
+    prepare_occupied_intervals,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
 
@@ -133,3 +139,79 @@ class TestIsIntervalsEmpty:
         monkeypatch.setattr(db, "get_session", mock_session)
         result = is_intervals_empty(db)
         assert result is True  # Should return True as fallback
+
+
+class TestPreparedIntervalLookup:
+    """Tests for ``prepare_occupied_intervals`` + ``is_timestamp_in_prepared_intervals``.
+
+    Behaviour parity with the legacy O(N) ``is_timestamp_occupied`` helper
+    is the core invariant — the bisect-based lookup is only useful if it
+    answers the same questions for the inputs the analysis pipeline
+    produces (sorted, non-overlapping intervals).
+    """
+
+    def test_empty_inputs(self) -> None:
+        starts, ends = prepare_occupied_intervals([])
+        assert starts == [] and ends == []
+        assert (
+            is_timestamp_in_prepared_intervals(dt_util.utcnow(), starts, ends) is False
+        )
+
+    def test_membership_matches_legacy_helper(self) -> None:
+        """Every probe lands the same answer through both code paths.
+
+        Covers the boundary cases the legacy tests already enforce
+        (start inclusive, end exclusive, gap, before, after) plus a
+        deliberately-shuffled input order so the sort step inside
+        ``prepare_occupied_intervals`` is exercised.
+        """
+        now = dt_util.utcnow()
+        intervals = [
+            (now + timedelta(hours=2), now + timedelta(hours=3)),  # second
+            (now, now + timedelta(hours=1)),  # first
+            (now + timedelta(hours=5), now + timedelta(hours=6)),  # third
+        ]
+        starts, ends = prepare_occupied_intervals(intervals)
+        # Sort guarantee — bisect relies on it.
+        assert starts == sorted(starts)
+
+        probes = [
+            now - timedelta(seconds=1),
+            now,  # at start (inclusive)
+            now + timedelta(minutes=30),  # inside first
+            now + timedelta(hours=1),  # at end (exclusive)
+            now + timedelta(hours=1, minutes=30),  # in gap
+            now + timedelta(hours=2, minutes=30),  # inside second
+            now + timedelta(hours=4),  # in gap
+            now + timedelta(hours=5, minutes=30),  # inside third
+            now + timedelta(hours=10),  # past end
+        ]
+        for probe in probes:
+            assert is_timestamp_in_prepared_intervals(
+                probe, starts, ends
+            ) == is_timestamp_occupied(probe, intervals), probe
+
+    def test_naive_inputs_normalised_to_utc(self) -> None:
+        """Naive datetimes are interpreted as UTC, matching ``to_utc``.
+
+        The hot loop callers in ``analyze_correlation`` mostly pass
+        already-aware datetimes (``from_db_utc`` re-attaches UTC), but
+        this guards against a regression that breaks parity with the
+        legacy helper for ``tzinfo=None`` inputs.
+        """
+        naive_now = dt_util.utcnow().replace(tzinfo=None)
+        intervals = [(naive_now, naive_now + timedelta(hours=1))]
+        starts, ends = prepare_occupied_intervals(intervals)
+        # Endpoints are stored UTC-aware after normalisation.
+        assert starts[0].tzinfo is not None
+        assert ends[0].tzinfo is not None
+        # Probe with a non-UTC aware timestamp that converts to a UTC
+        # instant inside the interval — the helper must convert the
+        # probe to UTC before comparison, otherwise a Sydney clock at
+        # 12:30 wouldn't match a UTC interval covering ~04:30 UTC.
+        plus_two = timezone(timedelta(hours=2))
+        # naive_now + 30min, interpreted as UTC, then re-expressed as +02:00
+        probe = (
+            (naive_now + timedelta(minutes=30)).replace(tzinfo=UTC).astimezone(plus_two)
+        )
+        assert is_timestamp_in_prepared_intervals(probe, starts, ends) is True


### PR DESCRIPTION
Closes #450.

## Summary

Two bugs that compounded into the symptom on #450 — HA Core pegged near 100% CPU for 4-5 minutes after restart, and a `Task … was still running after final writes shutdown stage` warning when the user tried to remove the integration.

### 1. Analysis hot loop was quadratic-ish with re-conversion every iteration

`db.utils.is_timestamp_occupied` was `O(N)` with **two** `astimezone()` calls per scanned interval. Inside the per-chunk and per-sample loops in `analyze_correlation` (`db/correlation.py:812` and `:869`) that became `O(chunks × intervals)` with no caching of the UTC conversion — tens of millions of `astimezone` calls per analysis cycle on a Pi 5.

Adds two helpers in `db/utils.py`:
- `prepare_occupied_intervals(intervals)` — sorts + UTC-normalises endpoints **once**, returns parallel arrays.
- `is_timestamp_in_prepared_intervals(ts, starts, ends)` — `bisect_right` lookup, `O(log N)`.

`analyze_correlation` now prepares the index once after `get_occupied_intervals_for_analysis(...)` and uses the indexed lookup in both the binary chunk loop and the numeric sample loop. The legacy `is_timestamp_occupied` is kept for one-shot use in scripts/tests.

Behaviour parity with the legacy helper is enforced by a new oracle test (`TestPreparedIntervalLookup::test_membership_matches_legacy_helper`) that probes every boundary case the existing tests already cover and asserts both code paths return the same answer.

### 2. No early shutdown signal — in-flight pipeline could only be torn down too late

The integration had no `EVENT_HOMEASSISTANT_STOP` listener. The coordinator-base `async_shutdown` fires *after* HA's "final writes shutdown stage", which is what the user's warning was reporting. Even with the signal there was no plumbing inside the pipeline to act on it — the slow step is sync code dispatched via `async_add_executor_job`, and the executor refuses to abandon a running thread.

Adds:
- `coordinator._stop_requested` flag + public `stop_requested` accessor.
- `EVENT_HOMEASSISTANT_STOP` listener registered in `setup()` that flips the flag and cancels the analysis + decay timers.
- Cleanup in `async_shutdown()` so a config-entry reload (no bus event) doesn't leak the listener.
- `run_analysis` short-circuits when `stop_requested` is set.
- `run_full_analysis._run_step` skips remaining steps and `coro.close()`s the unused awaitable.
- `_analyze_area_sensors` checks at the per-entity loop boundary and `break`s.
- `analyze_correlation` checks at the per-binary-interval boundary and every 1024 samples in the numeric loop, raising `AnalysisCancelled` (distinct from `CORRELATION_FAILURE_ERRORS` so a clean shutdown isn't counted as a correlation failure by the pipeline-health monitor on next start-up).
- `analyze_binary_likelihoods` adds the same per-interval check + re-raise.

## Test plan

- [x] `scripts/lint` clean
- [x] `uv run pytest -q` — **1621 passed** (was 1614; 7 new tests added)
- New tests:
  - `TestPreparedIntervalLookup` (×3) — empty inputs, oracle parity vs legacy helper across boundary cases, naive→UTC normalisation
  - `TestRunFullAnalysisCancellation::test_no_steps_run_when_stop_requested_at_start`
  - `TestAreaOccupancyCoordinator::test_stop_requested_default_false`
  - `TestAreaOccupancyCoordinator::test_on_homeassistant_stop_sets_flag_and_cancels_timers`
  - `TestAreaOccupancyCoordinator::test_run_analysis_skips_when_stop_requested`
- [ ] Manual: load in devcontainer with a populated DB, restart HA, confirm no `Task … still running after final writes shutdown stage` warning and that idle CPU returns to baseline within seconds rather than minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown: analysis and timers now stop cleanly, cancellation is recognised and avoids rescheduling or treating shutdown as failures.

* **Performance**
  * Faster occupancy analysis via optimised interval indexing and O(log N) membership checks.

* **Tests**
  * Expanded tests for shutdown races, cancellation behaviour, timer cancellation and interval-lookup correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->