### PR TITLE
feat: configurable sensor state precision to reduce recorder load

### DIFF
--- a/custom_components/area_occupancy/config_flow.py
+++ b/custom_components/area_occupancy/config_flow.py
@@ -85,6 +85,7 @@ from .const import (
     CONF_POWER_SENSORS,
     CONF_PRESSURE_SENSORS,
     CONF_PURPOSE,
+    CONF_SENSOR_PRECISION,
     CONF_SLEEP_END,
     CONF_SLEEP_START,
     CONF_SOUND_PRESSURE_SENSORS,
@@ -120,6 +121,7 @@ from .const import (
     DEFAULT_MOTION_PROB_GIVEN_TRUE,
     DEFAULT_MOTION_TIMEOUT,
     DEFAULT_PURPOSE,
+    DEFAULT_SENSOR_PRECISION,
     DEFAULT_SLEEP_CONFIDENCE_THRESHOLD,
     DEFAULT_SLEEP_END,
     DEFAULT_SLEEP_START,
@@ -1830,6 +1832,20 @@ def _create_global_settings_schema(defaults: dict[str, Any]) -> vol.Schema:
                 CONF_HEALTH_ENABLED,
                 default=defaults.get(CONF_HEALTH_ENABLED, DEFAULT_HEALTH_ENABLED),
             ): BooleanSelector(),
+            vol.Required(
+                CONF_SENSOR_PRECISION,
+                default=defaults.get(CONF_SENSOR_PRECISION, DEFAULT_SENSOR_PRECISION),
+            ): vol.All(
+                NumberSelector(
+                    NumberSelectorConfig(
+                        min=0,
+                        max=2,
+                        step=1,
+                        mode=NumberSelectorMode.BOX,
+                    )
+                ),
+                vol.Coerce(int),
+            ),
         }
     )
 
@@ -2851,6 +2867,10 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
     ) -> ConfigFlowResult:
         """Manage global settings."""
         if user_input is not None:
+            # Validate and coerce using the schema
+            schema = _create_global_settings_schema(self.config_entry.options)
+            user_input = schema(user_input)
+
             # Update the config entry options directly
             new_options = dict(self.config_entry.options)
             new_options.update(user_input)
@@ -2867,6 +2887,9 @@ class AreaOccupancyOptionsFlow(OptionsFlow, BaseOccupancyFlow):
             ),
             CONF_HEALTH_ENABLED: self.config_entry.options.get(
                 CONF_HEALTH_ENABLED, DEFAULT_HEALTH_ENABLED
+            ),
+            CONF_SENSOR_PRECISION: self.config_entry.options.get(
+                CONF_SENSOR_PRECISION, DEFAULT_SENSOR_PRECISION
             ),
         }
 

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -229,6 +229,8 @@ SLEEP_PROB_GIVEN_FALSE: Final[float] = 0.02
 
 # Helper constants
 ROUNDING_PRECISION: Final = 2
