### PR TITLE
fix(prior): keep quiet tail in global prior denominator

### DIFF
--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -489,39 +489,27 @@ class PriorAnalyzer:
                 now.tzinfo,
             )
 
-            # Use actual period: from first interval to now (or last interval if very recent)
-            # If last interval is more than 1 hour old, use it; otherwise use now
-            # Ensure we use UTC-aware datetimes for all calculations
-            if (now - last_interval_end).total_seconds() > 3600:
-                actual_period_end = last_interval_end
-            else:
-                actual_period_end = now
+            # Use actual period: from first interval start to now. Time after
+            # the last interval is known-unoccupied and must stay in the
+            # denominator — truncating the period at last_interval_end inflates
+            # the prior every time the area is quiet for a while (#483).
+            actual_period_end = now
 
             # Defensive check: ensure actual_period_end >= first_interval_start
             if actual_period_end < first_interval_start:
-                _LOGGER.warning(
-                    "actual_period_end (%s) < first_interval_start (%s) for area %s. "
-                    "This may indicate timezone issues or clock skew. Using now instead.",
+                _LOGGER.error(
+                    "'now' (%s) is before first_interval_start (%s) for area %s. "
+                    "This indicates severe clock skew or timezone issues. Using fallback prior.",
                     actual_period_end,
                     first_interval_start,
                     self.area_name,
                 )
-                actual_period_end = now
-                # Double-check after using now
-                if actual_period_end < first_interval_start:
-                    _LOGGER.error(
-                        "Even 'now' (%s) is before first_interval_start (%s) for area %s. "
-                        "This indicates severe clock skew or timezone issues. Using fallback prior.",
-                        actual_period_end,
-                        first_interval_start,
-                        self.area_name,
-                    )
-                    self.area.prior.set_global_prior(0.01)
-                    _LOGGER.debug(
-                        "Prior analysis completed for area %s: global_prior=0.010 (fallback due to clock skew)",
-                        self.area_name,
-                    )
-                    return
+                self.area.prior.set_global_prior(0.01)
+                _LOGGER.debug(
+                    "Prior analysis completed for area %s: global_prior=0.010 (fallback due to clock skew)",
+                    self.area_name,
+                )
+                return
 
             actual_period_duration = (
                 actual_period_end - first_interval_start

--- a/docs/docs/technical/global-prior-flow.md
+++ b/docs/docs/technical/global-prior-flow.md
@@ -23,17 +23,14 @@ global_prior = total_occupied_time / total_period_duration
 Where:
 
 - `total_occupied_time`: Sum of all occupied interval durations (from motion sensors)
-- `total_period_duration`: Duration from first interval to last interval (or current time)
+- `total_period_duration`: Duration from first interval start to current time
 
 ### Period Calculation
 
 The system uses the **actual data period** rather than a fixed lookback window:
 
 1. **First Interval Start**: Earliest motion sensor interval start time
-2. **Last Interval End**: Latest motion sensor interval end time
-3. **Period End Determination**:
-   - If last interval is more than 1 hour old: Use `last_interval_end`
-   - Otherwise: Use current time (`now`)
+2. **Period End**: Always the current time (`now`). Time after the last interval is known-unoccupied and must stay in the denominator — truncating the period at the last interval inflated the prior on every recalculation during a quiet stretch (#483).
 
 This approach ensures the prior reflects the actual data available, not an arbitrary time window.
 
@@ -123,13 +120,9 @@ occupied_intervals = self.get_occupied_intervals(days)
 
 ```python
 first_interval_start = min(start for start, end in occupied_intervals)
-last_interval_end = max(end for start, end in occupied_intervals)
 now = dt_util.utcnow()
 
-if (now - last_interval_end).total_seconds() > 3600:
-    actual_period_end = last_interval_end
-else:
-    actual_period_end = now
+actual_period_end = now
 
 actual_period_duration = (actual_period_end - first_interval_start).total_seconds()
 ```
@@ -137,7 +130,7 @@ actual_period_duration = (actual_period_end - first_interval_start).total_second
 **Rationale**: Using actual data period instead of fixed lookback ensures:
 
 - Prior reflects actual data availability
-- No artificial inflation from empty periods
+- Known-unoccupied time after the last interval stays in the denominator (#483)
 - More accurate representation of occupancy patterns
 
 **Edge Case Handling**: If duration is zero or negative (bad timestamps or clock skew), the system sets a safe fallback prior of 0.01 and returns early.
@@ -397,13 +390,11 @@ sequenceDiagram
 
 ## Known Issues and Limitations
 
-1. **Period Calculation Edge Case**: The 1-hour threshold for determining `actual_period_end` may cause issues if last interval is exactly 1 hour old (uses last interval end instead of current time).
+1. **No Validation of Loaded Prior**: Loaded prior from database is set without validation that it's still valid or within expected bounds.
 
-2. **No Validation of Loaded Prior**: Loaded prior from database is set without validation that it's still valid or within expected bounds.
+2. **Race Conditions**: If multiple areas calculate priors simultaneously, database operations may conflict (though SQLite handles this gracefully).
 
-3. **Race Conditions**: If multiple areas calculate priors simultaneously, database operations may conflict (though SQLite handles this gracefully).
-
-4. **Missing Error Handling**: If `save_global_prior()` fails, calculation continues but prior is lost (should log warning).
+3. **Missing Error Handling**: If `save_global_prior()` fails, calculation continues but prior is lost (should log warning).
 
 ## Related Documentation
 

--- a/tests/test_data_analysis.py
+++ b/tests/test_data_analysis.py
@@ -232,12 +232,43 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
 
         # Period calculation:
         # - first_interval_start = occupied_start (now - 8h)
-        # - last_interval_end = occupied_end (now - 6h)
-        # - Since (now - last_interval_end) = 6h > 1h, actual_period_end = last_interval_end
-        # - actual_period_duration = (now - 6h) - (now - 8h) = 2 hours
+        # - actual_period_end = now (quiet tail stays in the denominator, #483)
+        # - actual_period_duration = 8 hours
         # - occupied_duration = 2 hours
-        # - prior = 2h / 2h = 1.0, clamped to 0.99 max
-        assert area.prior.global_prior == 0.99
+        # - prior = 2h / 8h = 0.25
+        assert area.prior.global_prior == 0.25
+
+    def test_quiet_tail_included_in_denominator(
+        self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
+    ) -> None:
+        """Test that a long quiet tail does not inflate the prior (#483).
+
+        Regression test: the period previously ended at last_interval_end
+        whenever the area had been quiet for >1h, which dropped the
+        known-unoccupied tail from the denominator and inflated the prior
+        on every overnight recalculation.
+        """
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+        analyzer = PriorAnalyzer(coordinator, area_name)
+
+        # 6 hours occupied, ending 18 hours ago (e.g. overnight quiet period)
+        now = freeze_time
+        occupied_start = now - timedelta(hours=24)
+        occupied_end = now - timedelta(hours=18)
+        intervals = [(occupied_start, occupied_end)]
+
+        with (
+            patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch(
+                "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
+                return_value=now,
+            ),
+        ):
+            analyzer.calculate_and_update_prior()
+
+        # prior = 6h occupied / 24h period = 0.25, NOT 6h / 6h = 0.99
+        assert area.prior.global_prior == 0.25
 
     def test_prior_bounds_clamping_min(
         self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime


### PR DESCRIPTION
## What & Why

Fixes #483.

`PriorAnalyzer.calculate_and_update_prior()` truncated the observation period at `last_interval_end` whenever the area had been quiet for more than an hour. That dropped the known-unoccupied tail from the denominator while the numerator kept all occupied time, so `global_prior` inflated on every hourly recalculation that ran during a quiet stretch (overnight, weekends), eventually pinning at the 0.99 cap — exactly what the reporter observed on a kitchen area with a true occupancy rate of ~28–35%.

## Change

- `actual_period_end` is now always `now`. The old conditional's stated purpose (guarding a degenerate period right after startup) is already covered by the `actual_period_duration <= 0` guard below.
- The two-step defensive check ("warn, retry with now, then error") collapsed into a single clock-skew error path, since `actual_period_end` is already `now`.
- Updated `test_valid_calculation_sets_correct_prior`, which had encoded the buggy behaviour (2h occupied ending 6h ago asserted prior 0.99; it now asserts the true 0.25), and added a regression test for the overnight quiet-tail case.

Credit to @mscharwere for the precise root-cause analysis in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prior calculation so long quiet periods are now included in the full time window, preventing inflated occupancy estimates.
  * Added a regression check to ensure overnight inactivity does not push the prior toward an unrealistically high value.
  * Made timestamp handling more robust when system time appears inconsistent, falling back to a safe default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->