### PR TITLE
docs: fix broken purpose link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ For an ideal setup you will need to perform these steps in Home Assistant before
 Almost every option in the config is optional, sensible defaults are available for eveything. The minimum configuration for an area is:
 
 - A Home Assistant Area. Must exist in Home Assistant first, [see here to set up areas](https://www.home-assistant.io/docs/organizing/areas/)
-- A Purpose. What the room is used for, [see more about purposes here](../features/purpose.md)
+- A Purpose. What the room is used for, [see more about purposes here](https://hankanman.github.io/Area-Occupancy-Detection/features/purpose/)
 - 1 Motion sensor. A physical device in the area like PIR, mmWave
 
 The integration will work with just these configured. Everything else can be added as you get new devices. However the more you add in, the more accurate the predictions will be.


### PR DESCRIPTION
## What & Why

Fixes #490.

The reporter's 404 URL (`.../blob/features/purpose.md`) is what GitHub produces when it resolves the README's docs-relative link `../features/purpose.md` from the repo root. The purpose docs page itself exists and is in the mkdocs nav — only this README link was broken. It now points at the published docs site (verified 200), matching the style of the README's other documentation links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE