### PR TITLE
fix(decay): respect custom half-life for Bedroom purpose

### DIFF
--- a/custom_components/area_occupancy/data/decay.py
+++ b/custom_components/area_occupancy/data/decay.py
@@ -59,6 +59,12 @@ class Decay:
         if self._purpose is None or self._purpose.awake_half_life is None:
             return self._base_half_life
 
+        # A user-configured half-life overrides the sleep/awake switching:
+        # the awake_half_life alternative only applies when the half-life
+        # is the purpose's own default (#481).
+        if self._base_half_life != self._purpose.half_life:
+            return self._base_half_life
+
         # If sleep times are not configured, use base half-life
         if not self.sleep_start or not self.sleep_end:
             return self._base_half_life

--- a/tests/test_data_decay.py
+++ b/tests/test_data_decay.py
@@ -532,6 +532,31 @@ class TestDecayHalfLife:
             current_time, sleep_start, sleep_end, expected_half_life, SLEEPING_HALF_LIFE
         )
 
+    @pytest.mark.parametrize(
+        ("current_time", "sleep_start", "sleep_end"),
+        [
+            # Outside the sleep window — previously returned awake_half_life,
+            # discarding the user's custom value
+            ("12:00:00", "23:00:00", "07:00:00"),
+            ("22:59:59", "23:00:00", "07:00:00"),
+            # Inside the sleep window
+            ("01:00:00", "23:00:00", "07:00:00"),
+        ],
+    )
+    def test_sleeping_custom_half_life_respected(
+        self, current_time: str, sleep_start: str, sleep_end: str
+    ) -> None:
+        """Test a custom half-life overrides sleep/awake switching (#481).
+
+        Regression test: a Bedroom-purpose area with a user-configured
+        half-life (e.g. 10s) used awake_half_life (620s) outside the sleep
+        window, ignoring the custom value entirely.
+        """
+        custom_half_life = 10.0
+        self.check_sleep_window_half_life(
+            current_time, sleep_start, sleep_end, custom_half_life, custom_half_life
+        )
+
     def test_sleeping_error_handling_invalid_format(self) -> None:
         """Test SLEEPING purpose with invalid sleep time format falls back to base_half_life."""
         decay = Decay(


### PR DESCRIPTION
## What & Why

Fixes #481.

`Decay.half_life` implements the Bedroom (SLEEPING) sleep/awake split: inside the configured sleep window it uses the area's half-life, outside it switches to the purpose's shorter `awake_half_life` (620s) so the room clears quickly once everyone is up. The bug: that switch applied **unconditionally**, so a user-configured half-life (the reporter's 10s) was silently replaced by 620s during all waking hours — which is why the room took ~15 minutes to clear instead of ~10 seconds, and why every non-Bedroom purpose (no `awake_half_life`) behaved correctly.

## Change

The sleep/awake switch now only engages when the area's half-life equals the purpose's own default (i.e. the user left it on auto). A custom half-life wins at all times of day. This mirrors the custom-vs-default semantics established for purpose switching in #440.

Auto-configured bedrooms are unaffected: default half-life while asleep, 620s while awake, exactly as before.

## Tests

Added regression cases (custom 10s half-life inside and outside the sleep window) alongside the existing `TestDecayHalfLife` suite, which all still passes since it exercises the default-value path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE