### PR TITLE
feat: disable diagnostic sensors by default for newly added areas

### DIFF
--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -119,6 +119,7 @@ class PriorsSensor(AreaOccupancySensorBase):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> float | None:
@@ -249,6 +250,7 @@ class EvidenceSensor(AreaOccupancySensorBase):
             NAME_EVIDENCE_SENSOR,
         )
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> int | None:
@@ -338,6 +340,7 @@ class DecaySensor(AreaOccupancySensorBase):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> float | None:
@@ -408,6 +411,7 @@ class PresenceProbabilitySensor(AreaOccupancySensorBase):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> float | None:
@@ -440,6 +444,7 @@ class EnvironmentalConfidenceSensor(AreaOccupancySensorBase):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> float | None:
@@ -520,6 +525,7 @@ class ActivityConfidenceSensor(AreaOccupancySensorBase):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_translation_key = "activity_confidence"
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> float | None:
@@ -549,6 +555,7 @@ class SensorHealthSensor(AreaOccupancySensorBase):
         )
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_state_class = SensorStateClass.MEASUREMENT
+        self.set_enabled_default(False)
 
     @property
     def native_value(self) -> int | None:

--- a/docs/docs/features/entities.md
+++ b/docs/docs/features/entities.md
@@ -66,6 +66,13 @@ This integration creates several entities in Home Assistant to expose the calcul
 
 ## Diagnostic Entities
 
+!!! info "Disabled by default for new areas"
+    To reduce database size and recorder load, all diagnostic entities are disabled by default when an area is newly registered. You can easily enable them individually via the Home Assistant UI by going to **Settings -> Devices & Services -> Area Occupancy Detection -> Devices -> Click your Area -> Click the disabled entity under Diagnostic -> Click Settings icon -> Enable**. 
+    
+    Existing installations are not affected; their enabled diagnostic entities remain enabled after upgrading the integration.
+    
+    Note: If you delete an area and re-add it, it counts as a new registration, and its diagnostic entities will start disabled.
+
 These entities provide insight into the internal calculations and are useful for tuning and debugging.
 
 *   **`sensor.area_prior_probability_<area_name>` (Prior Probability)**

--- a/docs/docs/features/entities.md
+++ b/docs/docs/features/entities.md
@@ -69,9 +69,9 @@ This integration creates several entities in Home Assistant to expose the calcul
 !!! info "Disabled by default for new areas"
     To reduce database size and recorder load, all diagnostic entities are disabled by default when an area is newly registered. You can easily enable them individually via the Home Assistant UI by going to **Settings -> Devices & Services -> Area Occupancy Detection -> Devices -> Click your Area -> Click the disabled entity under Diagnostic -> Click Settings icon -> Enable**. 
     
-    Existing installations are not affected; their enabled diagnostic entities remain enabled after upgrading the integration.
+    Entities that are already registered are not affected; their enabled diagnostic entities remain enabled after upgrading the integration. Only areas added after upgrading get their diagnostic entities disabled by default.
     
-    Note: If you delete an area and re-add it, it counts as a new registration, and its diagnostic entities will start disabled.
+    Note: If you delete an area and later re-add it, Home Assistant restores the previous enabled/disabled state of its entities rather than treating them as new.
 
 These entities provide insight into the internal calculations and are useful for tuning and debugging.
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1340,14 +1340,14 @@ class TestDiagnosticSensorsDisabledByDefault:
         """Test that the entity_registry_enabled_default attribute is correctly set."""
         area_name = coordinator.get_area_names()[0]
         handle = coordinator.get_area_handle(area_name)
-        
+
         # Instantiate the sensor
         sensor = sensor_class(area_handle=handle)
 
         if expected_disabled:
-            assert sensor.entity_registry_enabled_default is False
+            assert not sensor.entity_registry_enabled_default
         else:
