### PR TITLE
fix(health): preserve user-ignored repairs across condition flaps

### DIFF
--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -241,6 +241,38 @@ class HealthMonitor:
             )
             return set()
 
+    def _is_ignored(self, issue_id: str) -> bool:
+        """Whether the user has marked this repair issue as Ignored in HA.
+
+        Without this guard the next ``_update_repair_issues`` call deletes
+        any issue whose condition has cleared. That delete also wipes HA's
+        ignore state, so when the condition recurs (TV unavailable again
+        the following evening) a fresh issue is created and the user's
+        prior "Ignore" is silently forgotten. Treating an ignored issue as
+        if it had already been deleted lets the registry's own suppression
+        survive these flap cycles.
+
+        HA represents the ignore state on ``IssueEntry`` via
+        ``dismissed_version: str | None`` — populated with the HA version
+        at the moment the user clicked Ignore (see
+        ``IssueRegistry.async_ignore`` in homeassistant/helpers/issue_registry.py).
+        It is preserved across restart even for non-persistent issues, so a
+        plain ``is not None`` test is the canonical "is ignored" check.
+
+        We require ``isinstance(..., str)`` rather than ``is not None`` so a
+        bare ``unittest.mock.Mock()`` standing in for the ``ir`` module
+        (used by older tests) — whose attribute access yields another
+        Mock, which is itself ``not None`` — doesn't accidentally suppress
+        deletion. The real registry only stores string versions.
+        """
+        try:
+            entry = ir.async_get(self._hass).async_get_issue(DOMAIN, issue_id)
+        except (AttributeError, KeyError, TypeError):
+            return False
+        if entry is None:
+            return False
+        return isinstance(getattr(entry, "dismissed_version", None), str)
+
     @property
     def issues(self) -> list[HealthIssue]:
         """Current health issues."""
@@ -785,9 +817,27 @@ class HealthMonitor:
         # the new-issue path below. The repair_id prefix is the source of
         # truth (``_issue_id`` chooses ``pipeline_health_*`` for any issue
         # type in ``_PIPELINE_ISSUE_TYPES``).
-        resolved_ids = self._active_issue_ids - current_issue_ids
+        #
+        # Issues the user has explicitly Ignored in HA's Repairs UI are
+        # left in place: deleting would also wipe HA's ignore state, so
+        # the next time the condition recurs (e.g. TV unavailable again
+        # tomorrow night) a fresh issue would appear and the user's
+        # Ignore would be silently forgotten. Drop them from our active
+        # set instead so we don't re-create them on the next cycle
+        # (HA will keep them suppressed; if the user un-ignores, the
+        # condition either resolves or persists naturally).
+        candidate_ids = self._active_issue_ids - current_issue_ids
+        ignored_ids = {i for i in candidate_ids if self._is_ignored(i)}
+        resolved_ids = candidate_ids - ignored_ids
         for resolved_id in resolved_ids:
             ir.async_delete_issue(self._hass, DOMAIN, resolved_id)
+        if ignored_ids:
+            _LOGGER.debug(
+                "Preserved %d user-ignored repair issue(s) in area '%s' "
+                "despite condition clearing",
+                len(ignored_ids),
+                self._area_name,
+            )
 
         pipeline_prefix = f"pipeline_health_{self._area_id}_"
         resolved_pipeline_ids = {
@@ -840,4 +890,8 @@ class HealthMonitor:
                     ", ".join(pipeline_descriptions),
                 )
 
-        self._active_issue_ids = current_issue_ids
+        # Keep ignored-but-resolved ids in the tracked active set so a
+        # later recurrence of the same condition isn't logged as a "new"
+        # issue. ``async_create_issue`` is idempotent and preserves HA's
+        # ``dismissed_version`` on existing entries.
+        self._active_issue_ids = current_issue_ids | ignored_ids

--- a/tests/test_data_health.py
+++ b/tests/test_data_health.py
@@ -1207,3 +1207,158 @@ class TestClearAllIssues:
         with patch("custom_components.area_occupancy.data.health.ir"):
             monitor.clear_all_issues()
         assert "sensor.foo" in monitor._unavailable_since
