### PR TITLE
feat(health): add integration-level toggle to disable repair monitoring

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -62,6 +62,7 @@ from .const import (
     CONF_DOOR_ACTIVE_STATE,
     CONF_DOOR_SENSORS,
     CONF_EXCLUDE_FROM_ALL_AREAS,
+    CONF_HEALTH_ENABLED,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
     CONF_MEDIA_ACTIVE_STATES,
@@ -112,6 +113,7 @@ from .const import (
     DEFAULT_DECAY_HALF_LIFE,
     DEFAULT_DOOR_ACTIVE_STATE,
     DEFAULT_EXCLUDE_FROM_ALL_AREAS,
+    DEFAULT_HEALTH_ENABLED,
     DEFAULT_MEDIA_ACTIVE_STATES,
     DEFAULT_MIN_PRIOR_OVERRIDE,
     DEFAULT_MOTION_PROB_GIVEN_FALSE,
@@ -1824,6 +1826,10 @@ def _create_global_settings_schema(defaults: dict[str, Any]) -> vol.Schema:
                 CONF_SLEEP_END,
                 default=defaults.get(CONF_SLEEP_END, DEFAULT_SLEEP_END),
             ): TimeSelector(),
+            vol.Required(
+                CONF_HEALTH_ENABLED,
+                default=defaults.get(CONF_HEALTH_ENABLED, DEFAULT_HEALTH_ENABLED),
+            ): BooleanSelector(),
         }
     )
 
@@ -2858,6 +2864,9 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
             ),
             CONF_SLEEP_END: self.config_entry.options.get(
                 CONF_SLEEP_END, DEFAULT_SLEEP_END
+            ),
+            CONF_HEALTH_ENABLED: self.config_entry.options.get(
+                CONF_HEALTH_ENABLED, DEFAULT_HEALTH_ENABLED
             ),
         }
 

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -90,6 +90,7 @@ CONF_MIN_PRIOR_OVERRIDE: Final = "min_prior_override"
 CONF_EXCLUDE_FROM_ALL_AREAS: Final = "exclude_from_all_areas"
 CONF_SLEEP_START: Final = "sleep_start"
 CONF_SLEEP_END: Final = "sleep_end"
+CONF_HEALTH_ENABLED: Final = "health_enabled"
 
 # People configuration constants
 CONF_PEOPLE: Final = "people"
@@ -134,6 +135,7 @@ DEFAULT_MIN_PRIOR_OVERRIDE: Final = 0.0  # 0.0 = disabled by default
 DEFAULT_EXCLUDE_FROM_ALL_AREAS: Final = False
 DEFAULT_SLEEP_START: Final = "23:00:00"
 DEFAULT_SLEEP_END: Final = "07:00:00"