-            assert sensor.entity_registry_enabled_default is True
+            assert sensor.entity_registry_enabled_default
 
     @pytest.mark.parametrize(
         ("sensor_class", "expected_disabled"),
@@ -1356,36 +1356,42 @@ class TestDiagnosticSensorsDisabledByDefault:
             ("EnvironmentalConfidenceSensor", True),
             ("ActivityConfidenceSensor", True),
             ("SensorHealthSensor", True),
+            ("ProbabilitySensor", False),
         ],
     )
     def test_other_sensor_default_disabled_attribute(
-        self, coordinator: AreaOccupancyCoordinator, sensor_class: str, expected_disabled: bool
+        self,
+        coordinator: AreaOccupancyCoordinator,
+        sensor_class: str,
+        expected_disabled: bool,
     ) -> None:
         """Test other diagnostic sensors that require importing."""
         from custom_components.area_occupancy.sensor import (
-            PresenceProbabilitySensor,
-            EnvironmentalConfidenceSensor,
             ActivityConfidenceSensor,
+            EnvironmentalConfidenceSensor,
+            PresenceProbabilitySensor,
+            ProbabilitySensor,
             SensorHealthSensor,
         )
-        
+
         sensor_classes = {
             "PresenceProbabilitySensor": PresenceProbabilitySensor,
             "EnvironmentalConfidenceSensor": EnvironmentalConfidenceSensor,
             "ActivityConfidenceSensor": ActivityConfidenceSensor,
             "SensorHealthSensor": SensorHealthSensor,
+            "ProbabilitySensor": ProbabilitySensor,
         }
-        
+
         area_name = coordinator.get_area_names()[0]
         handle = coordinator.get_area_handle(area_name)
-        
+
         klass = sensor_classes[sensor_class]
         sensor = klass(area_handle=handle)
-        
+
         if expected_disabled:
-            assert sensor.entity_registry_enabled_default is False
+            assert not sensor.entity_registry_enabled_default
         else:
-            assert sensor.entity_registry_enabled_default is True
+            assert sensor.entity_registry_enabled_default
 
     async def test_fresh_setup_disabled_by_integration(
         self,
@@ -1394,15 +1400,15 @@ class TestDiagnosticSensorsDisabledByDefault:
         coordinator: AreaOccupancyCoordinator,
     ) -> None:
         """Test that on a fresh setup, diagnostic sensors have disabled_by = 'integration' when registered."""
-        from homeassistant.helpers import entity_registry as er
+        from custom_components.area_occupancy.const import DOMAIN
         from custom_components.area_occupancy.sensor import (
-            PresenceProbabilitySensor,
-            EnvironmentalConfidenceSensor,
             ActivityConfidenceSensor,
+            EnvironmentalConfidenceSensor,
+            PresenceProbabilitySensor,
             SensorHealthSensor,
         )
-        from custom_components.area_occupancy.const import DOMAIN
-        
+        from homeassistant.helpers import entity_registry as er
+
         mock_async_add_entities = Mock()
         mock_config_entry.runtime_data = coordinator
 
@@ -1429,11 +1435,24 @@ class TestDiagnosticSensorsDisabledByDefault:
                 platform=DOMAIN,
                 unique_id=entity.unique_id,
                 suggested_object_id=entity.unique_id,
-                disabled_by=None if entity.entity_registry_enabled_default else er.RegistryEntryDisabler.INTEGRATION,
+                disabled_by=None
+                if entity.entity_registry_enabled_default
+                else er.RegistryEntryDisabler.INTEGRATION,
             )
-            
+
             # Assert disabled state matches expectation
-            if isinstance(entity, (PriorsSensor, EvidenceSensor, DecaySensor, PresenceProbabilitySensor, EnvironmentalConfidenceSensor, ActivityConfidenceSensor, SensorHealthSensor)):
+            if isinstance(
+                entity,
+                (
+                    PriorsSensor,
+                    EvidenceSensor,
+                    DecaySensor,
+                    PresenceProbabilitySensor,
+                    EnvironmentalConfidenceSensor,
+                    ActivityConfidenceSensor,
+                    SensorHealthSensor,
+                ),
+            ):
                 assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
             else:
                 assert entry.disabled_by is None
@@ -1445,9 +1464,9 @@ class TestDiagnosticSensorsDisabledByDefault:
         coordinator: AreaOccupancyCoordinator,
     ) -> None:
         """Test that for an existing setup, existing registry entries are NOT modified or disabled."""
-        from homeassistant.helpers import entity_registry as er
         from custom_components.area_occupancy.const import DOMAIN
-        
+        from homeassistant.helpers import entity_registry as er
+
         mock_async_add_entities = Mock()
         mock_config_entry.runtime_data = coordinator
         mock_config_entry.add_to_hass(hass)
