### PR TITLE
docs: refresh stale documentation to match current behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,14 +97,18 @@ AreaOccupancyCoordinator (global singleton)
 - `db/sync.py`: Import entity states from Home Assistant recorder
 - `db/maintenance.py`: Health checks, pruning, backups
 
-**Analysis Pipeline**: Every hour (configurable), the coordinator runs:
+**Analysis Pipeline**: Every hour (configurable), the coordinator runs 13 steps in order:
 1. Sync states from recorder → import recent entity state changes
-2. Health check and pruning → validate database integrity, remove old data
-3. Populate occupied intervals cache → identify when areas were occupied
-4. Run aggregations → hourly/daily/weekly/monthly summaries
-5. Recalculate priors → update learned probabilities from historical data
-6. Correlation analysis → identify sensor relationships with occupancy
-7. Save and refresh → persist changes, update entities
+2. Database health check and pruning → validate integrity, remove old data
+3. Sensor health check → per-entity anomalies raised as HA repair issues
+4. Populate occupied intervals cache → identify when areas were occupied
+5. Interval aggregation → daily/weekly/monthly summaries
+6. Numeric aggregation → environmental sensor sample rollups
+7. Recalculate priors → update learned probabilities from historical data
+8. Correlation analysis → identify sensor relationships with occupancy
+9. Transition learning → record adjacent-area movement chains (adjacency feature)
+10. Pipeline health check → per-area calculation anomalies as repair issues
+11-13. Save, refresh coordinator, save again → persist and publish changes
 
 ### Critical Files
 
@@ -116,6 +120,7 @@ AreaOccupancyCoordinator (global singleton)
 - `data/config.py`: Configuration management for both integration-level and area-level settings
 - `data/decay.py`: Time-based probability decay implementation
 - `data/purpose.py`: Room purpose definitions (social, work, sleep, etc.) with default decay settings
+- `data/adjacency.py` + `data/trajectory.py` + `db/transitions.py`: Adjacent-areas transition learning — Bayesian boost and decay modifier from learned room-to-room movement
 - `db/core.py`: Database initialization, connection management
 - `db/correlation.py`: Statistical analysis of sensor-occupancy relationships (660+ lines)
 - `utils.py`: Bayesian probability calculations, state mapping utilities
@@ -144,7 +149,7 @@ The integration uses Home Assistant's config flow with a **list-based multi-area
 
 Tests use `pytest-homeassistant-custom-component` with extensive mocking:
 - `tests/conftest.py`: Shared fixtures for Home Assistant, coordinator, database
-- 85%+ coverage requirement (90% for core calculations)
+- Coverage: 85% enforced in CI (`fail_under` in pyproject.toml); aim for 90%+ on core calculation modules
 - Tests organized by component: area, coordinator, db, entities, config flow, etc.
 - Mock Home Assistant services, entity states, recorder data
 - Use `pytest-cov` for coverage reporting
@@ -197,11 +202,11 @@ The integration uses timezone-aware datetimes throughout:
 
 ### Branch and Release Strategy
 
-- Development happens on `dev` branch
-- PR from `dev` to `preview` for prereleases
-- PR from `preview` to `main` for full releases
-- Use semantic versioning (MAJOR.MINOR.PATCH)
-- Version stored in `pyproject.toml`, `const.py`, and `manifest.json`
+- Feature/fix branches PR directly to `main` (a repository ruleset requires PRs; the historical `dev`/`preview` flow is retired)
+- Versioning is CalVer: `YYYY.M.N` (e.g. `2026.7.1`), with `-preN` suffixes for pre-releases
+- Version stored in three files that must always match: `pyproject.toml`, `const.py` (`DEVICE_SW_VERSION`), and `manifest.json` — the release workflow hard-fails if `manifest.json` doesn't equal the release tag
+- GitHub Releases are the changelog of record (`CHANGELOG.md` is retired); release notes are hand-written narrative
+- Pre-releases are published with the GitHub prerelease flag and soak on the maintainer's install before GA
 
 ### Pre-commit Hooks
 
@@ -213,7 +218,8 @@ Pre-commit runs ruff formatting and linting automatically. If it fails:
 ### Code Style
 
 - Use ruff for formatting and linting (matches Home Assistant core standards)
