### PR TITLE
chore: bump version to 2026.5.17

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -29,7 +29,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
 # Device information
 DEVICE_MANUFACTURER: Final = "Hankanman"
 DEVICE_MODEL: Final = "Area Occupancy Detector"
-DEVICE_SW_VERSION: Final = "2026.5.2"
+DEVICE_SW_VERSION: Final = "2026.5.17"
 CONF_VERSION: Final = 18
 CONF_VERSION_MINOR: Final = 0
 HA_RECORDER_DAYS: Final = 10  # days

--- a/custom_components/area_occupancy/manifest.json
+++ b/custom_components/area_occupancy/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/Hankanman/Area-Occupancy-Detection/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2026.5.2"
+  "version": "2026.5.17"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "area-occupancy-detection"
-version = "2026.5.2"
+version = "2026.5.17"
 license = "Apache-2.0"
 description = "Home Assistant integration for intelligent room occupancy detection using Bayesian probability."
 readme = "README.md"  # Assuming you'll have a README.md


### PR DESCRIPTION
## Summary

Bumps version `2026.5.2` → `2026.5.17` across the three canonical locations called out in CLAUDE.md.

| File | Field |
| --- | --- |
| `pyproject.toml` | `[project] version` |
| `custom_components/area_occupancy/manifest.json` | `version` |
| `custom_components/area_occupancy/const.py` | `DEVICE_SW_VERSION` |

Rolls up the recent batch of merged work into a tagged release:

- #472 — integration-level toggle to disable repair monitoring
- #473 — preserve user-ignored repairs across condition flaps
- #474 — purpose-aware stuck-active thresholds and saner defaults
- (plus the diagnostics export, pipeline health checks, parallel correlation, and Reset Learning button series)

`CONF_VERSION` / `CONF_VERSION_MINOR` are unchanged — no config migration needed for this release.

## Test plan

- [x] `grep -rn "2026.5.2"` returns no stragglers in code/docs/config
- [x] Pre-commit hooks (ruff format + check) pass on the commit
- [ ] CI green (Lint, Test, Hassfest, HACS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated integration version to 2026.5.17.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Hankanman/Area-Occupancy-Detection/pull/475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->