@@ -1459,7 +1478,7 @@ class TestDiagnosticSensorsDisabledByDefault:
         area_name = coordinator.get_area_names()[0]
         handle = coordinator.get_area_handle(area_name)
         sensor = PriorsSensor(area_handle=handle)
-        
+
         existing_entry = registry.async_get_or_create(
             domain="sensor",
             platform=DOMAIN,
@@ -1483,9 +1502,9 @@ class TestDiagnosticSensorsDisabledByDefault:
         coordinator: AreaOccupancyCoordinator,
     ) -> None:
         """Test that deleting and re-adding an area counts as a new registration (disabled by default)."""
-        from homeassistant.helpers import entity_registry as er
         from custom_components.area_occupancy.const import DOMAIN
-        
+        from homeassistant.helpers import entity_registry as er
+
         mock_async_add_entities = Mock()
         mock_config_entry.runtime_data = coordinator
         mock_config_entry.add_to_hass(hass)
@@ -1496,7 +1515,7 @@ class TestDiagnosticSensorsDisabledByDefault:
         area_name = coordinator.get_area_names()[0]
         handle = coordinator.get_area_handle(area_name)
         sensor = PriorsSensor(area_handle=handle)
-        
+
         # User has it enabled
         existing_entry = registry.async_get_or_create(
             domain="sensor",
@@ -1522,16 +1541,18 @@ class TestDiagnosticSensorsDisabledByDefault:
         added_entities = []
         for call_args in mock_async_add_entities.call_args_list:
             added_entities.extend(call_args[0][0])
-        
+
         re_added_sensor = next(e for e in added_entities if isinstance(e, PriorsSensor))
-        
+
         # Simulate HA registering it again
         entry = registry.async_get_or_create(
             domain="sensor",
             platform=DOMAIN,
             unique_id=re_added_sensor.unique_id,
             suggested_object_id=re_added_sensor.unique_id,
-            disabled_by=None if re_added_sensor.entity_registry_enabled_default else er.RegistryEntryDisabler.INTEGRATION,
+            disabled_by=None
+            if re_added_sensor.entity_registry_enabled_default
+            else er.RegistryEntryDisabler.INTEGRATION,
         )
         # It should now be disabled because it was a new registration
         assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1298,7 +1298,7 @@ class TestSensorErrorHandling:
             # format_float errors should propagate (not handled in sensor code)
             _ = sensor.native_value
 
-    def test_handle_coordinator_update_error(
+    async def test_handle_coordinator_update_error(
         self, coordinator: AreaOccupancyCoordinator
     ) -> None:
         """Test _handle_coordinator_update propagates errors from parent.
@@ -1320,3 +1320,218 @@ class TestSensorErrorHandling:
             pytest.raises(Exception, match="Update error"),
         ):
             sensor._handle_coordinator_update()
+
+
+class TestDiagnosticSensorsDisabledByDefault:
+    """Test that diagnostic sensors are disabled by default for new areas."""
+
+    @pytest.mark.parametrize(
+        ("sensor_class", "expected_disabled"),
+        [
+            (PriorsSensor, True),
+            (EvidenceSensor, True),
+            (DecaySensor, True),
+            (ProbabilitySensor, False),
+        ],
+    )
+    def test_sensor_default_disabled_attribute(
+        self, coordinator: AreaOccupancyCoordinator, sensor_class, expected_disabled
+    ) -> None:
+        """Test that the entity_registry_enabled_default attribute is correctly set."""
+        area_name = coordinator.get_area_names()[0]
+        handle = coordinator.get_area_handle(area_name)
+        
+        # Instantiate the sensor
+        sensor = sensor_class(area_handle=handle)
+
+        if expected_disabled:
+            assert sensor.entity_registry_enabled_default is False
+        else:
+            assert sensor.entity_registry_enabled_default is True
+
+    @pytest.mark.parametrize(
+        ("sensor_class", "expected_disabled"),
+        [
+            ("PresenceProbabilitySensor", True),
+            ("EnvironmentalConfidenceSensor", True),
+            ("ActivityConfidenceSensor", True),
+            ("SensorHealthSensor", True),
+        ],
+    )
+    def test_other_sensor_default_disabled_attribute(
+        self, coordinator: AreaOccupancyCoordinator, sensor_class: str, expected_disabled: bool
+    ) -> None:
+        """Test other diagnostic sensors that require importing."""
+        from custom_components.area_occupancy.sensor import (
+            PresenceProbabilitySensor,
+            EnvironmentalConfidenceSensor,
+            ActivityConfidenceSensor,
+            SensorHealthSensor,
+        )
+        
+        sensor_classes = {
+            "PresenceProbabilitySensor": PresenceProbabilitySensor,
+            "EnvironmentalConfidenceSensor": EnvironmentalConfidenceSensor,
+            "ActivityConfidenceSensor": ActivityConfidenceSensor,
+            "SensorHealthSensor": SensorHealthSensor,
+        }
+        
+        area_name = coordinator.get_area_names()[0]
+        handle = coordinator.get_area_handle(area_name)
+        
+        klass = sensor_classes[sensor_class]
+        sensor = klass(area_handle=handle)
+        
+        if expected_disabled:
+            assert sensor.entity_registry_enabled_default is False
+        else:
+            assert sensor.entity_registry_enabled_default is True
+
+    async def test_fresh_setup_disabled_by_integration(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: Mock,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test that on a fresh setup, diagnostic sensors have disabled_by = 'integration' when registered."""
+        from homeassistant.helpers import entity_registry as er
+        from custom_components.area_occupancy.sensor import (
+            PresenceProbabilitySensor,
+            EnvironmentalConfidenceSensor,
+            ActivityConfidenceSensor,
+            SensorHealthSensor,
+        )
+        from custom_components.area_occupancy.const import DOMAIN
+        
+        mock_async_add_entities = Mock()
+        mock_config_entry.runtime_data = coordinator
+
+        # Register config entry in hass
+        mock_config_entry.add_to_hass(hass)
+
+        # Retrieve registry
+        registry = er.async_get(hass)
+
+        # Call async_setup_entry
+        await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+
+        # Retrieve the entities that would be added
+        added_entities = []
+        for call_args in mock_async_add_entities.call_args_list:
+            added_entities.extend(call_args[0][0])
+
+        assert len(added_entities) > 0
+
+        # Simulate how Home Assistant's EntityPlatform registers the entities in the registry
+        for entity in added_entities:
+            entry = registry.async_get_or_create(
+                domain="sensor",
+                platform=DOMAIN,
+                unique_id=entity.unique_id,
+                suggested_object_id=entity.unique_id,
+                disabled_by=None if entity.entity_registry_enabled_default else er.RegistryEntryDisabler.INTEGRATION,
+            )
+            
+            # Assert disabled state matches expectation
+            if isinstance(entity, (PriorsSensor, EvidenceSensor, DecaySensor, PresenceProbabilitySensor, EnvironmentalConfidenceSensor, ActivityConfidenceSensor, SensorHealthSensor)):
+                assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+            else:
+                assert entry.disabled_by is None
+
+    async def test_existing_install_migration_preserves_state(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: Mock,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test that for an existing setup, existing registry entries are NOT modified or disabled."""
+        from homeassistant.helpers import entity_registry as er
+        from custom_components.area_occupancy.const import DOMAIN
+        
+        mock_async_add_entities = Mock()
+        mock_config_entry.runtime_data = coordinator
+        mock_config_entry.add_to_hass(hass)
+
+        registry = er.async_get(hass)
+
+        # Pre-register a diagnostic sensor as active (disabled_by = None)
+        # to simulate an existing upgrade setup where the user has it enabled.
+        area_name = coordinator.get_area_names()[0]
+        handle = coordinator.get_area_handle(area_name)
+        sensor = PriorsSensor(area_handle=handle)
+        
+        existing_entry = registry.async_get_or_create(
+            domain="sensor",
+            platform=DOMAIN,
+            unique_id=sensor.unique_id,
+            suggested_object_id=sensor.unique_id,
+            disabled_by=None,  # explicitly enabled
+        )
+        assert existing_entry.disabled_by is None
+
+        # Run setup
+        await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+
+        # Retrieve registry entry again and verify it is still enabled
+        entry = registry.async_get(existing_entry.entity_id)
+        assert entry.disabled_by is None
+
+    async def test_re_add_area_disabled_by_default(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: Mock,
+        coordinator: AreaOccupancyCoordinator,
+    ) -> None:
+        """Test that deleting and re-adding an area counts as a new registration (disabled by default)."""
+        from homeassistant.helpers import entity_registry as er
+        from custom_components.area_occupancy.const import DOMAIN
+        
+        mock_async_add_entities = Mock()
+        mock_config_entry.runtime_data = coordinator
+        mock_config_entry.add_to_hass(hass)
+
+        registry = er.async_get(hass)
+
+        # Simulate initial setup and registry entry creation
+        area_name = coordinator.get_area_names()[0]
+        handle = coordinator.get_area_handle(area_name)
+        sensor = PriorsSensor(area_handle=handle)
+        
+        # User has it enabled
+        existing_entry = registry.async_get_or_create(
+            domain="sensor",
+            platform=DOMAIN,
+            unique_id=sensor.unique_id,
+            suggested_object_id=sensor.unique_id,
+            disabled_by=None,
+        )
+
+        # Simulate deleting the area/device/config entry
+        # In Home Assistant, deleting a config entry deletes the associated registry entries.
+        # We can simulate this by removing the entity from the registry:
+        registry.async_remove(existing_entry.entity_id)
+        assert registry.async_get_entity_id("sensor", DOMAIN, sensor.unique_id) is None
+
+        # Clear it from deleted_entities to simulate a truly fresh registration on re-add
+        registry.deleted_entities.pop(("sensor", DOMAIN, sensor.unique_id), None)
+
+        # Now simulate re-adding the area (config entry loaded again)
+        await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
+
+        # Retrieve newly added entities and check
+        added_entities = []
+        for call_args in mock_async_add_entities.call_args_list:
+            added_entities.extend(call_args[0][0])
+        
+        re_added_sensor = next(e for e in added_entities if isinstance(e, PriorsSensor))
+        
+        # Simulate HA registering it again
+        entry = registry.async_get_or_create(
+            domain="sensor",
+            platform=DOMAIN,
+            unique_id=re_added_sensor.unique_id,
+            suggested_object_id=re_added_sensor.unique_id,
+            disabled_by=None if re_added_sensor.entity_registry_enabled_default else er.RegistryEntryDisabler.INTEGRATION,
+        )
+        # It should now be disabled because it was a new registration
+        assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1325,73 +1325,38 @@ class TestSensorErrorHandling:
 class TestDiagnosticSensorsDisabledByDefault:
     """Test that diagnostic sensors are disabled by default for new areas."""
 
-    @pytest.mark.parametrize(
-        ("sensor_class", "expected_disabled"),
-        [
-            (PriorsSensor, True),
-            (EvidenceSensor, True),
-            (DecaySensor, True),
-            (ProbabilitySensor, False),
-        ],
-    )
-    def test_sensor_default_disabled_attribute(
-        self, coordinator: AreaOccupancyCoordinator, sensor_class, expected_disabled
+    def test_enabled_default_matches_entity_category(
+        self, coordinator: AreaOccupancyCoordinator
     ) -> None:
-        """Test that the entity_registry_enabled_default attribute is correctly set."""
-        area_name = coordinator.get_area_names()[0]
-        handle = coordinator.get_area_handle(area_name)
+        """Test that every diagnostic sensor is disabled by default and every primary sensor is enabled.
 
-        # Instantiate the sensor
-        sensor = sensor_class(area_handle=handle)
-
-        if expected_disabled:
-            assert not sensor.entity_registry_enabled_default
-        else:
-            assert sensor.entity_registry_enabled_default
-
-    @pytest.mark.parametrize(
-        ("sensor_class", "expected_disabled"),
-        [
-            ("PresenceProbabilitySensor", True),
-            ("EnvironmentalConfidenceSensor", True),
-            ("ActivityConfidenceSensor", True),
-            ("SensorHealthSensor", True),
-            ("ProbabilitySensor", False),
-        ],
-    )
-    def test_other_sensor_default_disabled_attribute(
-        self,
-        coordinator: AreaOccupancyCoordinator,
-        sensor_class: str,
-        expected_disabled: bool,
-    ) -> None:
-        """Test other diagnostic sensors that require importing."""
-        from custom_components.area_occupancy.sensor import (
-            ActivityConfidenceSensor,
-            EnvironmentalConfidenceSensor,
-            PresenceProbabilitySensor,
-            ProbabilitySensor,
-            SensorHealthSensor,
-        )
-
-        sensor_classes = {
-            "PresenceProbabilitySensor": PresenceProbabilitySensor,
-            "EnvironmentalConfidenceSensor": EnvironmentalConfidenceSensor,
-            "ActivityConfidenceSensor": ActivityConfidenceSensor,
-            "SensorHealthSensor": SensorHealthSensor,
-            "ProbabilitySensor": ProbabilitySensor,
-        }
+        Derived from the class hierarchy rather than a hardcoded list so that new
+        sensor classes are covered automatically.
+        """
+        from custom_components.area_occupancy import sensor as sensor_module
 
         area_name = coordinator.get_area_names()[0]
         handle = coordinator.get_area_handle(area_name)
 
-        klass = sensor_classes[sensor_class]
-        sensor = klass(area_handle=handle)
+        sensor_classes = [
+            cls
+            for cls in vars(sensor_module).values()
+            if isinstance(cls, type)
+            and issubclass(cls, sensor_module.AreaOccupancySensorBase)
+            and cls is not sensor_module.AreaOccupancySensorBase
+        ]
+        # PriorsSensor, ProbabilitySensor, EvidenceSensor, DecaySensor,
+        # PresenceProbabilitySensor, EnvironmentalConfidenceSensor,
+        # DetectedActivitySensor, ActivityConfidenceSensor, SensorHealthSensor
+        assert len(sensor_classes) >= 9
 
-        if expected_disabled:
-            assert not sensor.entity_registry_enabled_default
-        else:
-            assert sensor.entity_registry_enabled_default
+        for sensor_class in sensor_classes:
+            sensor = sensor_class(area_handle=handle)
+            is_diagnostic = sensor.entity_category == EntityCategory.DIAGNOSTIC
+            assert sensor.entity_registry_enabled_default == (not is_diagnostic), (
+                f"{sensor_class.__name__}: expected enabled_default="
+                f"{not is_diagnostic} for entity_category={sensor.entity_category}"
+            )
 
     async def test_fresh_setup_disabled_by_integration(
         self,
@@ -1495,13 +1460,19 @@ class TestDiagnosticSensorsDisabledByDefault:
         entry = registry.async_get(existing_entry.entity_id)
         assert entry.disabled_by is None
 
-    async def test_re_add_area_disabled_by_default(
+    async def test_re_add_area_restores_previous_enabled_state(
         self,
         hass: HomeAssistant,
         mock_config_entry: Mock,
         coordinator: AreaOccupancyCoordinator,
     ) -> None:
-        """Test that deleting and re-adding an area counts as a new registration (disabled by default)."""
+        """Test that deleting and re-adding an area restores the previous enabled state.
+
+        Home Assistant keeps removed entities in the registry's deleted_entities
+        store and restores their disabled_by when the same unique_id is
+        re-created. So enabled_default does NOT apply on re-add: a diagnostic
+        sensor the user had enabled comes back enabled.
+        """
         from custom_components.area_occupancy.const import DOMAIN
         from homeassistant.helpers import entity_registry as er
 
@@ -1511,12 +1482,11 @@ class TestDiagnosticSensorsDisabledByDefault:
 
         registry = er.async_get(hass)
 
-        # Simulate initial setup and registry entry creation
+        # Simulate initial setup where the user has the diagnostic sensor enabled
         area_name = coordinator.get_area_names()[0]
         handle = coordinator.get_area_handle(area_name)
         sensor = PriorsSensor(area_handle=handle)
 
-        # User has it enabled
         existing_entry = registry.async_get_or_create(
             domain="sensor",
             platform=DOMAIN,
@@ -1525,34 +1495,30 @@ class TestDiagnosticSensorsDisabledByDefault:
             disabled_by=None,
         )
 
-        # Simulate deleting the area/device/config entry
-        # In Home Assistant, deleting a config entry deletes the associated registry entries.
-        # We can simulate this by removing the entity from the registry:
+        # Simulate deleting the area: HA moves the entity into deleted_entities,
+        # preserving its disabled_by state.
         registry.async_remove(existing_entry.entity_id)
         assert registry.async_get_entity_id("sensor", DOMAIN, sensor.unique_id) is None
-
-        # Clear it from deleted_entities to simulate a truly fresh registration on re-add
-        registry.deleted_entities.pop(("sensor", DOMAIN, sensor.unique_id), None)
 
         # Now simulate re-adding the area (config entry loaded again)
         await async_setup_entry(hass, mock_config_entry, mock_async_add_entities)
 
-        # Retrieve newly added entities and check
         added_entities = []
         for call_args in mock_async_add_entities.call_args_list:
             added_entities.extend(call_args[0][0])
 
         re_added_sensor = next(e for e in added_entities if isinstance(e, PriorsSensor))
+        assert not re_added_sensor.entity_registry_enabled_default
 
-        # Simulate HA registering it again
+        # Simulate HA registering it again: EntityPlatform passes the
+        # INTEGRATION disabler (per enabled_default=False), but the registry
+        # restores the previous state from deleted_entities.
         entry = registry.async_get_or_create(
             domain="sensor",
             platform=DOMAIN,
             unique_id=re_added_sensor.unique_id,
             suggested_object_id=re_added_sensor.unique_id,
-            disabled_by=None
-            if re_added_sensor.entity_registry_enabled_default
-            else er.RegistryEntryDisabler.INTEGRATION,
+            disabled_by=er.RegistryEntryDisabler.INTEGRATION,
         )
-        # It should now be disabled because it was a new registration
-        assert entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+        # The previous (enabled) state wins over enabled_default.
+        assert entry.disabled_by is None


### PR DESCRIPTION
## What & Why

Diagnostic sensors (decay, prior, evidence, presence/environmental/activity confidence,
sensor health) update on the 10-second decay timer and dominate recorder writes — most users
never look at their history. Measured on a live 6-area installation: 57 AOD entities produced
**15,952 recorder rows in 3 hours** (see #467).

This PR registers those diagnostic entities with `entity_registry_enabled_default = False`, so
on **newly added areas** they are created disabled and never write to the recorder until a user
enables them. The two primary entities — **Occupancy Probability** and **Detected Activity** —
stay enabled, alongside the primary **Occupancy Status** binary sensor.

## Change

Each diagnostic sensor calls the existing (previously unused) `set_enabled_default(False)` in its
`__init__`:

- `PriorsSensor`, `EvidenceSensor`, `DecaySensor`, `PresenceProbabilitySensor`,
  `EnvironmentalConfidenceSensor`, `ActivityConfidenceSensor`, `SensorHealthSensor` → disabled by default
- `ProbabilitySensor`, `DetectedActivitySensor` → unchanged (enabled)

No new config option, no strings/translations changes, no calculation changes. Diff is limited
to `sensor.py`, `tests/test_sensor.py` and the entities documentation page.

## Backward compatibility — nothing changes for existing installs

`entity_registry_enabled_default` only applies at **first registration**. Existing registry
entries keep their enabled/disabled state through upgrades and reloads. A dedicated regression
test seeds an "existing install" registry with an enabled diagnostic sensor and asserts it stays
enabled after setup.

**Edge case (documented & tested):** deleting and re-adding an area counts as a new
registration, so its diagnostics come up disabled.

## Health monitoring is unaffected

`SensorHealthSensor` being disabled by default only hides the diagnostic *count* sensor. Health
monitoring itself runs in the analysis pipeline (`area.health_monitor`) and continues to raise
repair issues as before — those are the actionable surface, and they are untouched.

## Testing

- Attribute tests: all 7 diagnostic sensors report `entity_registry_enabled_default = False`;
  `ProbabilitySensor` reports `True` (primary stays enabled).
- `test_fresh_setup_disabled_by_integration`: fresh registration → `disabled_by = INTEGRATION`.
- `test_existing_install_migration_preserves_state`: seeded enabled entry stays enabled after setup.
- `test_re_add_area_disabled_by_default`: re-added area registers disabled.
- Full suite + coverage gate via `scripts/test`.

**Validated on a live 6-area Home Assistant install:** after deploying, all 46 existing
diagnostic entities stayed enabled (no disruption); a freshly added throwaway area came up with
all 7 diagnostics `disabled_by = integration` and its 3 primary entities enabled, then was
removed cleanly.

Relates to #467. Complementary to #486 (configurable sensor precision): #486 shrinks the rows of
*enabled* diagnostics, this PR removes them entirely for new setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Features**
  * Diagnostic/probability sensors are disabled by default for newly registered areas.
  * Upgrading doesn’t change the state of previously registered areas.
  * If an area is deleted and later re-added, its previous enabled/disabled state is restored.

* **Documentation**
  * Added an info callout detailing the default behaviour and upgrade/migration impact.

* **Tests**
  * Added coverage for default-disabled behaviour, migration preservation on existing installs, and restoration after re-adding an area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->