### PR TITLE
feat(health): purpose-aware stuck-active thresholds and saner defaults

### DIFF
--- a/custom_components/area_occupancy/area/area.py
+++ b/custom_components/area_occupancy/area/area.py
@@ -169,7 +169,10 @@ class Area:
         if self._health_monitor is None:
             area_id = self.config.area_id or self.area_name
             self._health_monitor = HealthMonitor(
-                self.area_name, area_id, self.coordinator.hass
+                self.area_name,
+                area_id,
+                self.coordinator.hass,
+                purpose=self.purpose.purpose,
             )
         return self._health_monitor
 

--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -27,6 +27,7 @@ from homeassistant.util import dt as dt_util
 
 from ..const import DOMAIN
 from .entity_type import BINARY_INPUT_TYPES, InputType
+from .purpose import AreaPurpose
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
@@ -47,15 +48,36 @@ _EXCLUDED_TYPES: set[InputType] = {
     InputType.SLEEP,
 }
 
-# How long a binary sensor can be stuck in its *active* state before flagging
+# How long a binary sensor can be stuck in its *active* state before flagging.
+# The motion default was 2h, which fired false-positives daily for bedrooms,
+# offices with stationary users, and any mmWave/presence sensor that
+# legitimately stays on for hours (#465, #468). 8h is a more realistic floor
+# for the base case; purpose-aware multipliers below extend it further for
+# rooms where long active periods are explicitly expected.
 STUCK_ACTIVE_THRESHOLDS: dict[InputType, timedelta] = {
-    InputType.MOTION: timedelta(hours=2),
+    InputType.MOTION: timedelta(hours=8),
     InputType.MEDIA: timedelta(hours=12),
     InputType.APPLIANCE: timedelta(hours=24),
     InputType.DOOR: timedelta(hours=48),
     InputType.WINDOW: timedelta(hours=72),
     InputType.COVER: timedelta(hours=24),
 }
+
+# Per-purpose multiplier applied on top of ``STUCK_ACTIVE_THRESHOLDS``. Rooms
+# where long stationary occupancy is normal (sleeping, relaxing, working) get
+# extended thresholds so a bedroom mmWave sensor doesn't trip every night
+# (#468). Purposes not listed use the base threshold unmodified.
+_PURPOSE_STUCK_ACTIVE_MULTIPLIER: dict[AreaPurpose, float] = {
+    AreaPurpose.SLEEPING: 6.0,  # 8h base × 6 = 48h for bedrooms
+    AreaPurpose.RELAXING: 4.0,  # 8h × 4 = 32h for media rooms
+    AreaPurpose.WORKING: 3.0,  # 8h × 3 = 24h for offices
+}
+
+# Entity-id domain prefixes whose ``unavailable`` state is normal operation
+# rather than a sensor fault. ``media_player.*`` becomes unavailable whenever
+# a TV or speaker is powered off — flagging that as a repair issue every
+# night was the root complaint behind #466's "TV off overnight" report.
+_UNAVAILABLE_EXEMPT_PREFIXES: tuple[str, ...] = ("media_player.",)
 
 # How long a binary sensor can remain *inactive* before flagging
 STUCK_INACTIVE_THRESHOLDS: dict[InputType, timedelta] = {
@@ -163,6 +185,24 @@ def _format_duration_human(hours: float) -> str:
     return f"{total_seconds // 86400}d"
 
 
+def _stuck_active_threshold(
+    input_type: InputType, purpose: AreaPurpose | None
+) -> timedelta | None:
+    """Return the stuck-active threshold for ``input_type`` in this area.
+
+    Applies ``_PURPOSE_STUCK_ACTIVE_MULTIPLIER`` if the area's purpose
+    expects long stationary occupancy. Returns ``None`` when ``input_type``
+    isn't tracked by the stuck-active check.
+    """
+    base = STUCK_ACTIVE_THRESHOLDS.get(input_type)
+    if base is None:
+        return None
+    multiplier = _PURPOSE_STUCK_ACTIVE_MULTIPLIER.get(purpose, 1.0) if purpose else 1.0
+    if multiplier == 1.0:
+        return base
+    return timedelta(seconds=base.total_seconds() * multiplier)
+
+
 def _issue_id(area_id: str, entity_id: str | None, issue_type: HealthIssueType) -> str:
     """Build a unique repair issue ID using the stable area_id.
 
@@ -188,17 +228,26 @@ class HealthMonitor:
     so issues survive area renames.
     """
 
-    def __init__(self, area_name: str, area_id: str, hass: HomeAssistant) -> None:
+    def __init__(
+        self,
+        area_name: str,
+        area_id: str,
+        hass: HomeAssistant,
+        purpose: AreaPurpose | None = None,
+    ) -> None:
         """Initialize health monitor for an area.
 
         Args:
             area_name: Human-readable area name (for log messages and translations)
             area_id: Stable HA area registry ID (for repair issue keys)
             hass: Home Assistant instance
+            purpose: Area purpose, used to scale stuck-active thresholds.
+                ``None`` falls back to the base thresholds (multiplier 1.0).
         """
         self._area_name = area_name
         self._area_id = area_id
         self._hass = hass
+        self._purpose = purpose
         self._issues: list[HealthIssue] = []
         self._checked_count: int = 0
         self._last_check: datetime | None = None
@@ -491,7 +540,7 @@ class HealthMonitor:
 
         # Check stuck active
         if evidence is True:
-            threshold = STUCK_ACTIVE_THRESHOLDS.get(entity.type.input_type)
+            threshold = _stuck_active_threshold(entity.type.input_type, self._purpose)
             if threshold and duration >= threshold:
                 hours = duration.total_seconds() / 3600
                 return HealthIssue(
@@ -539,7 +588,18 @@ class HealthMonitor:
         threshold the moment the source integration (Z2M, ESPHome, etc.)
         is slow to load on HA startup, producing a false-positive repair
         for every sensor in the area.
+
+        Some entity domains report ``unavailable`` as a normal off-state
+        (notably ``media_player.*`` for TVs and speakers that are simply
+        powered off) and are exempted via
+        ``_UNAVAILABLE_EXEMPT_PREFIXES``. This stops the repair from
+        firing every night a TV is off, which was the loudest complaint
+        in #466.
         """
+        if entity.entity_id.startswith(_UNAVAILABLE_EXEMPT_PREFIXES):
+            self._unavailable_since.pop(entity.entity_id, None)
+            return None
+
         if entity.available:
             # Recovered (or never was unavailable in this session) — clear
             # any tracked start so the next outage starts a fresh clock.

--- a/tests/test_data_health.py
+++ b/tests/test_data_health.py
@@ -12,10 +12,13 @@ from custom_components.area_occupancy.data.decay import Decay
 from custom_components.area_occupancy.data.entity import Entity
 from custom_components.area_occupancy.data.entity_type import EntityType, InputType
 from custom_components.area_occupancy.data.health import (
+    STUCK_ACTIVE_THRESHOLDS,
     HealthIssueType,
     HealthMonitor,
     _format_duration_human,
+    _stuck_active_threshold,
 )
+from custom_components.area_occupancy.data.purpose import AreaPurpose
 from homeassistant.const import STATE_ON
 from homeassistant.util import dt as dt_util
 
@@ -77,12 +80,12 @@ class TestStuckActive:
     """Tests for stuck active sensor detection."""
 
     def test_motion_stuck_active_above_threshold(self, monitor: HealthMonitor) -> None:
-        """Motion sensor stuck 'on' for 3h should trigger stuck_active."""
+        """Motion sensor stuck 'on' for 9h should trigger stuck_active (threshold 8h)."""
         entity = _make_entity(
             "binary_sensor.motion_1",
             InputType.MOTION,
             state="on",
-            last_updated=dt_util.utcnow() - timedelta(hours=3),
+            last_updated=dt_util.utcnow() - timedelta(hours=9),
             evidence=True,
         )
         with patch("custom_components.area_occupancy.data.health.ir"):
@@ -94,12 +97,12 @@ class TestStuckActive:
         assert issues[0].input_type == InputType.MOTION
 
     def test_motion_stuck_active_below_threshold(self, monitor: HealthMonitor) -> None:
-        """Motion sensor stuck 'on' for 1h should NOT trigger (below 2h threshold)."""
+        """Motion sensor stuck 'on' for 4h should NOT trigger (below 8h threshold)."""
         entity = _make_entity(
             "binary_sensor.motion_1",
             InputType.MOTION,
             state="on",
-            last_updated=dt_util.utcnow() - timedelta(hours=1),
+            last_updated=dt_util.utcnow() - timedelta(hours=4),
             evidence=True,
         )
         with patch("custom_components.area_occupancy.data.health.ir"):
@@ -702,7 +705,7 @@ class TestProperties:
             "binary_sensor.motion_1",
             InputType.MOTION,
             state="on",
-            last_updated=dt_util.utcnow() - timedelta(hours=5),
+            last_updated=dt_util.utcnow() - timedelta(hours=10),
             evidence=True,
         )
         with patch("custom_components.area_occupancy.data.health.ir"):
@@ -772,7 +775,7 @@ class TestNaiveLastUpdatedRegression:
             "binary_sensor.motion_1",
             InputType.MOTION,
             state="on",
-            last_updated=dt_util.utcnow() - timedelta(hours=3),
+            last_updated=dt_util.utcnow() - timedelta(hours=10),
             naive_last_updated=True,
             evidence=True,
         )
@@ -1362,3 +1365,144 @@ class TestStickyIgnore:
             warning_messages
         )
         assert issue_id in monitor._active_issue_ids
+
+
+class TestSanerDefaults:
+    """Regression guards on the tightened defaults shipped for #463 / #468."""
+
+    def test_motion_default_is_eight_hours(self) -> None:
+        """Motion stuck-active default must stay at 8h to silence #465/#468."""
+        assert STUCK_ACTIVE_THRESHOLDS[InputType.MOTION] == timedelta(hours=8)
+
+    def test_stuck_active_threshold_unmultiplied_for_social(self) -> None:
+        """SOCIAL areas use the base threshold (multiplier 1.0)."""
+        assert _stuck_active_threshold(InputType.MOTION, AreaPurpose.SOCIAL) == (
+            timedelta(hours=8)
+        )
+
+    def test_stuck_active_threshold_unmultiplied_for_none(self) -> None:
+        """An unset purpose also yields the base threshold."""
+        assert _stuck_active_threshold(InputType.MOTION, None) == timedelta(hours=8)
+
+    @pytest.mark.parametrize(
+        ("purpose", "expected_hours"),
+        [
+            (AreaPurpose.SLEEPING, 48),  # 8h × 6
+            (AreaPurpose.RELAXING, 32),  # 8h × 4
+            (AreaPurpose.WORKING, 24),  # 8h × 3
+        ],
+    )
+    def test_purpose_multipliers_extend_motion_threshold(
+        self, purpose: AreaPurpose, expected_hours: int
+    ) -> None:
+        """Purposes where long active periods are normal get longer thresholds."""
+        assert _stuck_active_threshold(InputType.MOTION, purpose) == timedelta(
+            hours=expected_hours
+        )
+
+
+class TestPurposeAwareStuckActive:
+    """End-to-end check: a sleeping-area monitor doesn't trip on 12h of motion."""
+
+    def test_sleeping_area_skips_stuck_active_at_twelve_hours(
+        self, mock_hass: Mock
+    ) -> None:
+        """12h is past the base 8h threshold but inside the 48h SLEEPING window."""
+        monitor = HealthMonitor(
+            "bedroom", "bedroom_id", mock_hass, purpose=AreaPurpose.SLEEPING
+        )
+        entity = _make_entity(
+            "binary_sensor.bedroom_mmwave",
+            InputType.MOTION,
+            state="on",
+            last_updated=dt_util.utcnow() - timedelta(hours=12),
+            evidence=True,
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"mmwave": entity})
+
+        assert issues == []
+
+    def test_sleeping_area_still_trips_above_multiplied_threshold(
+        self, mock_hass: Mock
+    ) -> None:
+        """49h crosses the 48h SLEEPING threshold and still flags."""
+        monitor = HealthMonitor(
+            "bedroom", "bedroom_id", mock_hass, purpose=AreaPurpose.SLEEPING
+        )
+        entity = _make_entity(
+            "binary_sensor.bedroom_mmwave",
+            InputType.MOTION,
+            state="on",
+            last_updated=dt_util.utcnow() - timedelta(hours=49),
+            evidence=True,
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"mmwave": entity})
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == HealthIssueType.STUCK_ACTIVE
+
+    def test_social_area_trips_at_nine_hours(self, mock_hass: Mock) -> None:
+        """SOCIAL uses the base 8h threshold so 9h still trips (regression guard)."""
+        monitor = HealthMonitor(
+            "lounge", "lounge_id", mock_hass, purpose=AreaPurpose.SOCIAL
+        )
+        entity = _make_entity(
+            "binary_sensor.lounge_motion",
+            InputType.MOTION,
+            state="on",
+            last_updated=dt_util.utcnow() - timedelta(hours=9),
+            evidence=True,
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"lounge_motion": entity})
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == HealthIssueType.STUCK_ACTIVE
+
+
+class TestMediaPlayerUnavailableExempt:
+    """`media_player.*` unavailable is normal (TV off); skip the repair (#466)."""
+
+    def test_media_player_unavailable_two_hours_is_not_flagged(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """A TV unavailable for 2h must not generate an UNAVAILABLE issue."""
+        entity = _make_entity(
+            "media_player.tv",
+            InputType.MEDIA,
+            state=None,
+            last_updated=dt_util.utcnow() - timedelta(hours=2),
+            evidence=None,
+        )
+        # Even if some prior cycle had marked it unavailable, the exempt
+        # path must clear that tracking and return no issue.
+        monitor._unavailable_since[entity.entity_id] = dt_util.utcnow() - timedelta(
+            hours=2
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"tv": entity})
+
+        assert issues == []
+        assert "media_player.tv" not in monitor._unavailable_since
+
+    def test_non_media_player_unavailable_still_flagged(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """A regular binary_sensor unavailable for 2h still flags (regression guard)."""
+        entity = _make_entity(
+            "binary_sensor.contact",
+            InputType.DOOR,
+            state=None,
+            last_updated=dt_util.utcnow() - timedelta(hours=2),
+            evidence=None,
+        )
+        monitor._unavailable_since[entity.entity_id] = dt_util.utcnow() - timedelta(
+            hours=2
+        )
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_health({"contact": entity})
+
+        assert len(issues) == 1
+        assert issues[0].issue_type == HealthIssueType.UNAVAILABLE


### PR DESCRIPTION
## Summary

Three coordinated changes that close the false-positive cluster in #465, #466, and #468 without exposing any new configuration.

| Change | Effect |
| --- | --- |
| Motion stuck-active default `2h` → `8h` | Stops bedrooms/offices/mmWave sensors tripping daily |
| Per-purpose multiplier (`SLEEPING` 6×, `RELAXING` 4×, `WORKING` 3×) | Bedroom motion now needs **48 h** to flag, media room 32 h, office 24 h |
| `media_player.*` exempt from the unavailable check | TVs powered off overnight no longer raise repairs |

`HealthMonitor` takes an optional `purpose: AreaPurpose | None = None` arg (defaults preserve existing test behaviour). `Area.health_monitor` passes `self.purpose.purpose` at construction.

## Why

- `#468`: bedroom mmWave reports active for hours during sleep; under the old 2h threshold this flagged every night.
- `#465`: same pattern, different reporter.
- `#466`: explicit "TV off overnight" complaint; `media_player.tv` going `unavailable` is normal, not a fault.
- The user-facing fixes (toggle in #472, sticky-ignore in #473) help, but better defaults mean far fewer users will need either.

## Test plan

- [x] `tests/test_data_health.py::TestSanerDefaults` — 5 tests: motion default is 8h; `_stuck_active_threshold` returns base for SOCIAL/None; parametrised multiplier check for SLEEPING/RELAXING/WORKING
- [x] `tests/test_data_health.py::TestPurposeAwareStuckActive` — 3 tests: SLEEPING area skips at 12h, still trips at 49h; SOCIAL still trips at 9h (regression guard)
- [x] `tests/test_data_health.py::TestMediaPlayerUnavailableExempt` — 2 tests: TV unavailable 2h is silenced and tracking cleared; non-media-player binary sensor still flagged
- [x] Two existing tests updated to reflect the new 8h motion floor (`test_motion_stuck_active_above_threshold` 3h → 9h, `test_motion_stuck_active_below_threshold` 1h → 4h, `test_check_stuck_sensor_with_naive_input` 3h → 10h, `test_has_critical_issues` 5h → 10h)
- [x] All 74 health tests + 25 area tests pass
- [x] `scripts/lint` clean

## Notes

- No config schema changes; defaults change is internal.
- Can be merged independently of #472 and #473; conflict-free where the diffs overlap (mostly additive).
- If you prefer different multipliers (e.g. SLEEPING 8× to give 64h), it's a one-line table edit — happy to adjust.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PqRbdfJCFjxfN8oLEac8dj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Health monitoring now respects each area’s configured purpose (sleeping, social, working, relaxing) to scale stuck-active timeouts.
  * Default stuck-active thresholds increased (e.g. motion sensors) to reduce false stuck-active reports.
  * Purpose-aware thresholds adjust sensitivity so sleeping/relaxing areas are less likely to flag long-idle sensors.

* **Bug Fixes**
  * Media player devices (TVs, speakers) no longer trigger false “unavailable” repair issues when normally powered off.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hankanman/Area-Occupancy-Detection/pull/474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->