+DEFAULT_HEALTH_ENABLED: Final = True
 DEFAULT_SLEEP_CONFIDENCE_THRESHOLD: Final = 75
 DEFAULT_SLEEP_WEIGHT: Final = 0.9
 SLEEP_PRESENCE_HALF_LIFE: Final = (

--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -118,6 +118,10 @@ async def run_full_analysis(
         )
 
     async def _sensor_health_check() -> None:
+        if not coordinator.integration_config.health_enabled:
+            for area in coordinator.areas.values():
+                area.health_monitor.clear_all_issues()
+            return
         for area in coordinator.areas.values():
             excluded = set()
             if area.wasp_entity_id:
@@ -234,6 +238,11 @@ async def _run_pipeline_health_check(
     HA repair registry in one pass. Extracted from ``run_full_analysis``
     to keep the orchestrator's complexity inside ruff's threshold.
     """
+    if not coordinator.integration_config.health_enabled:
+        for area in coordinator.areas.values():
+            area.health_monitor.clear_all_issues()
+        return
+
     now_aware = dt_util.utcnow()
     # Canonical correlatable set per area — defined by the same helper
     # the correlation runner uses, so the denominator matches what the

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -28,6 +28,7 @@ from ..const import (
     CONF_DOOR_ACTIVE_STATE,
     CONF_DOOR_SENSORS,
     CONF_EXCLUDE_FROM_ALL_AREAS,
+    CONF_HEALTH_ENABLED,
     CONF_HUMIDITY_SENSORS,
     CONF_ILLUMINANCE_SENSORS,
     CONF_MEDIA_ACTIVE_STATES,
@@ -77,6 +78,7 @@ from ..const import (
     DEFAULT_DECAY_HALF_LIFE,
     DEFAULT_DOOR_ACTIVE_STATE,
     DEFAULT_EXCLUDE_FROM_ALL_AREAS,
+    DEFAULT_HEALTH_ENABLED,
     DEFAULT_MEDIA_ACTIVE_STATES,
     DEFAULT_MIN_PRIOR_OVERRIDE,
     DEFAULT_MOTION_PROB_GIVEN_FALSE,
@@ -179,6 +181,18 @@ class IntegrationConfig:
     def sleep_end(self) -> str:
         """Get sleep end time from config entry options."""
         return self.config_entry.options.get(CONF_SLEEP_END, DEFAULT_SLEEP_END)
+
+    @property
+    def health_enabled(self) -> bool:
+        """Whether sensor and pipeline health repair issues are emitted.
+
+        When False, ``HealthMonitor.check_health`` and
+        ``check_pipeline_health`` are short-circuited at the analysis-pipeline
+        call sites and any previously-created repair issues are cleared.
+        """
+        return bool(
+            self.config_entry.options.get(CONF_HEALTH_ENABLED, DEFAULT_HEALTH_ENABLED)
+        )
 
     @property
     def people(self) -> list[PersonConfig]:

--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -369,16 +369,19 @@ class HealthMonitor:
         in-memory ``_unavailable_since`` clock is left intact so re-enabling
         the toggle later doesn't make every currently-unavailable sensor
         instantly trip the threshold.
+
+        ``_issues`` is cleared unconditionally so any in-memory state that
+        isn't (yet) mirrored to ``_active_issue_ids`` doesn't linger after
+        a toggle-off.
         """
-        if not self._active_issue_ids:
-            return
         for issue_id in self._active_issue_ids:
             ir.async_delete_issue(self._hass, DOMAIN, issue_id)
-        _LOGGER.debug(
-            "Cleared %d repair issue(s) for area '%s' (health monitoring disabled)",
-            len(self._active_issue_ids),
-            self._area_name,
-        )
+        if self._active_issue_ids:
+            _LOGGER.debug(
+                "Cleared %d repair issue(s) for area '%s' (health monitoring disabled)",
+                len(self._active_issue_ids),
+                self._area_name,
+            )
         self._active_issue_ids.clear()
         self._issues.clear()
 

--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -361,6 +361,27 @@ class HealthMonitor:
         self._issues.clear()
         self._unavailable_since.clear()
 
+    def clear_all_issues(self) -> None:
+        """Delete every active repair issue without resetting runtime state.
+
+        Used when the integration-level ``health_enabled`` toggle is turned
+        off: existing repairs should disappear immediately, but the
+        in-memory ``_unavailable_since`` clock is left intact so re-enabling
+        the toggle later doesn't make every currently-unavailable sensor
+        instantly trip the threshold.
+        """
+        if not self._active_issue_ids:
+            return
+        for issue_id in self._active_issue_ids:
+            ir.async_delete_issue(self._hass, DOMAIN, issue_id)
+        _LOGGER.debug(
+            "Cleared %d repair issue(s) for area '%s' (health monitoring disabled)",
+            len(self._active_issue_ids),
+            self._area_name,
+        )
+        self._active_issue_ids.clear()
+        self._issues.clear()
+
     def check_pipeline_health(
         self,
         *,

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -782,11 +782,13 @@
                 "description": "Configure global settings that apply to all areas",
                 "data": {
                     "sleep_start": "Sleep Start Time",
-                    "sleep_end": "Sleep End Time"
+                    "sleep_end": "Sleep End Time",
+                    "health_enabled": "Sensor health monitoring"
                 },
                 "data_description": {
                     "sleep_start": "The time when your sleep schedule begins. Areas with the 'Sleeping' purpose will use their configured decay half-life during this period.",
-                    "sleep_end": "The time when your sleep schedule ends. Areas with the 'Sleeping' purpose will behave like 'Relaxing' areas outside of sleep hours."
+                    "sleep_end": "The time when your sleep schedule ends. Areas with the 'Sleeping' purpose will behave like 'Relaxing' areas outside of sleep hours.",
+                    "health_enabled": "When enabled, the integration raises Home Assistant repair issues for stuck, unavailable, or never-triggered sensors and for slow or failing analysis cycles. Turn off to silence all repairs from this integration; previously raised issues will be cleared on the next analysis cycle."
                 }
             },
             "manage_people": {

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -783,11 +783,13 @@
                 "description": "Configure global settings that apply to all areas",
                 "data": {
                     "sleep_start": "Sleep Start Time",
-                    "sleep_end": "Sleep End Time"
+                    "sleep_end": "Sleep End Time",
+                    "health_enabled": "Sensor health monitoring"
                 },
                 "data_description": {
                     "sleep_start": "The time when your sleep schedule begins. Areas with the 'Sleeping' purpose will use their configured decay half-life during this period.",
-                    "sleep_end": "The time when your sleep schedule ends. Areas with the 'Sleeping' purpose will behave like 'Relaxing' areas outside of sleep hours."
+                    "sleep_end": "The time when your sleep schedule ends. Areas with the 'Sleeping' purpose will behave like 'Relaxing' areas outside of sleep hours.",
+                    "health_enabled": "When enabled, the integration raises Home Assistant repair issues for stuck, unavailable, or never-triggered sensors and for slow or failing analysis cycles. Turn off to silence all repairs from this integration; previously raised issues will be cleared on the next analysis cycle."
                 }
             },
             "manage_people": {

--- a/tests/test_data_analysis.py
+++ b/tests/test_data_analysis.py
@@ -15,6 +15,7 @@ from custom_components.area_occupancy.const import (
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
 from custom_components.area_occupancy.data.analysis import (
     PriorAnalyzer,
+    _run_pipeline_health_check,
     ensure_occupied_intervals_cache,
     run_full_analysis,
     run_interval_aggregation,
@@ -999,6 +1000,62 @@ class TestRunFullAnalysisCancellation:
         info_messages = [call.args[0] for call in mock_logger.info.call_args_list]
         assert any("cancelled mid-run" in msg for msg in info_messages), info_messages
         assert not any("succeeded" in msg for msg in info_messages), info_messages
+
+
+class TestHealthEnabledToggle:
+    """Pipeline gates on ``integration_config.health_enabled``.
+
+    When the user disables the global toggle, the analysis pipeline must
+    not run health checks and must clear any previously-raised repairs so
+    the Repairs UI empties immediately rather than waiting for the
+    condition itself to clear.
+    """
+
+    async def test_pipeline_health_check_short_circuits_when_disabled(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Disabling the toggle skips per-area work and calls clear instead."""
+        with patch.object(
+            type(coordinator.integration_config),
+            "health_enabled",
+            new=False,
+        ):
+            for area in coordinator.areas.values():
+                area._health_monitor = Mock()
+
+            await _run_pipeline_health_check(coordinator)
+
+            for area in coordinator.areas.values():
+                area.health_monitor.clear_all_issues.assert_called_once()
+                area.health_monitor.check_pipeline_health.assert_not_called()
+
+    async def test_pipeline_health_check_runs_when_enabled(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """With the toggle on, ``check_pipeline_health`` is invoked normally."""
+        with (
+            patch.object(
+                type(coordinator.integration_config),
+                "health_enabled",
+                new=True,
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis.get_area_created_at",
+                return_value=dt_util.utcnow() - timedelta(days=30),
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis.get_occupied_intervals_cache_age_hours",
+                return_value=1.0,
+            ),
+        ):
+            for area in coordinator.areas.values():
+                area._health_monitor = Mock()
+
+            await _run_pipeline_health_check(coordinator)
+
+            for area in coordinator.areas.values():
+                area.health_monitor.check_pipeline_health.assert_called_once()
+                area.health_monitor.clear_all_issues.assert_not_called()
 
 
 class TestMergeOverlappingIntervals:

--- a/tests/test_data_health.py
+++ b/tests/test_data_health.py
@@ -1158,3 +1158,52 @@ class TestPipelinePlaceholderFormatting:
             "translation_placeholders"
         ]
         assert placeholders["duration"] == "14d"
+
+
+class TestClearAllIssues:
+    """``clear_all_issues`` removes every active issue without losing context.
+
+    Used by the integration-level ``health_enabled`` toggle: when the user
+    disables health monitoring, existing repairs disappear immediately but
+    in-memory state needed if they re-enable (the ``_unavailable_since``
+    clock) is preserved so we don't instantly re-trip.
+    """
+
+    def test_clear_deletes_all_active_issues(self, monitor: HealthMonitor) -> None:
+        """Every tracked issue id is deleted from the HA registry."""
+        entity = _make_entity(
+            "binary_sensor.motion_1",
+            InputType.MOTION,
+            state=None,
+            last_updated=dt_util.utcnow() - timedelta(hours=5),
+            evidence=None,
+        )
+        monitor._unavailable_since[entity.entity_id] = dt_util.utcnow() - timedelta(
+            hours=5
+        )
+        with patch("custom_components.area_occupancy.data.health.ir") as mock_ir:
+            monitor.check_health({"motion_1": entity})
+            assert monitor._active_issue_ids  # sanity
+            monitor.clear_all_issues()
+
+        assert mock_ir.async_delete_issue.call_count == 1
+        assert monitor._active_issue_ids == set()
+        assert monitor.issues == []
+
+    def test_clear_is_no_op_when_no_active_issues(self, monitor: HealthMonitor) -> None:
+        """No registry calls when there's nothing to clear."""
+        with patch("custom_components.area_occupancy.data.health.ir") as mock_ir:
+            monitor.clear_all_issues()
+        mock_ir.async_delete_issue.assert_not_called()
+
+    def test_clear_preserves_unavailable_clock(self, monitor: HealthMonitor) -> None:
+        """``_unavailable_since`` is intentionally not reset (vs. ``cleanup``).
+
+        This is what differentiates ``clear_all_issues`` from ``cleanup``:
+        toggling health monitoring off and back on must not make
+        currently-unavailable sensors instantly trip the threshold.
+        """
+        monitor._unavailable_since["sensor.foo"] = dt_util.utcnow()
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            monitor.clear_all_issues()
+        assert "sensor.foo" in monitor._unavailable_since


### PR DESCRIPTION
## Summary

Adds a "Sensor health monitoring" boolean to **Global Settings** (default **on**). When off, both sensor- and pipeline-scope health checks short-circuit at the analysis-pipeline call sites and existing repair issues are cleared via a new `HealthMonitor.clear_all_issues` helper, so the HA Repairs UI empties on the next cycle rather than waiting for each condition to resolve. Runtime state (the `_unavailable_since` clock) is preserved so re-enabling the toggle doesn't make currently-unavailable sensors instantly trip thresholds.

## Why

Several users (#463, #468, #466) report being overwhelmed by repair noise — one comment says "I wake up every morning to 40+ issues". This PR gives them a single off-switch while the more granular per-sensor / per-purpose work is staged in follow-up PRs.

## Closes / mitigates

- Closes the loudest part of #463
- Provides immediate relief for #465, #466, #468 while the saner-defaults and sticky-ignore PRs land separately

## Changes

- `const.py` — `CONF_HEALTH_ENABLED`, `DEFAULT_HEALTH_ENABLED = True`
- `data/config.py` — new `IntegrationConfig.health_enabled` property
- `data/health.py` — new `HealthMonitor.clear_all_issues()` (distinct from `cleanup()` — keeps the unavailable clock)
- `data/analysis.py` — gates `_sensor_health_check` and `_run_pipeline_health_check` on the toggle
- `config_flow.py` — adds the toggle to the Global Settings options-flow step
- `strings.json` / `translations/en.json` — UI label + description

## Test plan

- [x] `tests/test_data_health.py::TestClearAllIssues` — 3 tests (deletes all, no-op when empty, preserves unavailable clock)
- [x] `tests/test_data_analysis.py::TestHealthEnabledToggle` — 2 tests (disabled short-circuits + clears, enabled runs normally)
- [x] Full `test_data_health.py` (66 tests) + `test_data_analysis.py` (93 tests) + `test_config_flow.py` (109 tests) all pass
- [x] `scripts/lint` clean

## Out of scope (follow-up PRs)

- Sticky-ignore so HA's "Ignore" survives condition flaps (separate PR)
- Saner defaults: raise motion stuck-active default, purpose-aware multipliers, exempt `media_player.*` from unavailable checks (separate PR)
- Per-sensor suppression UI from #466 (deferred — covered partly by the toggle + better defaults)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqRbdfJCFjxfN8oLEac8dj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global setting to enable or disable sensor health monitoring.
  * Health checks and repairs are skipped when disabled; previously-created repair issues are cleared.

* **User Interface**
  * Configuration UI updated with the new health toggle and explanatory text.

* **Tests**
  * Added tests covering the health toggle behaviour and clearing of repair issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hankanman/Area-Occupancy-Detection/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->