### PR TITLE
fix(sleep): detect sleep when person presence is unknown

### DIFF
--- a/custom_components/area_occupancy/binary_sensor.py
+++ b/custom_components/area_occupancy/binary_sensor.py
@@ -13,7 +13,13 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_HOME, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    STATE_HOME,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.event import (
@@ -848,6 +854,20 @@ class SleepPresenceSensor(RestoreEntity, BinarySensorEntity):
         """Handle state changes for tracked entities."""
         self._evaluate_and_update()
 
+    def _person_home_state(self, person: PersonConfig) -> bool | None:
+        """Return whether the person is home, or None if presence is unknown.
+
+        Uses the configured device tracker if set, otherwise the person
+        entity. A person entity with no device trackers assigned reports
+        "unknown" — in that case presence cannot be determined and None is
+        returned so sleep detection can rely on the sleep sensors alone.
+        """
+        entity_id = person.device_tracker or person.person_entity
+        state = self.hass.states.get(entity_id)
+        if state is None or state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, ""):
+            return None
+        return state.state == STATE_HOME
+
     def _evaluate_sleep_state(self) -> bool:
         """Evaluate whether any person is home and sleeping.
 
@@ -855,13 +875,11 @@ class SleepPresenceSensor(RestoreEntity, BinarySensorEntity):
         Any active sleep sensor means the person is sleeping (OR logic).
         """
         for person in self._people:
-            # Use device_tracker if configured, otherwise fall back to person entity
-            if person.device_tracker:
-                home_state = self.hass.states.get(person.device_tracker)
-            else:
-                home_state = self.hass.states.get(person.person_entity)
-
-            if not home_state or home_state.state != STATE_HOME:
+            # Skip a person only when they are definitively away. When
+            # presence can't be determined (e.g. a person entity with no
+            # device trackers reports "unknown"), trust the sleep sensors
+            # directly (#464).
+            if self._person_home_state(person) is False:
                 continue
 
             for sensor_id in person.sleep_sensors:
@@ -923,7 +941,9 @@ class SleepPresenceSensor(RestoreEntity, BinarySensorEntity):
                 home_entity_state = self.hass.states.get(person.device_tracker)
             else:
                 home_entity_state = person_state
-            is_home = home_entity_state and home_entity_state.state == STATE_HOME
+            # None means presence is unknown; only a definitive "away"
+            # blocks sleep detection (#464).
+            is_home = self._person_home_state(person)
 
             # Build per-sensor details
             sensor_details: list[dict[str, Any]] = []
@@ -957,7 +977,7 @@ class SleepPresenceSensor(RestoreEntity, BinarySensorEntity):
                     }
                 )
 
-            is_sleeping = is_home and any_sensor_active
+            is_sleeping = is_home is not False and any_sensor_active
 
             if is_sleeping:
                 people_sleeping.append(friendly_name)

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -7,11 +7,12 @@ import pytest
 
 from custom_components.area_occupancy.binary_sensor import (
     Occupancy,
+    SleepPresenceSensor,
     WaspInBoxSensor,
     async_setup_entry,
 )
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
-from custom_components.area_occupancy.data.config import Sensors
+from custom_components.area_occupancy.data.config import PersonConfig, Sensors
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -2303,3 +2304,145 @@ class TestOccupancyEntityEdgeCases:
         # Test when all_areas is None
         entity._all_areas = None
         assert entity.is_on is False
+
+
+class TestSleepPresenceSensor:
+    """Test SleepPresenceSensor presence gating and sleep evaluation."""
+
+    @staticmethod
+    def _make_sensor(
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        person: PersonConfig,
+    ) -> SleepPresenceSensor:
+        area_name = coordinator.get_area_names()[0]
+        handle = coordinator.get_area_handle(area_name)
+        sensor = SleepPresenceSensor(
+            area_handle=handle, config_entry=Mock(), people=[person]
+        )
+        sensor.hass = hass
+        return sensor
+
+    @pytest.mark.parametrize(
+        ("person_state", "sleep_state", "expected"),
+        [
+            # Person home + sleep sensor on → sleeping
+            ("home", STATE_ON, True),
+            # Person home + sleep sensor off → not sleeping
+            ("home", STATE_OFF, False),
+            # Person definitively away → not sleeping even with sensor on
+            ("not_home", STATE_ON, False),
+            # Person in a named zone (away) → not sleeping
+            ("work", STATE_ON, False),
+            # Regression #464: person entity without device trackers reports
+            # "unknown" — presence indeterminable, trust the sleep sensor
+            ("unknown", STATE_ON, True),
+            ("unknown", STATE_OFF, False),
+            ("unavailable", STATE_ON, True),
+        ],
+    )
+    def test_evaluate_sleep_state_person_entity(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        person_state: str,
+        sleep_state: str,
+        expected: bool,
+    ) -> None:
+        """Test sleep evaluation against person entity states (no device tracker)."""
+        person = PersonConfig(
+            person_entity="person.test",
+            sleep_sensors=["binary_sensor.in_bed"],
+            sleep_area_id="bedroom",
+        )
+        sensor = self._make_sensor(hass, coordinator, person)
+
+        hass.states.async_set("person.test", person_state)
+        hass.states.async_set("binary_sensor.in_bed", sleep_state)
+
+        assert sensor._evaluate_sleep_state() is expected
+
+    def test_evaluate_sleep_state_missing_person_entity(
+        self, hass: HomeAssistant, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Test that a missing person entity does not block sleep detection."""
+        person = PersonConfig(
+            person_entity="person.missing",
+            sleep_sensors=["binary_sensor.in_bed"],
+            sleep_area_id="bedroom",
+        )
+        sensor = self._make_sensor(hass, coordinator, person)
+
+        hass.states.async_set("binary_sensor.in_bed", STATE_ON)
+
+        assert sensor._evaluate_sleep_state() is True
+
+    @pytest.mark.parametrize(
+        ("tracker_state", "expected"),
+        [
+            ("home", True),
+            ("not_home", False),
+            # Tracker unavailable → presence unknown, trust sleep sensor
+            ("unavailable", True),
+        ],
+    )
+    def test_evaluate_sleep_state_device_tracker_precedence(
+        self,
+        hass: HomeAssistant,
+        coordinator: AreaOccupancyCoordinator,
+        tracker_state: str,
+        expected: bool,
+    ) -> None:
+        """Test that a configured device tracker takes precedence over the person entity."""
+        person = PersonConfig(
+            person_entity="person.test",
+            sleep_sensors=["binary_sensor.in_bed"],
+            sleep_area_id="bedroom",
+            device_tracker="device_tracker.phone",
+        )
+        sensor = self._make_sensor(hass, coordinator, person)
+
+        # Person entity says not_home; tracker must win
+        hass.states.async_set("person.test", "not_home")
+        hass.states.async_set("device_tracker.phone", tracker_state)
+        hass.states.async_set("binary_sensor.in_bed", STATE_ON)
+
+        assert sensor._evaluate_sleep_state() is expected
+
+    def test_evaluate_sleep_state_numeric_sensor_unknown_presence(
+        self, hass: HomeAssistant, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Test numeric confidence threshold still applies when presence is unknown."""
+        person = PersonConfig(
+            person_entity="person.test",
+            sleep_sensors=["sensor.sleep_confidence"],
+            sleep_area_id="bedroom",
+            confidence_threshold=80,
+        )
+        sensor = self._make_sensor(hass, coordinator, person)
+
+        hass.states.async_set("person.test", "unknown")
+
+        hass.states.async_set("sensor.sleep_confidence", "85")
+        assert sensor._evaluate_sleep_state() is True
+
+        hass.states.async_set("sensor.sleep_confidence", "40")
+        assert sensor._evaluate_sleep_state() is False
+
+    def test_extra_state_attributes_unknown_presence(
+        self, hass: HomeAssistant, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Test attributes report sleeping when presence is unknown and sensor active."""
+        person = PersonConfig(
+            person_entity="person.test",
+            sleep_sensors=["binary_sensor.in_bed"],
+            sleep_area_id="bedroom",
+        )
+        sensor = self._make_sensor(hass, coordinator, person)
+
+        hass.states.async_set("person.test", "unknown")
+        hass.states.async_set("binary_sensor.in_bed", STATE_ON)
+
+        attributes = sensor.extra_state_attributes
+        assert attributes["people"][0]["sleeping"] is True
+        assert attributes["people_sleeping"] == ["person.test"]


### PR DESCRIPTION
## What & Why

Fixes #464.

The sleep presence sensor gates on the person being home before checking sleep sensors. A person entity with **no device trackers assigned** reports state `unknown`, which the check `home_state.state != STATE_HOME` treated identically to being away — so sleep was never detected for those people, exactly as @laszlojakab traced in the issue.

## Change

- New `_person_home_state()` helper returns `True`/`False` when presence is known (device tracker if configured, else person entity) and `None` when it can't be determined (`unknown`/`unavailable`/missing entity).
- `_evaluate_sleep_state()` now skips a person only when they are **definitively away**. When presence is unknown, the sleep sensors are trusted directly, as suggested in the issue.
- The same logic applies to the `sleeping` flag in the entity attributes, so state and attributes stay consistent.
- A person who is `not_home` or in a named zone still blocks sleep detection — behavior for tracked people is unchanged.

## Tests

`SleepPresenceSensor` had no test coverage; added 13 cases covering home/away/zone/unknown/unavailable person states, device-tracker precedence over the person entity, numeric confidence thresholds under unknown presence, missing person entities, and the attributes path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sleep detection when a person’s presence cannot be confirmed, so sleep status is handled more consistently.
  * Sleep-related status now works even when person information is missing or unavailable.
  * Presence checks now better respect tracker priority and confidence settings.
  * Updated displayed sleep attributes so unknown presence is treated more naturally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->