+CONF_SENSOR_PRECISION: Final = "sensor_precision"
+DEFAULT_SENSOR_PRECISION: Final = ROUNDING_PRECISION
 
 # Performance optimization constants
 DEFAULT_LOOKBACK_DAYS: Final = 60  # Days of interval data to load for analysis

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -52,6 +52,7 @@ from ..const import (
     CONF_PURPOSE,
     CONF_SLEEP_END,
     CONF_SLEEP_START,
+    CONF_SENSOR_PRECISION,
     CONF_SOUND_PRESSURE_SENSORS,
     CONF_TEMPERATURE_SENSORS,
     CONF_THRESHOLD,
@@ -85,6 +86,7 @@ from ..const import (
     DEFAULT_MOTION_PROB_GIVEN_TRUE,
     DEFAULT_MOTION_TIMEOUT,
     DEFAULT_PURPOSE,
+    DEFAULT_SENSOR_PRECISION,
     DEFAULT_SLEEP_CONFIDENCE_THRESHOLD,
     DEFAULT_SLEEP_END,
     DEFAULT_SLEEP_START,
@@ -193,6 +195,19 @@ class IntegrationConfig:
         return bool(
             self.config_entry.options.get(CONF_HEALTH_ENABLED, DEFAULT_HEALTH_ENABLED)
         )
+
+    @property
+    def sensor_precision(self) -> int:
+        """Get global sensor state precision from config entry options."""
+        try:
+            return int(
+                self.config_entry.options.get(
+                    CONF_SENSOR_PRECISION, DEFAULT_SENSOR_PRECISION
+                )
+            )
+        except (ValueError, TypeError):
+            return DEFAULT_SENSOR_PRECISION
+
 
     @property
     def people(self) -> list[PersonConfig]:

--- a/custom_components/area_occupancy/data/config.py
+++ b/custom_components/area_occupancy/data/config.py
@@ -50,9 +50,9 @@ from ..const import (
     CONF_POWER_SENSORS,
     CONF_PRESSURE_SENSORS,
     CONF_PURPOSE,
+    CONF_SENSOR_PRECISION,
     CONF_SLEEP_END,
     CONF_SLEEP_START,
-    CONF_SENSOR_PRECISION,
     CONF_SOUND_PRESSURE_SENSORS,
     CONF_TEMPERATURE_SENSORS,
     CONF_THRESHOLD,
@@ -198,16 +198,16 @@ class IntegrationConfig:
 
     @property
     def sensor_precision(self) -> int:
-        """Get global sensor state precision from config entry options."""
+        """Get global sensor state precision (clamped to 0-2) from config entry options."""
         try:
-            return int(
+            precision = int(
                 self.config_entry.options.get(
                     CONF_SENSOR_PRECISION, DEFAULT_SENSOR_PRECISION
                 )
             )
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             return DEFAULT_SENSOR_PRECISION
-
+        return max(0, min(2, precision))
 
     @property
     def people(self) -> list[PersonConfig]:

--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -97,6 +97,13 @@ class AreaOccupancySensorBase(CoordinatorEntity, SensorEntity):
             return None
         return self._area_handle.resolve()
 
+    def _get_sensor_precision(self) -> int:
+        """Return configured sensor precision with safe fallback."""
+        try:
+            return self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            return DEFAULT_SENSOR_PRECISION
+
 
 class PriorsSensor(AreaOccupancySensorBase):
     """Combined sensor for all priors."""
@@ -123,10 +130,7 @@ class PriorsSensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the overall occupancy prior as the state."""
-        try:
-            precision = self.coordinator.integration_config.sensor_precision
-        except AttributeError:
-            precision = DEFAULT_SENSOR_PRECISION
+        precision = self._get_sensor_precision()
 
         if self._all_areas is not None:
             return format_float(self._all_areas.area_prior() * 100, precision)
@@ -192,10 +196,7 @@ class ProbabilitySensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the current occupancy probability as a percentage."""
-        try:
-            precision = self.coordinator.integration_config.sensor_precision
-        except AttributeError:
-            precision = DEFAULT_SENSOR_PRECISION
+        precision = self._get_sensor_precision()
 
         if self._all_areas is not None:
             return format_float(self._all_areas.probability() * 100, precision)
@@ -352,10 +353,7 @@ class DecaySensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the decay status as a percentage."""
-        try:
-            precision = self.coordinator.integration_config.sensor_precision
-        except AttributeError:
-            precision = DEFAULT_SENSOR_PRECISION
+        precision = self._get_sensor_precision()
 
         if self._all_areas is not None:
             decay_value = self._all_areas.decay()
@@ -427,10 +425,7 @@ class PresenceProbabilitySensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the presence probability as a percentage."""
-        try:
-            precision = self.coordinator.integration_config.sensor_precision
-        except AttributeError:
-            precision = DEFAULT_SENSOR_PRECISION
+        precision = self._get_sensor_precision()
 
         if self._all_areas is not None:
             return format_float(self._all_areas.presence_probability() * 100, precision)
@@ -469,13 +464,12 @@ class EnvironmentalConfidenceSensor(AreaOccupancySensorBase):
         >50% means environmental data supports occupancy.
         <50% means environmental data opposes occupancy.
         """
-        try:
-            precision = self.coordinator.integration_config.sensor_precision
-        except AttributeError:
-            precision = DEFAULT_SENSOR_PRECISION
+        precision = self._get_sensor_precision()
 
         if self._all_areas is not None:
-            return format_float(self._all_areas.environmental_confidence() * 100, precision)
+            return format_float(
+                self._all_areas.environmental_confidence() * 100, precision
+            )
         area = self._get_area()
         if area is None:
             return None
@@ -549,10 +543,7 @@ class ActivityConfidenceSensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the activity confidence as a percentage."""
-        try:
-            precision = self.coordinator.integration_config.sensor_precision
-        except AttributeError:
-            precision = DEFAULT_SENSOR_PRECISION
+        precision = self._get_sensor_precision()
 
         area = self._get_area()
         if area is None:

--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .area import AllAreas, AreaDeviceHandle, FloorAreas
-from .const import ALL_AREAS_IDENTIFIER
+from .const import ALL_AREAS_IDENTIFIER, DEFAULT_SENSOR_PRECISION
 from .data.activity import ActivityId
 from .data.entity_type import InputType
 from .utils import format_float, format_percentage, generate_entity_unique_id
@@ -123,12 +123,17 @@ class PriorsSensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the overall occupancy prior as the state."""
+        try:
+            precision = self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            precision = DEFAULT_SENSOR_PRECISION
+
         if self._all_areas is not None:
-            return format_float(self._all_areas.area_prior() * 100)
+            return format_float(self._all_areas.area_prior() * 100, precision)
         area = self._get_area()
         if area is None:
             return None
-        return format_float(area.area_prior() * 100)
+        return format_float(area.area_prior() * 100, precision)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -187,12 +192,17 @@ class ProbabilitySensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the current occupancy probability as a percentage."""
+        try:
+            precision = self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            precision = DEFAULT_SENSOR_PRECISION
+
         if self._all_areas is not None:
-            return format_float(self._all_areas.probability() * 100)
+            return format_float(self._all_areas.probability() * 100, precision)
         area = self._get_area()
         if area is None:
             return None
-        return format_float(area.probability() * 100)
+        return format_float(area.probability() * 100, precision)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -342,6 +352,11 @@ class DecaySensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the decay status as a percentage."""
+        try:
+            precision = self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            precision = DEFAULT_SENSOR_PRECISION
+
         if self._all_areas is not None:
             decay_value = self._all_areas.decay()
         else:
@@ -349,7 +364,7 @@ class DecaySensor(AreaOccupancySensorBase):
             if area is None:
                 return None
             decay_value = area.decay()
-        return format_float((1 - decay_value) * 100)
+        return format_float((1 - decay_value) * 100, precision)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -412,12 +427,17 @@ class PresenceProbabilitySensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the presence probability as a percentage."""
+        try:
+            precision = self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            precision = DEFAULT_SENSOR_PRECISION
+
         if self._all_areas is not None:
-            return format_float(self._all_areas.presence_probability() * 100)
+            return format_float(self._all_areas.presence_probability() * 100, precision)
         area = self._get_area()
         if area is None:
             return None
-        return format_float(area.presence_probability() * 100)
+        return format_float(area.presence_probability() * 100, precision)
 
 
 class EnvironmentalConfidenceSensor(AreaOccupancySensorBase):
@@ -449,12 +469,17 @@ class EnvironmentalConfidenceSensor(AreaOccupancySensorBase):
         >50% means environmental data supports occupancy.
         <50% means environmental data opposes occupancy.
         """
+        try:
+            precision = self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            precision = DEFAULT_SENSOR_PRECISION
+
         if self._all_areas is not None:
-            return format_float(self._all_areas.environmental_confidence() * 100)
+            return format_float(self._all_areas.environmental_confidence() * 100, precision)
         area = self._get_area()
         if area is None:
             return None
-        return format_float(area.environmental_confidence() * 100)
+        return format_float(area.environmental_confidence() * 100, precision)
 
 
 class DetectedActivitySensor(AreaOccupancySensorBase):
@@ -524,10 +549,15 @@ class ActivityConfidenceSensor(AreaOccupancySensorBase):
     @property
     def native_value(self) -> float | None:
         """Return the activity confidence as a percentage."""
+        try:
+            precision = self.coordinator.integration_config.sensor_precision
+        except AttributeError:
+            precision = DEFAULT_SENSOR_PRECISION
+
         area = self._get_area()
         if area is None:
             return None
-        return format_float(area.detected_activity().confidence * 100)
+        return format_float(area.detected_activity().confidence * 100, precision)
 
 
 class SensorHealthSensor(AreaOccupancySensorBase):

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -783,12 +783,14 @@
                 "data": {
                     "sleep_start": "Sleep Start Time",
                     "sleep_end": "Sleep End Time",
-                    "health_enabled": "Sensor health monitoring"
+                    "health_enabled": "Sensor health monitoring",
+                    "sensor_precision": "Sensor state precision (decimals)"
                 },
                 "data_description": {
                     "sleep_start": "The time when your sleep schedule begins. Areas with the 'Sleeping' purpose will use their configured decay half-life during this period.",
                     "sleep_end": "The time when your sleep schedule ends. Areas with the 'Sleeping' purpose will behave like 'Relaxing' areas outside of sleep hours.",
-                    "health_enabled": "When enabled, the integration raises Home Assistant repair issues for stuck, unavailable, or never-triggered sensors and for slow or failing analysis cycles. Turn off to silence all repairs from this integration; previously raised issues will be cleared on the next analysis cycle."
+                    "health_enabled": "When enabled, the integration raises Home Assistant repair issues for stuck, unavailable, or never-triggered sensors and for slow or failing analysis cycles. Turn off to silence all repairs from this integration; previously raised issues will be cleared on the next analysis cycle.",
+                    "sensor_precision": "Lower values significantly reduce recorder database writes from diagnostic sensors. 0 is recommended unless you need sub-percent resolution."
                 }
             },
             "manage_people": {

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -784,12 +784,14 @@
                 "data": {
                     "sleep_start": "Sleep Start Time",
                     "sleep_end": "Sleep End Time",
-                    "health_enabled": "Sensor health monitoring"
+                    "health_enabled": "Sensor health monitoring",
+                    "sensor_precision": "Sensor state precision (decimals)"
                 },
                 "data_description": {
                     "sleep_start": "The time when your sleep schedule begins. Areas with the 'Sleeping' purpose will use their configured decay half-life during this period.",
                     "sleep_end": "The time when your sleep schedule ends. Areas with the 'Sleeping' purpose will behave like 'Relaxing' areas outside of sleep hours.",
-                    "health_enabled": "When enabled, the integration raises Home Assistant repair issues for stuck, unavailable, or never-triggered sensors and for slow or failing analysis cycles. Turn off to silence all repairs from this integration; previously raised issues will be cleared on the next analysis cycle."
+                    "health_enabled": "When enabled, the integration raises Home Assistant repair issues for stuck, unavailable, or never-triggered sensors and for slow or failing analysis cycles. Turn off to silence all repairs from this integration; previously raised issues will be cleared on the next analysis cycle.",
+                    "sensor_precision": "Lower values significantly reduce recorder database writes from diagnostic sensors. 0 is recommended unless you need sub-percent resolution."
                 }
             },
             "manage_people": {

--- a/custom_components/area_occupancy/utils.py
+++ b/custom_components/area_occupancy/utils.py
@@ -20,9 +20,9 @@ if TYPE_CHECKING:
     from .data.entity import Entity
 
 
-def format_float(value: float) -> float:
+def format_float(value: float, precision: int = ROUNDING_PRECISION) -> float:
     """Format float value."""
-    return round(float(value), ROUNDING_PRECISION)
+    return round(float(value), precision)
 
 
 def format_percentage(value: float) -> str:

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -40,6 +40,9 @@ You can override the resulting half-life in the Detection Behavior step if neede
 **Global Sleep Schedule:**
 For areas with the `Bedroom` purpose, the half-life dynamically adjusts based on your configured sleep schedule. You can set your household’s `Sleep Start` and `Sleep End` times in the **Global Settings** menu (accessible via the main integration options). Outside of sleep hours, `Bedroom` areas behave like `Living Room` areas.
 
+**Sensor State Precision:**
+To reduce database writes and storage consumption in the Home Assistant recorder, you can configure the global `Sensor state precision (decimals)` setting (0-2 decimals, default: 2) in the **Global Settings** menu. Lowering this value rounds the state of numeric diagnostic sensors (like probability, prior, decay, and confidence sensors), significantly reducing the volume of database updates.
+
 ### Step 2: Motion Sensors
 
 Configure motion and presence sensors for the area. At least one motion sensor is required. You can also adjust:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1347,6 +1347,7 @@ class TestAreaOccupancyOptionsFlow:
         from custom_components.area_occupancy.const import (
             CONF_SLEEP_END,
             CONF_SLEEP_START,
+            CONF_SENSOR_PRECISION,
         )
 
         flow = config_flow_options_flow
@@ -1356,12 +1357,14 @@ class TestAreaOccupancyOptionsFlow:
         flow.config_entry.options = {
             CONF_SLEEP_START: "22:00:00",
             CONF_SLEEP_END: "07:00:00",
+            CONF_SENSOR_PRECISION: 2,
         }
 
         # Update global settings
         user_input = {
             CONF_SLEEP_START: "23:00:00",
             CONF_SLEEP_END: "08:00:00",
+            CONF_SENSOR_PRECISION: 1.0,  # Float value to test vol.Coerce(int)
         }
 
         result = await flow.async_step_global_settings(user_input)
@@ -1371,6 +1374,8 @@ class TestAreaOccupancyOptionsFlow:
         result_data = result["data"]
         assert result_data[CONF_SLEEP_START] == "23:00:00"
         assert result_data[CONF_SLEEP_END] == "08:00:00"
+        assert result_data[CONF_SENSOR_PRECISION] == 1
+        assert isinstance(result_data[CONF_SENSOR_PRECISION], int)
 
     async def test_options_flow_area_action_menu_includes_reset_learning(
         self,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1345,9 +1345,9 @@ class TestAreaOccupancyOptionsFlow:
     ):
         """Test that global settings are actually saved."""
         from custom_components.area_occupancy.const import (
+            CONF_SENSOR_PRECISION,
             CONF_SLEEP_END,
             CONF_SLEEP_START,
-            CONF_SENSOR_PRECISION,
         )
 
         flow = config_flow_options_flow

--- a/tests/test_data_config.py
+++ b/tests/test_data_config.py
@@ -32,6 +32,7 @@ from custom_components.area_occupancy.const import (
     CONF_POWER_SENSORS,
     CONF_PRESSURE_SENSORS,
     CONF_PURPOSE,
+    CONF_SENSOR_PRECISION,
     CONF_SLEEP_END,
     CONF_SLEEP_START,
     CONF_SOUND_PRESSURE_SENSORS,
@@ -48,6 +49,7 @@ from custom_components.area_occupancy.const import (
     CONF_WEIGHT_WINDOW,
     CONF_WINDOW_SENSORS,
     DECAY_INTERVAL,
+    DEFAULT_SENSOR_PRECISION,
     DEFAULT_SLEEP_CONFIDENCE_THRESHOLD,
     DEFAULT_SLEEP_END,
     DEFAULT_SLEEP_START,
@@ -1070,6 +1072,7 @@ class TestIntegrationConfig:
         [
             ("sleep_start", CONF_SLEEP_START, DEFAULT_SLEEP_START, "22:00:00"),
             ("sleep_end", CONF_SLEEP_END, DEFAULT_SLEEP_END, "08:00:00"),
+            ("sensor_precision", CONF_SENSOR_PRECISION, DEFAULT_SENSOR_PRECISION, 1),
         ],
     )
     def test_sleep_properties(
@@ -1081,7 +1084,7 @@ class TestIntegrationConfig:
         default_value: str,
         custom_value: str,
     ) -> None:
-        """Test sleep_start and sleep_end properties read from config entry options."""
+        """Test sleep_start, sleep_end, and sensor_precision properties read from config entry options."""
         coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
         integration_config = IntegrationConfig(coordinator, mock_realistic_config_entry)
 
@@ -1092,6 +1095,22 @@ class TestIntegrationConfig:
         mock_realistic_config_entry.options = {config_key: custom_value}
         integration_config = IntegrationConfig(coordinator, mock_realistic_config_entry)
         assert getattr(integration_config, property_name) == custom_value
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        ["invalid", None, [], {}, "1.5"],
+    )
+    def test_sensor_precision_fallback(
+        self,
+        hass: HomeAssistant,
+        mock_realistic_config_entry: Mock,
+        invalid_value: Any,
+    ) -> None:
+        """Test that sensor_precision falls back to default on ValueError or TypeError."""
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        mock_realistic_config_entry.options = {CONF_SENSOR_PRECISION: invalid_value}
+        integration_config = IntegrationConfig(coordinator, mock_realistic_config_entry)
+        assert integration_config.sensor_precision == DEFAULT_SENSOR_PRECISION
 
     def test_integration_name_from_config_entry(
         self, hass: HomeAssistant, mock_realistic_config_entry: Mock

--- a/tests/test_data_config.py
+++ b/tests/test_data_config.py
@@ -1098,7 +1098,7 @@ class TestIntegrationConfig:
 
     @pytest.mark.parametrize(
         "invalid_value",
-        ["invalid", None, [], {}, "1.5"],
+        ["invalid", None, [], {}, "1.5", float("inf"), float("nan")],
     )
     def test_sensor_precision_fallback(
         self,
@@ -1106,11 +1106,33 @@ class TestIntegrationConfig:
         mock_realistic_config_entry: Mock,
         invalid_value: Any,
     ) -> None:
-        """Test that sensor_precision falls back to default on ValueError or TypeError."""
+        """Test that sensor_precision falls back to default on ValueError, TypeError or OverflowError."""
         coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
         mock_realistic_config_entry.options = {CONF_SENSOR_PRECISION: invalid_value}
         integration_config = IntegrationConfig(coordinator, mock_realistic_config_entry)
         assert integration_config.sensor_precision == DEFAULT_SENSOR_PRECISION
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (-1, 0),
+            (3, 2),
+            (5, 2),
+            (-10, 0),
+        ],
+    )
+    def test_sensor_precision_clamping(
+        self,
+        hass: HomeAssistant,
+        mock_realistic_config_entry: Mock,
+        value: int,
+        expected: int,
+    ) -> None:
+        """Test that sensor_precision correctly clamps out-of-range integers."""
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        mock_realistic_config_entry.options = {CONF_SENSOR_PRECISION: value}
+        integration_config = IntegrationConfig(coordinator, mock_realistic_config_entry)
+        assert integration_config.sensor_precision == expected
 
     def test_integration_name_from_config_entry(
         self, hass: HomeAssistant, mock_realistic_config_entry: Mock

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1027,12 +1027,12 @@ class TestSensorIntegration:
         self, coordinator_with_sensors: AreaOccupancyCoordinator
     ) -> None:
         """Test that diagnostic sensors round their native_value based on sensor_precision setting."""
-        from custom_components.area_occupancy.sensor import (
-            PresenceProbabilitySensor,
-            EnvironmentalConfidenceSensor,
-            ActivityConfidenceSensor,
-        )
         from custom_components.area_occupancy.const import CONF_SENSOR_PRECISION
+        from custom_components.area_occupancy.sensor import (
+            ActivityConfidenceSensor,
+            EnvironmentalConfidenceSensor,
+            PresenceProbabilitySensor,
+        )
 
         area_name = coordinator_with_sensors.get_area_names()[0]
         area = coordinator_with_sensors.get_area(area_name)
@@ -1057,17 +1057,21 @@ class TestSensorIntegration:
         area.decay = Mock(return_value=0.154321)
         area.presence_probability = Mock(return_value=0.456789)
         area.environmental_confidence = Mock(return_value=0.554321)
-        
+
         mock_activity = Mock()
         mock_activity.confidence = 0.756789
         area.detected_activity = Mock(return_value=mock_activity)
 
         # Backup original options
-        original_options = coordinator_with_sensors.integration_config.config_entry.options
+        original_options = (
+            coordinator_with_sensors.integration_config.config_entry.options
+        )
 
         try:
             # 1. Test precision = 2 (default)
-            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 2}
+            coordinator_with_sensors.integration_config.config_entry.options = {
+                CONF_SENSOR_PRECISION: 2
+            }
             assert probability_sensor.native_value == 65.43
             assert priors_sensor.native_value == 35.68
             assert decay_sensor.native_value == 84.57
@@ -1076,7 +1080,9 @@ class TestSensorIntegration:
             assert activity_sensor.native_value == 75.68
 
             # 2. Test precision = 1
-            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 1}
+            coordinator_with_sensors.integration_config.config_entry.options = {
+                CONF_SENSOR_PRECISION: 1
+            }
             assert probability_sensor.native_value == 65.4
             assert priors_sensor.native_value == 35.7
             assert decay_sensor.native_value == 84.6
@@ -1085,7 +1091,9 @@ class TestSensorIntegration:
             assert activity_sensor.native_value == 75.7
 
             # 3. Test precision = 0
-            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 0}
+            coordinator_with_sensors.integration_config.config_entry.options = {
+                CONF_SENSOR_PRECISION: 0
+            }
             assert probability_sensor.native_value == 65.0
             assert priors_sensor.native_value == 36.0
             assert decay_sensor.native_value == 85.0
@@ -1093,7 +1101,9 @@ class TestSensorIntegration:
             assert env_sensor.native_value == 55.0
             assert activity_sensor.native_value == 76.0
         finally:
-            coordinator_with_sensors.integration_config.config_entry.options = original_options
+            coordinator_with_sensors.integration_config.config_entry.options = (
+                original_options
+            )
 
     def test_occupancy_decoupled_from_precision(
         self, coordinator_with_sensors: AreaOccupancyCoordinator
@@ -1103,29 +1113,35 @@ class TestSensorIntegration:
 
         area_name = coordinator_with_sensors.get_area_names()[0]
         area = coordinator_with_sensors.get_area(area_name)
-        
+
         # Set threshold to 65% (0.65)
         # Set base probability to 0.649 -> 64.9% (below threshold)
         # However, if precision = 1, it rounds to 65.0%
         # Or if precision = 0, it rounds to 65.0% (exactly at threshold)
         area.config.threshold = 0.65
-        
+
         # Mock probability to return 0.649 (unrounded raw value)
         area.probability = Mock(return_value=0.649)
-        
+
         # Backup original options
-        original_options = coordinator_with_sensors.integration_config.config_entry.options
+        original_options = (
+            coordinator_with_sensors.integration_config.config_entry.options
+        )
 
         try:
             # Even with precision = 0 (which rounds 64.9 to 65.0), area.occupied() should use raw probability 0.649 and return False.
-            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 0}
+            coordinator_with_sensors.integration_config.config_entry.options = {
+                CONF_SENSOR_PRECISION: 0
+            }
             assert area.occupied() is False
 
             # If probability is 0.651, area.occupied() should return True, regardless of precision
             area.probability = Mock(return_value=0.651)
             assert area.occupied() is True
         finally:
-            coordinator_with_sensors.integration_config.config_entry.options = original_options
+            coordinator_with_sensors.integration_config.config_entry.options = (
+                original_options
+            )
 
 
 class TestSensorErrorHandling:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1023,6 +1023,110 @@ class TestSensorIntegration:
         decay_sensor = DecaySensor(area_handle=handle)
         assert decay_sensor.extra_state_attributes == {}
 
+    def test_sensor_precision_rounding(
+        self, coordinator_with_sensors: AreaOccupancyCoordinator
+    ) -> None:
+        """Test that diagnostic sensors round their native_value based on sensor_precision setting."""
+        from custom_components.area_occupancy.sensor import (
+            PresenceProbabilitySensor,
+            EnvironmentalConfidenceSensor,
+            ActivityConfidenceSensor,
+        )
+        from custom_components.area_occupancy.const import CONF_SENSOR_PRECISION
+
+        area_name = coordinator_with_sensors.get_area_names()[0]
+        area = coordinator_with_sensors.get_area(area_name)
+        handle = coordinator_with_sensors.get_area_handle(area_name)
+
+        probability_sensor = ProbabilitySensor(area_handle=handle)
+        priors_sensor = PriorsSensor(area_handle=handle)
+        decay_sensor = DecaySensor(area_handle=handle)
+        presence_sensor = PresenceProbabilitySensor(area_handle=handle)
+        env_sensor = EnvironmentalConfidenceSensor(area_handle=handle)
+        activity_sensor = ActivityConfidenceSensor(area_handle=handle)
+
+        # Set up mock methods that return exact values with high precision fraction:
+        # Probability = 0.654321 -> 65.4321%
+        # Prior = 0.356789 -> 35.6789%
+        # Decay = 0.154321 -> (1 - 0.154321) * 100 = 84.5679%
+        # Presence = 0.456789 -> 45.6789%
+        # Env Confidence = 0.554321 -> 55.4321%
+        # Activity Confidence = 0.756789 -> 75.6789%
+        area.probability = Mock(return_value=0.654321)
+        area.area_prior = Mock(return_value=0.356789)
+        area.decay = Mock(return_value=0.154321)
+        area.presence_probability = Mock(return_value=0.456789)
+        area.environmental_confidence = Mock(return_value=0.554321)
+        
+        mock_activity = Mock()
+        mock_activity.confidence = 0.756789
+        area.detected_activity = Mock(return_value=mock_activity)
+
+        # Backup original options
+        original_options = coordinator_with_sensors.integration_config.config_entry.options
+
+        try:
+            # 1. Test precision = 2 (default)
+            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 2}
+            assert probability_sensor.native_value == 65.43
+            assert priors_sensor.native_value == 35.68
+            assert decay_sensor.native_value == 84.57
+            assert presence_sensor.native_value == 45.68
+            assert env_sensor.native_value == 55.43
+            assert activity_sensor.native_value == 75.68
+
+            # 2. Test precision = 1
+            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 1}
+            assert probability_sensor.native_value == 65.4
+            assert priors_sensor.native_value == 35.7
+            assert decay_sensor.native_value == 84.6
+            assert presence_sensor.native_value == 45.7
+            assert env_sensor.native_value == 55.4
+            assert activity_sensor.native_value == 75.7
+
+            # 3. Test precision = 0
+            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 0}
+            assert probability_sensor.native_value == 65.0
+            assert priors_sensor.native_value == 36.0
+            assert decay_sensor.native_value == 85.0
+            assert presence_sensor.native_value == 46.0
+            assert env_sensor.native_value == 55.0
+            assert activity_sensor.native_value == 76.0
+        finally:
+            coordinator_with_sensors.integration_config.config_entry.options = original_options
+
+    def test_occupancy_decoupled_from_precision(
+        self, coordinator_with_sensors: AreaOccupancyCoordinator
+    ) -> None:
+        """Test that internal occupancy logic (threshold matching) is decoupled from precision rounding."""
+        from custom_components.area_occupancy.const import CONF_SENSOR_PRECISION
+
+        area_name = coordinator_with_sensors.get_area_names()[0]
+        area = coordinator_with_sensors.get_area(area_name)
+        
+        # Set threshold to 65% (0.65)
+        # Set base probability to 0.649 -> 64.9% (below threshold)
+        # However, if precision = 1, it rounds to 65.0%
+        # Or if precision = 0, it rounds to 65.0% (exactly at threshold)
+        area.config.threshold = 0.65
+        
+        # Mock probability to return 0.649 (unrounded raw value)
+        area.probability = Mock(return_value=0.649)
+        
+        # Backup original options
+        original_options = coordinator_with_sensors.integration_config.config_entry.options
+
+        try:
+            # Even with precision = 0 (which rounds 64.9 to 65.0), area.occupied() should use raw probability 0.649 and return False.
+            coordinator_with_sensors.integration_config.config_entry.options = {CONF_SENSOR_PRECISION: 0}
+            assert area.occupied() is False
+
+            # If probability is 0.651, area.occupied() should return True, regardless of precision
+            area.probability = Mock(return_value=0.651)
+            assert area.occupied() is True
+        finally:
+            coordinator_with_sensors.integration_config.config_entry.options = original_options
+
 
 class TestSensorErrorHandling:
     """Test sensor error handling scenarios."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -101,6 +101,20 @@ class TestUtils:
         """Test float formatting to 2 decimal places."""
         assert format_float(input_value) == expected
 
+    def test_format_float_custom_precision(self) -> None:
+        """Test float formatting with custom precision settings."""
+        # Test default precision (2)
+        assert format_float(1.234567) == 1.23
+        
+        # Test precision = 1
+        assert format_float(1.234567, 1) == 1.2
+        assert format_float(1.2789, 1) == 1.3
+        
+        # Test precision = 0
+        assert format_float(1.234567, 0) == 1.0
+        assert format_float(1.789, 0) == 2.0
+        assert format_float(0.0, 0) == 0.0
+
     @pytest.mark.parametrize(
         ("input_value", "expected"),
         [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -105,11 +105,11 @@ class TestUtils:
         """Test float formatting with custom precision settings."""
         # Test default precision (2)
         assert format_float(1.234567) == 1.23
-        
+
         # Test precision = 1
         assert format_float(1.234567, 1) == 1.2
         assert format_float(1.2789, 1) == 1.3
-        
+
         # Test precision = 0
         assert format_float(1.234567, 0) == 1.0
         assert format_float(1.789, 0) == 2.0

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ wheels = [
 
 [[package]]
 name = "area-occupancy-detection"
-version = "2026.5.2"
+version = "2026.5.17"
 source = { editable = "." }
 dependencies = [
     { name = "ha-ffmpeg" },


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><html><head></head><body><h2>What &amp; Why</h2>
<p>Diagnostic sensors (decay, probability, confidences, prior) update on the 10-second global
decay timer and publish 2-decimal states, so effectively every tick writes a recorder row
per sensor. This is the primary driver behind #467.</p>
<p><strong>Measured on a live 6-area installation (v2026.5.17, 57 AOD entities):</strong></p>

Window (3 h) | Precision | Recorder rows | Δ
-- | -- | -- | --
Afternoon (active) | 2 (baseline) | 15,952 | —
Evening 21:30–00:30 (going to bed) | 0 | 7,058 | −55 %
Morning (low activity) | 0 | 3,323 | −79 %


<p>The reduction scales with how quiet the home is: quantising to whole percent removes the
sub-decimal noise during steady state, while genuine decay transitions still cross integer
boundaries and are recorded. Extrapolated, the baseline corresponds to ~1.0–1.3 M rows /
100–190 MB of pure diagnostic history per 10 days.</p>
<h2>Change</h2>
<p>Adds a global setting <strong>Sensor state precision</strong> (0–2 decimals, default <strong>2 = unchanged
behaviour</strong>) under the existing Global Settings menu. At 0 decimals the recorder only writes
on whole-percent changes.</p>
<h2>Why this is functionally safe</h2>
<p>All decision logic — <code>area.occupied()</code>, wasp-in-box, activity scoring, thresholds — operates
on internal <strong>unrounded</strong> floats. The sensor states are publication-only formatting via
<code>format_float</code>. This PR therefore touches no calculation code: only <code>const.py</code>,
<code>data/config.py</code>, <code>config_flow.py</code>, <code>utils.py</code>, <code>sensor.py</code>, strings/translations, docs and
tests. <code>suggested_display_precision</code> was deliberately <strong>not</strong> used — it only rounds the UI
display, not the recorded state, so it would not reduce recorder load.</p>
<p>Verified live: with precision set to 0, all numeric diagnostic sensors report integers
(e.g. <code>occupancy_probability = 39.0</code>, <code>decay_status = 0.0</code>) while occupancy status, wasp and
activity detection behave identically.</p>
<h2>Backward compatibility</h2>
<p>Default stays at 2 decimals. Existing config entries that don't contain the new key fall back
to 2 via <code>.get(CONF_SENSOR_PRECISION, DEFAULT_SENSOR_PRECISION)</code> — no migration, no
<code>CONF_VERSION</code> bump, no change for current installs.</p>
<h2>Testing</h2>
<ul>
<li><code>format_float</code> rounding for precision 0/1/2 and default.</li>
<li>Config-flow persistence + range validation + default-when-missing.</li>
<li>Sensor-level: probability/decay return integer states at precision 0, identical to current
output at precision 2 (regression).</li>
<li>Decoupling regression: <code>binary_sensor.is_on</code> decisions are independent of the setting.</li>
<li>Full suite + coverage gate via <code>scripts/test</code>.</li>
</ul>
<p>Relates to #467.</p></body></html><!--EndFragment-->
</body>
</html>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global sensor state precision setting (0–2 decimals, default 2) in Global Settings to control rounding of diagnostic/percentage sensors.

* **Bug Fixes**
  * Ensured occupancy threshold calculations use unrounded raw probability values, so rounding no longer affects threshold behaviour.

* **Documentation**
  * Documented the new sensor state precision option, including recommended defaults and what it impacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->