+
+
+class TestStickyIgnore:
+    """User-ignored repair issues must survive condition flaps.
+
+    Regression for #463: deleting an issue when its condition cleared
+    also wiped HA's ``dismissed_version`` (the field
+    ``IssueRegistry.async_ignore`` sets to the current HA version when
+    the user clicks Ignore), so when the condition recurred — TV
+    unavailable again the next night — a fresh issue appeared and the
+    Ignore was silently forgotten.
+    """
+
+    @staticmethod
+    def _patch_ir(ignored: bool):
+        """Return a context-manager-style mock for the ``ir`` module.
+
+        Sets ``dismissed_version`` to a fake version string when
+        ``ignored`` is ``True`` (matching what ``IssueRegistry.async_ignore``
+        does at runtime) and ``None`` otherwise.
+        """
+        mock_ir = Mock()
+        mock_entry = Mock()
+        mock_entry.dismissed_version = "2026.5.0" if ignored else None
+        mock_ir.async_get.return_value.async_get_issue.return_value = mock_entry
+        return mock_ir
+
+    def _seed_unavailable_issue(self, monitor: HealthMonitor) -> str:
+        """Run one check that raises an unavailable issue; return its id."""
+        entity = _make_entity(
+            "binary_sensor.tv",
+            InputType.MEDIA,
+            state=None,
+            last_updated=dt_util.utcnow() - timedelta(hours=5),
+            evidence=None,
+        )
+        monitor._unavailable_since[entity.entity_id] = dt_util.utcnow() - timedelta(
+            hours=5
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            monitor.check_health({"tv": entity})
+        assert monitor._active_issue_ids, "seed step must register an issue"
+        return next(iter(monitor._active_issue_ids))
+
+    def test_ignored_issue_is_not_deleted_when_condition_clears(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """If HA marks the issue ignored, condition-clear must not delete."""
+        self._seed_unavailable_issue(monitor)
+
+        entity_ok = _make_entity(
+            "binary_sensor.tv",
+            InputType.MEDIA,
+            state="off",
+            last_updated=dt_util.utcnow(),
+            evidence=False,
+        )
+        mock_ir = self._patch_ir(ignored=True)
+        with patch("custom_components.area_occupancy.data.health.ir", mock_ir):
+            monitor.check_health({"tv": entity_ok})
+
+        mock_ir.async_delete_issue.assert_not_called()
+
+    def test_ignored_issue_stays_in_active_set(self, monitor: HealthMonitor) -> None:
+        """Tracking the ignored id forward avoids spurious 'new' logs on recurrence."""
+        issue_id = self._seed_unavailable_issue(monitor)
+
+        entity_ok = _make_entity(
+            "binary_sensor.tv",
+            InputType.MEDIA,
+            state="off",
+            last_updated=dt_util.utcnow(),
+            evidence=False,
+        )
+        mock_ir = self._patch_ir(ignored=True)
+        with patch("custom_components.area_occupancy.data.health.ir", mock_ir):
+            monitor.check_health({"tv": entity_ok})
+
+        assert issue_id in monitor._active_issue_ids
+
+    def test_non_ignored_resolved_issue_is_deleted(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """Sanity: behavior is unchanged for issues the user never ignored."""
+        self._seed_unavailable_issue(monitor)
+
+        entity_ok = _make_entity(
+            "binary_sensor.tv",
+            InputType.MEDIA,
+            state="off",
+            last_updated=dt_util.utcnow(),
+            evidence=False,
+        )
+        mock_ir = self._patch_ir(ignored=False)
+        with patch("custom_components.area_occupancy.data.health.ir", mock_ir):
+            monitor.check_health({"tv": entity_ok})
+
+        mock_ir.async_delete_issue.assert_called_once()
+        assert monitor._active_issue_ids == set()
+
+    def test_recurring_condition_is_idempotent_for_ignored_issue(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """When the condition recurs after an ignored flap, no 'new issue' fires.
+
+        Without keeping the ignored id in ``_active_issue_ids``, the next
+        cycle that re-triggers the condition would compute the id as a
+        member of ``current - active`` and emit a fresh warning log even
+        though HA already silenced it. This guards the log behavior so
+        the integration stays quiet in ignored-issue steady state.
+        """
+        issue_id = self._seed_unavailable_issue(monitor)
+
+        # Flap: clear with the ignore flag present.
+        entity_ok = _make_entity(
+            "binary_sensor.tv",
+            InputType.MEDIA,
+            state="off",
+            last_updated=dt_util.utcnow(),
+            evidence=False,
+        )
+        with patch(
+            "custom_components.area_occupancy.data.health.ir",
+            self._patch_ir(ignored=True),
+        ):
+            monitor.check_health({"tv": entity_ok})
+
+        # Recurrence: condition is back, ignore flag still set.
+        entity_unavail = _make_entity(
+            "binary_sensor.tv",
+            InputType.MEDIA,
+            state=None,
+            last_updated=dt_util.utcnow() - timedelta(hours=5),
+            evidence=None,
+        )
+        monitor._unavailable_since[entity_unavail.entity_id] = (
+            dt_util.utcnow() - timedelta(hours=5)
+        )
+        with (
+            patch(
+                "custom_components.area_occupancy.data.health.ir",
+                self._patch_ir(ignored=True),
+            ),
+            patch(
+                "custom_components.area_occupancy.data.health._LOGGER"
+            ) as mock_logger,
+        ):
+            monitor.check_health({"tv": entity_unavail})
+
+        # No "New sensor health issues" warning — the id was already tracked.
+        warning_messages = [c.args[0] for c in mock_logger.warning.call_args_list]
+        assert not any("New sensor health issues" in msg for msg in warning_messages), (
+            warning_messages
+        )
+        assert issue_id in monitor._active_issue_ids


### PR DESCRIPTION
## Summary

Stops Home Assistant repair issues from re-appearing after the user clicks **Ignore** — the deeper root cause of #463.

When a repair issue's condition cleared (e.g. TV turned back on briefly), `_update_repair_issues` called `ir.async_delete_issue`, which also wiped HA's `is_ignored` flag. The next time the same condition recurred (TV unavailable again the following night), a fresh issue was created and the user's earlier "Ignore" was silently forgotten.

## Fix

- New `HealthMonitor._is_ignored(issue_id)` helper queries HA's issue registry for the `is_ignored` flag.
- `_update_repair_issues` partitions the "resolved" set into truly-resolved (delete) and user-ignored (skip).
- Ignored ids are kept in `_active_issue_ids` so a later recurrence isn't logged as a "new" issue — `async_create_issue` is idempotent and preserves HA's ignore flag on existing entries.
- The helper treats `is_ignored != True` as not-ignored, so a bare `unittest.mock.Mock()` placeholder for the `ir` module (used by older tests) doesn't accidentally suppress deletion.

## Closes / mitigates

- The "Ignore doesn't stick" half of #463 (the other half — sheer issue volume — is handled by the global toggle in #472 and saner defaults in the follow-up PR)

## Test plan

- [x] `tests/test_data_health.py::TestStickyIgnore` — 4 tests:
  - Ignored issue is not deleted when condition clears
  - Ignored id stays in `_active_issue_ids`
  - Non-ignored resolved issue still deleted (regression guard)
  - Recurring condition on ignored issue produces no "new issue" warning log
- [x] All 67 existing health tests still pass
- [x] `scripts/lint` clean

## Notes for reviewer

- No schema/config changes — purely runtime behavior.
- Can be merged independently of #472; they touch different parts of `health.py`. If both land, no conflict expected.
- The third PR in this series (saner defaults: motion threshold 2h→8h, purpose-aware multipliers, `media_player.*` exempt from unavailable) will land separately.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqRbdfJCFjxfN8oLEac8dj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Repair issues marked as ignored are preserved when their underlying health condition clears and are not deleted.
  * Ignored issues are not recreated if the underlying condition recurs, avoiding duplicate warnings.
  * Debug logging now indicates when ignored issues are intentionally preserved; internal tracking updated so ignored IDs remain suppressed across cycles.

* **Tests**
  * Added tests covering ignored repair-issue persistence, prevention of deletion for ignored issues, and idempotent handling on recurrence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hankanman/Area-Occupancy-Detection/pull/473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->