-- Full type annotations required (Python 3.13+)
+- Full type annotations required
+- The dev/test environment runs Python 3.14 (`.python-version`, required by the pinned `homeassistant` test dependency), but shipped integration code must stay importable on Python 3.13 — the runtime of older supported HA installs. `[tool.ruff] target-version = "py313"` guards this; do not raise it without raising the minimum supported HA version
 - Google-style docstrings for public APIs
 - Log at appropriate levels: debug for internals, info for user-visible events, warning/error for issues
 - Use `_LOGGER` from module-level `logging.getLogger(__name__)`

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ AOD is extensively documented [here](https://hankanman.github.io/Area-Occupancy-
 - **Location Aware**: Leveraging BLE, WiFi, GPS.
 - **Weather-Aware**: Integrate weather data into priors (cold and rainy → more likely to be indoors).
 - **Occupancy Zone Hierarchies**:
-  - **Parent-Child Area Relationships**: If the kitchen is occupied and the dining room is adjacent, allow probabilities to influence each other.
+  - **Parent-Child Area Relationships**: Hierarchical zones (floor → room) whose occupancy aggregates and cascades — beyond the peer-to-peer influence that [Adjacent Areas](https://hankanman.github.io/Area-Occupancy-Detection/features/adjacent-areas/) now provides.
   - **Multi-Room Tracking**: Track movement across rooms for more continuous occupancy detection.
 
 ## Installation

--- a/docs/docs/features/sensor-health.md
+++ b/docs/docs/features/sensor-health.md
@@ -19,14 +19,33 @@ Thresholds are tuned per sensor type to avoid false positives:
 
 ### Stuck Active (sensor continuously "on")
 
-| Sensor Type | Threshold | Rationale |
+| Sensor Type | Base Threshold | Rationale |
 |------------|-----------|-----------|
-| Motion | 2 hours | PIR sensors should cycle on/off frequently |
+| Motion | 8 hours | mmWave/presence sensors can legitimately stay active for a whole evening |
 | Media | 12 hours | TVs/speakers may run for hours but not overnight |
 | Appliance | 24 hours | Ovens/washers can run for hours but not a full day |
 | Door | 48 hours | Doors can legitimately stay open for a day or two |
 | Window | 72 hours | Windows may stay open for days in warm weather |
 | Cover | 24 hours | Covers shouldn't stay in transition for a full day |
+
+The base threshold is multiplied by the area's [purpose](purpose.md), so rooms
+where long stillness is normal get much more headroom:
+
+| Area Purpose | Multiplier | Effective motion threshold |
+|------------|-----------|-----------|
+| Bedroom (`Sleeping`) | ×6 | 48 hours |
+| Media Room (`Relaxing`) | ×4 | 32 hours |
+| Office (`Working`) | ×3 | 24 hours |
+| All other purposes | ×1 | 8 hours |
+
+Two exemptions apply: `media_player.*` entities are never flagged for being
+`unavailable` (a TV powering off is normal operation, not a fault), and the
+virtual Sleep presence sensor is excluded from all health checks.
+
+!!! tip "Turning it all off"
+    Repair monitoring can be disabled entirely under **Configure → Global
+    Settings → Enable sensor health monitoring**. Ignored repair issues also
+    stay ignored across restarts and condition flaps.
 
 ### Stuck Inactive (sensor never changes state)
 
@@ -134,11 +153,11 @@ A Zigbee motion sensor runs out of battery and goes `unavailable`. After 1 hour,
 
 ### Stuck Sensor
 
-A PIR sensor gets stuck in the "on" state (hardware malfunction). After 2 hours:
+A PIR sensor gets stuck in the "on" state (hardware malfunction). After the 8-hour base threshold (this area has no purpose multiplier):
 
 > **binary_sensor.toilet_motion_1 appears stuck in Toilet**
 >
-> The motion sensor has been continuously active for 3 hours, which exceeds the 2-hour threshold.
+> The motion sensor has been continuously active for 9 hours, which exceeds the 8-hour threshold.
 
 ### Misconfigured Sensor
 

--- a/docs/docs/getting-started/configuration.md
+++ b/docs/docs/getting-started/configuration.md
@@ -20,6 +20,8 @@ Area configuration uses a multi-step wizard that walks you through setup one sec
 
 Select the Home Assistant area and its primary [Purpose](../features/purpose.md). The purpose sets a sensible default for the [decay](../features/decay.md) half-life used when probability decreases.
 
+You can also select **Adjacent Areas** — other configured areas that physically connect to this one (a hallway and the bedroom it leads to, for example). The selection is symmetric: adding an area here also adds this one to its neighbour's list. Adjacency has no fixed strength setting; the integration learns how your household actually moves between the rooms and uses that to influence probability and decay. See [Adjacent Areas](../features/adjacent-areas.md) for details and what to expect during the learning period.
+
 The following purposes are available (in order of decay time, shortest to longest):
 
 - Passageway

--- a/docs/docs/technical/database-schema.md
+++ b/docs/docs/technical/database-schema.md
@@ -103,9 +103,9 @@ Stores state change intervals for all sensors.
 
 **Retention Policy:**
 
-- Raw intervals: 60 days
-- Daily aggregates: 90 days
-- Weekly aggregates: 365 days
+- Raw intervals: 28 days
+- Daily aggregates: 28 days (then rolled into weekly)
+- Weekly aggregates: 56 days (then rolled into monthly)
 - Monthly aggregates: 5 years
 
 ### `priors`
@@ -523,10 +523,10 @@ Stores database metadata (version, last prune time, etc.).
 
 1. **Raw Intervals**: State changes from Home Assistant recorder are converted to intervals and stored in `intervals` table with `aggregation_level="raw"`.
 2. **Aggregation**: Periodically, raw intervals are aggregated:
-   - Raw → Daily: After 60 days
-   - Daily → Weekly: After 90 days
-   - Weekly → Monthly: After 365 days
-   - Monthly aggregates are retained indefinitely
+   - Raw → Daily: After 28 days (`RETENTION_RAW_INTERVALS_DAYS`)
+   - Daily → Weekly: After 28 days (`RETENTION_DAILY_AGGREGATES_DAYS`)
+   - Weekly → Monthly: After 56 days (`RETENTION_WEEKLY_AGGREGATES_DAYS`)
+   - Monthly aggregates are retained for 5 years (effectively indefinite for trends)
 3. **Occupied Intervals Cache**: Raw intervals are processed to create precomputed occupied intervals stored in `occupied_intervals_cache`.
 
 ### Prior Calculation
@@ -544,10 +544,10 @@ Stores database metadata (version, last prune time, etc.).
 
 | Data Type                   | Retention Period               | Aggregation      |
 | --------------------------- | ------------------------------ | ---------------- |
-| Raw intervals               | 60 days                        | None             |
-| Raw numeric samples         | 14 days                        | None             |
-| Daily interval aggregates   | 90 days                        | From raw         |
-| Weekly interval aggregates  | 365 days                       | From daily       |
+| Raw intervals               | 28 days                        | None             |
+| Raw numeric samples         | 7 days                         | None             |
+| Daily interval aggregates   | 28 days                        | From raw         |
+| Weekly interval aggregates  | 56 days                        | From daily       |
 | Monthly interval aggregates | 5 years                        | From weekly      |
 | Hourly numeric aggregates   | 30 days                        | From raw samples |
 | Weekly numeric aggregates   | 3 years                        | From hourly      |


### PR DESCRIPTION
## What & Why

Follow-up audit after the 2026.7.1-pre1 wave: four docs of record had drifted from the code they describe.

- **sensor-health.md** still documented the pre-#474 thresholds (motion stuck-active "2 hours") — the false-positive fix wave from 2026.5.17 never reached this page. Now shows the 8h base, the purpose-multiplier table (Bedroom ×6 = 48h etc.), the `media_player.*` unavailable exemption, sleep-sensor exclusion, and the global monitoring toggle; the worked example updated to match.
- **database-schema.md** retention numbers matched no constant in the code (documented 60/14/90/365 days vs actual 28/7/28/56 from `const.py`) — corrected in the retention policy list, the aggregation flow, and the retention table, with constant names cited.
- **configuration.md** now documents the **Adjacent Areas** field added in #454 (symmetric selection, learned influence, link to the feature page).
- **CLAUDE.md** brought back to reality: 13-step analysis pipeline (was 7), CalVer + PR-to-main release strategy (was the retired dev→preview semver flow), enforced-85%/aspirational-90% coverage wording, the Python 3.14-dev / 3.13-runtime split with the ruff guard, and the adjacency modules in the critical-files list.

`mkdocs build` passes. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE