### PR TITLE
feat(trust-score): shadow-mode accuracy metrics (#499 phase 1)

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -320,6 +320,12 @@ AGGREGATION_LEVEL_RAW: Final = "raw"
 
 # Correlation analysis constants
 # Minimum samples needed for reliable correlation
+# --- Trust score (#499, shadow mode) ---
+# Rolling tick-buffer depth per area: ~24h at the 10s decay cadence.
+ACCURACY_TICK_BUFFER_MAXLEN: Final = 8640
+# Hours of tick history scored against ground truth each analysis cycle.
+ACCURACY_WINDOW_HOURS: Final = 24
+
 MIN_CORRELATION_SAMPLES: Final = 50
 # Minimum confidence for correlation to be considered significant
 CORRELATION_CONFIDENCE_THRESHOLD: Final = 0.7

--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 # Standard library imports
+from collections import deque
 import contextlib
 from datetime import datetime, timedelta
 import logging
@@ -29,7 +30,14 @@ from homeassistant.util import dt as dt_util
 
 # Local imports
 from .area import AllAreas, Area, AreaDeviceHandle, FloorAreas
-from .const import CONF_AREA_ID, CONF_AREAS, DEFAULT_NAME, DOMAIN, SAVE_INTERVAL
+from .const import (
+    ACCURACY_TICK_BUFFER_MAXLEN,
+    CONF_AREA_ID,
+    CONF_AREAS,
+    DEFAULT_NAME,
+    DOMAIN,
+    SAVE_INTERVAL,
+)
 from .data.adjacency import (
     BoostContribution,
     DecayModifierContribution,
@@ -39,6 +47,7 @@ from .data.adjacency import (
 )
 from .data.analysis import run_full_analysis
 from .data.config import IntegrationConfig
+from .data.metrics import AccuracyMetrics, TickSample
 from .data.trajectory import TrajectoryTracker
 from .db import AreaOccupancyDB
 from .db.transitions import build_adjacency_index, lookup_transition_probability
@@ -115,6 +124,12 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Decay modifiers (Option 3a) precomputed alongside the boosts
         # and applied to each entity's ``Decay.modifier_factor``.
         self._adjacency_decay_modifiers: dict[str, DecayModifierContribution] = {}
+        # Trust-score epic (#499), shadow mode: rolling per-area tick
+        # observations scored hourly against motion-confirmed ground
+        # truth. maxlen bounds memory to ~24h at the 10s decay cadence.
+        # Nothing here feeds back into probability or thresholds.
+        self._accuracy_ticks: dict[str, deque[TickSample]] = {}
+        self._accuracy_metrics: dict[str, AccuracyMetrics] = {}
 
     async def async_init_database(self) -> None:
         """Initialize the database asynchronously to avoid blocking the event loop.
@@ -563,6 +578,11 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 is_occupied=is_occupied,
                 now=now,
             )
+            self._accuracy_ticks.setdefault(
+                area_name, deque(maxlen=ACCURACY_TICK_BUFFER_MAXLEN)
+            ).append(
+                TickSample(timestamp=now, probability=probability, occupied=is_occupied)
+            )
             result[area_name] = {
                 "probability": probability,
                 "occupied": is_occupied,
@@ -599,6 +619,23 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> DecayModifierContribution | None:
         """Return the cached decay modifier for ``area_name`` this tick."""
         return self._adjacency_decay_modifiers.get(area_name)
+
+    # --- Trust score (#499, shadow mode) accessors ---
+    def accuracy_samples_for(self, area_name: str) -> list[TickSample]:
+        """Return the rolling tick observations for an area, oldest first."""
+        return list(self._accuracy_ticks.get(area_name, ()))
+
+    def accuracy_metrics_for(self, area_name: str) -> AccuracyMetrics | None:
+        """Return the most recent shadow accuracy snapshot for an area.
+
+        ``None`` until the hourly analysis pipeline has scored the area
+        at least once (or when the area has no tick history yet).
+        """
+        return self._accuracy_metrics.get(area_name)
+
+    def set_accuracy_metrics(self, area_name: str, metrics: AccuracyMetrics) -> None:
+        """Cache an area's shadow accuracy snapshot (analysis pipeline)."""
+        self._accuracy_metrics[area_name] = metrics
 
     def _compute_adjacency_state(
         self, now: datetime

--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -11,7 +11,12 @@ from typing import TYPE_CHECKING
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
 
-from ..const import DEFAULT_LOOKBACK_DAYS, TIME_PRIOR_MAX_BOUND, TIME_PRIOR_MIN_BOUND
+from ..const import (
+    ACCURACY_WINDOW_HOURS,
+    DEFAULT_LOOKBACK_DAYS,
+    TIME_PRIOR_MAX_BOUND,
+    TIME_PRIOR_MIN_BOUND,
+)
 from ..db.correlation import (
     CORRELATION_FAILURE_ERRORS,
     get_correlatable_entities_by_area,
@@ -37,7 +42,7 @@ async def run_full_analysis(
 ) -> None:
     """Run the full analysis chain for all areas.
 
-    This function orchestrates the complete 13-step analysis process:
+    This function orchestrates the complete 14-step analysis process:
     1. Sync states from recorder
     2. Database health check and pruning
     3. Sensor health check (per-entity anomalies → repair issues)
@@ -49,10 +54,12 @@ async def run_full_analysis(
     9. Transition learning (adjacent-areas Phase 3: count chain
        observations into ``AreaTransitions`` for the Bayesian boost
        and decay modifier)
-    10. Pipeline health check (per-area calc anomalies → repair issues)
-    11. Save data (preserve decay state before refresh)
-    12. Refresh coordinator
-    13. Save data (persist all changes)
+    10. Accuracy metrics (trust score #499, shadow mode: calibration +
+        decision stability vs motion-confirmed ground truth)
+    11. Pipeline health check (per-area calc anomalies → repair issues)
+    12. Save data (preserve decay state before refresh)
+    13. Refresh coordinator
+    14. Save data (persist all changes)
 
     Args:
         coordinator: The coordinator instance containing areas and database
@@ -66,7 +73,7 @@ async def run_full_analysis(
     analysis_start_time = time.perf_counter()
     failed_steps: list[str] = []
     cancelled = False
-    total_steps = 13
+    total_steps = 14
 
     async def _run_step(step_num: int, step_name: str, coro: Awaitable[None]) -> None:
         """Run a single analysis step with timing and error tracking."""
@@ -144,10 +151,11 @@ async def run_full_analysis(
         await _run_step(7, "recalculate_priors", _recalculate_priors())
         await _run_step(8, "correlation_analysis", _run_correlations())
         await _run_step(9, "transition_learning", _run_transition_learning(coordinator))
-        await _run_step(10, "pipeline_health_check", _pipeline_health_check())
-        await _run_step(11, "save_data_before_refresh", _save_data())
-        await _run_step(12, "refresh_coordinator", _refresh())
-        await _run_step(13, "save_data_after_refresh", _save_data())
+        await _run_step(10, "accuracy_metrics", _run_accuracy_metrics(coordinator))
+        await _run_step(11, "pipeline_health_check", _pipeline_health_check())
+        await _run_step(12, "save_data_before_refresh", _save_data())
+        await _run_step(13, "refresh_coordinator", _refresh())
+        await _run_step(14, "save_data_after_refresh", _save_data())
 
     except Exception as err:
         _LOGGER.error("Fatal error during analysis pipeline: %s", err)
@@ -246,6 +254,52 @@ async def _run_transition_learning(coordinator: AreaOccupancyCoordinator) -> Non
         coordinator.db,
         coordinator.config_entry.entry_id,
     )
+
+
+async def _run_accuracy_metrics(coordinator: AreaOccupancyCoordinator) -> None:
+    """Score each area's probability stream against ground truth (#499).
+
+    Shadow mode: computes calibration + decision-stability metrics from
+    the coordinator's rolling tick buffer and the motion-confirmed
+    occupied intervals, caches them for diagnostics, and logs a summary.
+    Nothing feeds back into probability, thresholds, or decay.
+    """
+    # Lazy import mirrors the transition-learning step's pattern.
+    from .metrics import compute_accuracy_metrics  # noqa: PLC0415
+
+    now = dt_util.utcnow()
+    window_start = now - timedelta(hours=ACCURACY_WINDOW_HOURS)
+    for area_name in coordinator.areas:
+        samples = [
+            s
+            for s in coordinator.accuracy_samples_for(area_name)
+            if s.timestamp >= window_start
+        ]
+        if not samples:
+            continue
+        intervals = await coordinator.hass.async_add_executor_job(
+            lambda name=area_name: coordinator.db.get_occupied_intervals(
+                area_name=name, start_time=window_start
+            )
+        )
+        metrics = compute_accuracy_metrics(samples, intervals)
+        coordinator.set_accuracy_metrics(area_name, metrics)
+        _LOGGER.debug(
+            "Accuracy (shadow) for area %s: samples=%d ece=%.4f agreement=%.3f "
+            "false_on=%s false_off=%s decision_flips=%d truth_flips=%d",
+            area_name,
+            metrics.sample_count,
+            metrics.expected_calibration_error or 0.0,
+            metrics.agreement or 0.0,
+            f"{metrics.false_on_rate:.3f}"
+            if metrics.false_on_rate is not None
+            else "n/a",
+            f"{metrics.false_off_rate:.3f}"
+            if metrics.false_off_rate is not None
+            else "n/a",
+            metrics.decision_transitions,
+            metrics.truth_transitions,
+        )
 
 
 async def _run_pipeline_health_check(

--- a/custom_components/area_occupancy/data/metrics.py
+++ b/custom_components/area_occupancy/data/metrics.py
@@ -1,0 +1,201 @@
+"""Shadow-mode accuracy metrics for the trust-score epic (#499).
+
+Pure math over two inputs the coordinator already produces:
+
+* **Tick samples** — the per-refresh ``(timestamp, probability, occupied)``
+  triples the coordinator records for each area (10s decay-timer cadence).
+* **Occupied intervals** — the motion-confirmed ground truth the prior
+  learning already uses (``db.get_occupied_intervals``).
+
+Two questions get answered per area:
+
+1. **Calibration** — when the engine says 70%, is the area actually
+   occupied about 70% of those times? Reported as per-bin reliability
+   rows plus the expected calibration error (ECE), the count-weighted
+   mean of |mean predicted − observed rate| across bins.
+2. **Decision stability** — how often does the occupancy binary flip
+   compared to the ground truth, and how much of the time does the
+   decision disagree with the truth (false-on / false-off rates)?
+
+This module deliberately has no coordinator or DB dependencies —
+callers gather inputs and pass them in, mirroring ``data/adjacency.py``,
+so the math stays testable without SQLite or Home Assistant.
+
+Shadow-mode contract: nothing here feeds back into probability,
+thresholds, or decay. Metrics are computed, cached, logged, and exported
+in diagnostics only. Promotion to a user-facing sensor or auto-threshold
+routes through the change-control gates (see issue #499's phases).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+
+DEFAULT_CALIBRATION_BINS = 10
+
+
+@dataclass(frozen=True)
+class TickSample:
+    """One coordinator refresh observation for an area."""
+
+    timestamp: datetime
+    probability: float
+    occupied: bool
+
+
+@dataclass
+class CalibrationBin:
+    """Reliability row for one probability band."""
+
+    lower: float
+    upper: float
+    count: int = 0
+    mean_probability: float = 0.0
+    observed_rate: float = 0.0
+
+
+@dataclass
+class AccuracyMetrics:
+    """Per-area shadow accuracy snapshot over an evaluation window."""
+
+    sample_count: int = 0
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+    # Calibration
+    expected_calibration_error: float | None = None
+    bins: list[CalibrationBin] = field(default_factory=list)
+    # Decision stability (sample-weighted at the fixed tick cadence)
+    decision_transitions: int = 0
+    truth_transitions: int = 0
+    false_on_rate: float | None = None  # P(decision on | truth off)
+    false_off_rate: float | None = None  # P(decision off | truth on)
+    agreement: float | None = None  # fraction of samples where decision == truth
+
+
+def _is_occupied_at(ts: datetime, intervals: list[tuple[datetime, datetime]]) -> bool:
+    """Return whether ``ts`` falls inside any occupied interval.
+
+    Intervals are half-open ``[start, end)`` so a tick landing exactly on
+    an interval boundary is attributed to only one side.
+    """
+    return any(start <= ts < end for start, end in intervals)
+
+
+def compute_accuracy_metrics(
+    samples: list[TickSample],
+    occupied_intervals: list[tuple[datetime, datetime]],
+    *,
+    bins: int = DEFAULT_CALIBRATION_BINS,
+) -> AccuracyMetrics:
+    """Score an area's probability stream against motion-confirmed truth.
+
+    Args:
+        samples: Tick observations ordered oldest-first. Samples outside
+            the intervals' coverage are still scored (truth = not
+            occupied), matching how the prior denominator treats
+            quiet time (#483 lesson: unobserved-quiet counts).
+        occupied_intervals: Motion-confirmed ``(start, end)`` ground
+            truth, same source the prior learning uses.
+        bins: Number of equal-width probability bands for calibration.
+
+    Returns:
+        ``AccuracyMetrics``; with no samples, a zeroed snapshot whose
+        rate fields stay ``None`` (unknown, not zero).
+    """
+    out = AccuracyMetrics()
+    if not samples:
+        return out
+
+    out.sample_count = len(samples)
+    out.window_start = samples[0].timestamp
+    out.window_end = samples[-1].timestamp
+
+    bin_count = [0] * bins
+    bin_prob_sum = [0.0] * bins
+    bin_hits = [0] * bins
+
+    true_on = true_off = false_on = false_off = 0
+    prev_decision: bool | None = None
+    prev_truth: bool | None = None
+
+    for sample in samples:
+        truth = _is_occupied_at(sample.timestamp, occupied_intervals)
+
+        # Calibration accumulation
+        p = min(max(sample.probability, 0.0), 1.0)
+        idx = min(int(p * bins), bins - 1)
+        bin_count[idx] += 1
+        bin_prob_sum[idx] += p
+        if truth:
+            bin_hits[idx] += 1
+
+        # Confusion accumulation
+        if sample.occupied and truth:
+            true_on += 1
+        elif sample.occupied and not truth:
+            false_on += 1
+        elif not sample.occupied and truth:
+            false_off += 1
+        else:
+            true_off += 1
+
+        # Flip counting
+        if prev_decision is not None and sample.occupied != prev_decision:
+            out.decision_transitions += 1
+        if prev_truth is not None and truth != prev_truth:
+            out.truth_transitions += 1
+        prev_decision = sample.occupied
+        prev_truth = truth
+
+    # Reliability rows + ECE
+    ece = 0.0
+    for i in range(bins):
+        row = CalibrationBin(lower=i / bins, upper=(i + 1) / bins)
+        row.count = bin_count[i]
+        if row.count:
+            row.mean_probability = bin_prob_sum[i] / row.count
+            row.observed_rate = bin_hits[i] / row.count
+            ece += (row.count / out.sample_count) * abs(
+                row.mean_probability - row.observed_rate
+            )
+        out.bins.append(row)
+    out.expected_calibration_error = ece
+
+    truth_off_total = true_off + false_on
+    truth_on_total = true_on + false_off
+    if truth_off_total:
+        out.false_on_rate = false_on / truth_off_total
+    if truth_on_total:
+        out.false_off_rate = false_off / truth_on_total
+    out.agreement = (true_on + true_off) / out.sample_count
+
+    return out
+
+
+def metrics_to_diagnostics(metrics: AccuracyMetrics) -> dict:
+    """Flatten an ``AccuracyMetrics`` into a JSON-safe diagnostics block."""
+    return {
+        "shadow_mode": True,
+        "sample_count": metrics.sample_count,
+        "window_start": metrics.window_start.isoformat()
+        if metrics.window_start
+        else None,
+        "window_end": metrics.window_end.isoformat() if metrics.window_end else None,
+        "expected_calibration_error": metrics.expected_calibration_error,
+        "agreement": metrics.agreement,
+        "false_on_rate": metrics.false_on_rate,
+        "false_off_rate": metrics.false_off_rate,
+        "decision_transitions": metrics.decision_transitions,
+        "truth_transitions": metrics.truth_transitions,
+        "calibration_bins": [
+            {
+                "band": f"{b.lower:.1f}-{b.upper:.1f}",
+                "count": b.count,
+                "mean_probability": round(b.mean_probability, 4),
+                "observed_rate": round(b.observed_rate, 4),
+            }
+            for b in metrics.bins
+            if b.count
+        ],
+    }

--- a/custom_components/area_occupancy/diagnostics.py
+++ b/custom_components/area_occupancy/diagnostics.py
@@ -20,6 +20,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_VERSION, CONF_VERSION_MINOR, DEVICE_SW_VERSION
+from .data.metrics import metrics_to_diagnostics
 from .db import queries
 
 if TYPE_CHECKING:
@@ -252,6 +253,9 @@ def _area_snapshot(
         adjacency = _adjacency_snapshot(coordinator, area_name)
         if adjacency:
             current["adjacency"] = adjacency
+        accuracy = coordinator.accuracy_metrics_for(area_name)
+        if accuracy is not None:
+            current["accuracy"] = metrics_to_diagnostics(accuracy)
         snapshot["current"] = current
     except Exception as err:  # noqa: BLE001 — see docstring
         _LOGGER.warning(

--- a/tests/test_data_metrics.py
+++ b/tests/test_data_metrics.py
@@ -1,0 +1,218 @@
+"""Tests for the shadow-mode accuracy metrics (trust score, #499)."""
+
+from datetime import UTC, datetime, timedelta
+import json
+from unittest.mock import patch
+
+from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
+from custom_components.area_occupancy.data.analysis import _run_accuracy_metrics
+from custom_components.area_occupancy.data.metrics import (
+    AccuracyMetrics,
+    TickSample,
+    compute_accuracy_metrics,
+    metrics_to_diagnostics,
+)
+from custom_components.area_occupancy.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.core import HomeAssistant
+
+T0 = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+
+
+def _samples(spec: list[tuple[float, bool]]) -> list[TickSample]:
+    """Build ticks 10s apart from (probability, occupied) pairs."""
+    return [
+        TickSample(timestamp=T0 + timedelta(seconds=10 * i), probability=p, occupied=o)
+        for i, (p, o) in enumerate(spec)
+    ]
+
+
+class TestComputeAccuracyMetrics:
+    """Pure-math behavior of compute_accuracy_metrics."""
+
+    def test_empty_samples_returns_unknowns(self) -> None:
+        """No data means rates are None (unknown), not zero."""
+        out = compute_accuracy_metrics([], [])
+        assert out.sample_count == 0
+        assert out.expected_calibration_error is None
+        assert out.agreement is None
+        assert out.false_on_rate is None
+        assert out.false_off_rate is None
+
+    def test_well_calibrated_confident_stream(self) -> None:
+        """0.9 while occupied and 0.1 while empty scores ECE=0.1, agreement=1."""
+        # Truth: first 5 ticks occupied, last 5 not
+        intervals = [(T0, T0 + timedelta(seconds=50))]
+        samples = _samples([(0.9, True)] * 5 + [(0.1, False)] * 5)
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        assert out.sample_count == 10
+        # Bin 0.9: mean 0.9 vs observed 1.0; bin 0.1: mean 0.1 vs 0.0
+        # ECE = 0.5*0.1 + 0.5*0.1 = 0.1
+        assert abs(out.expected_calibration_error - 0.1) < 1e-9
+        assert out.agreement == 1.0
+        assert out.false_on_rate == 0.0
+        assert out.false_off_rate == 0.0
+        assert out.decision_transitions == 1
+        assert out.truth_transitions == 1
+
+    def test_anti_calibrated_stream(self) -> None:
+        """Confident and always wrong: agreement 0, max false rates."""
+        intervals = [(T0, T0 + timedelta(seconds=50))]
+        # Occupied period predicted empty; empty period predicted occupied
+        samples = _samples([(0.1, False)] * 5 + [(0.9, True)] * 5)
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        assert out.agreement == 0.0
+        assert out.false_on_rate == 1.0
+        assert out.false_off_rate == 1.0
+        # ECE: bin 0.1 observed 1.0 (|0.1-1.0|=0.9), bin 0.9 observed 0.0
+        assert abs(out.expected_calibration_error - 0.9) < 1e-9
+
+    def test_flip_counting_spurious_decisions(self) -> None:
+        """A flappy decision stream racks up decision flips truth lacks."""
+        intervals = [(T0, T0 + timedelta(seconds=100))]  # truth: always on
+        samples = _samples(
+            [(0.6, True), (0.4, False), (0.6, True), (0.4, False), (0.6, True)]
+        )
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        assert out.decision_transitions == 4
+        assert out.truth_transitions == 0
+        assert out.false_off_rate == 2 / 5
+
+    def test_interval_boundaries_are_half_open(self) -> None:
+        """A tick exactly at interval end counts as not occupied."""
+        intervals = [(T0, T0 + timedelta(seconds=10))]
+        samples = _samples([(0.5, False), (0.5, False)])  # t=0 inside, t=10 at end
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        # First tick truth=True (false_off), second truth=False (true_off)
+        assert out.false_off_rate == 1.0
+        assert out.agreement == 0.5
+
+    def test_probability_out_of_range_is_clamped_into_bins(self) -> None:
+        """Probabilities outside [0,1] land in the edge bins, not crash."""
+        out = compute_accuracy_metrics(
+            _samples([(1.2, True), (-0.3, False)]), [(T0, T0 + timedelta(seconds=5))]
+        )
+        assert out.sample_count == 2
+        assert sum(b.count for b in out.bins) == 2
+
+    def test_quiet_tail_counts_as_unoccupied(self) -> None:
+        """Samples after the last interval score as truth=False (#483 lesson)."""
+        intervals = [(T0, T0 + timedelta(seconds=10))]
+        samples = _samples([(0.9, True)] * 6)  # only the first tick is truly occupied
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        assert out.agreement == 1 / 6
+        assert out.false_on_rate == 1.0
+
+
+class TestDiagnosticsShape:
+    """metrics_to_diagnostics output contract."""
+
+    def test_json_safe_and_skips_empty_bins(self) -> None:
+        """The block serializes and only carries populated bins."""
+        intervals = [(T0, T0 + timedelta(seconds=50))]
+        out = compute_accuracy_metrics(
+            _samples([(0.9, True)] * 5 + [(0.1, False)] * 5), intervals
+        )
+
+        block = metrics_to_diagnostics(out)
+
+        json.dumps(block)
+        assert block["shadow_mode"] is True
+        assert block["sample_count"] == 10
+        assert len(block["calibration_bins"]) == 2
+        assert block["window_start"] == T0.isoformat()
+
+
+class TestShadowWiring:
+    """Coordinator buffer, pipeline step, and diagnostics export."""
+
+    async def test_update_records_tick_samples(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Every update() appends one sample per area."""
+        area_name = coordinator.get_area_names()[0]
+
+        await coordinator.update()
+        await coordinator.update()
+
+        samples = coordinator.accuracy_samples_for(area_name)
+        assert len(samples) == 2
+        assert 0.0 <= samples[0].probability <= 1.0
+        assert isinstance(samples[0].occupied, bool)
+
+    async def test_pipeline_step_caches_metrics(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """_run_accuracy_metrics scores buffered ticks against DB truth."""
+        area_name = coordinator.get_area_names()[0]
+        await coordinator.update()
+
+        with patch.object(
+            coordinator.db,
+            "get_occupied_intervals",
+            return_value=[],
+        ):
+            await _run_accuracy_metrics(coordinator)
+
+        metrics = coordinator.accuracy_metrics_for(area_name)
+        assert metrics is not None
+        assert metrics.sample_count >= 1
+        # With no occupied intervals, truth is always False
+        assert metrics.false_off_rate is None
+
+    async def test_no_samples_no_metrics(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """The step is a no-op for areas with an empty tick buffer."""
+        area_name = coordinator.get_area_names()[0]
+
+        await _run_accuracy_metrics(coordinator)
+
+        assert coordinator.accuracy_metrics_for(area_name) is None
+
+    async def test_diagnostics_exports_accuracy_block(
+        self, hass: HomeAssistant, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Cached metrics surface under current.accuracy and stay JSON-safe."""
+        area_name = coordinator.get_area_names()[0]
+        entry = coordinator.config_entry
+        entry.runtime_data = coordinator
+
+        coordinator.set_accuracy_metrics(
+            area_name,
+            compute_accuracy_metrics(
+                _samples([(0.8, True)] * 3),
+                [(T0, T0 + timedelta(seconds=100))],
+            ),
+        )
+
+        result = await async_get_config_entry_diagnostics(hass, entry)
+
+        area_snapshot = next(a for a in result["areas"] if a["area_name"] == area_name)
+        accuracy = area_snapshot["current"]["accuracy"]
+        assert accuracy["shadow_mode"] is True
+        assert accuracy["sample_count"] == 3
+        json.dumps(result)
+
+    async def test_metrics_never_touch_probability_path(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Shadow contract: cached metrics don't change area probability."""
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+        before = area.probability()
+
+        coordinator.set_accuracy_metrics(area_name, AccuracyMetrics(sample_count=999))
+
+        assert area.probability() == before


### PR DESCRIPTION
## What & Why

First increment of roadmap epic #499 (per-area trust score), targeting `next` per the new branching model. Implements phase 1-2 of the epic: the metrics exist, are computed hourly, and are observable — but feed back into nothing.

## Mechanism

- **`data/metrics.py`** (pure math, no coordinator/DB deps — mirrors `data/adjacency.py`): scores a stream of `(timestamp, probability, occupied)` ticks against motion-confirmed occupied intervals (the same ground truth prior learning uses). Produces reliability bins + **expected calibration error**, agreement, **false-on/false-off rates**, and decision-vs-truth **flip counts**. Unknown rates are `None`, never a misleading zero. Quiet time outside intervals scores as unoccupied (the #483 lesson applied to scoring).
- **Coordinator**: each `update()` appends one tick per area to a bounded deque (~24h at the 10s decay cadence, `ACCURACY_TICK_BUFFER_MAXLEN`).
- **Pipeline step 10 `accuracy_metrics`** (pipeline now **14 steps**): joins the last 24h of ticks with DB ground truth in the executor, caches per-area `AccuracyMetrics`, logs a one-line summary.
- **Diagnostics**: `current.accuracy` block with `shadow_mode: true`, populated bins only.

## Shadow-mode contract

Nothing here touches probability, thresholds, or decay — enforced by a dedicated test. The user-facing Accuracy sensor and earned auto-threshold are later phases of #499, gated on these metrics being stable for 14 days on two real homes.

## Tests

13 new (1792 total passing): hand-computed ECE for calibrated/anti-calibrated streams, flip counting, half-open interval boundaries, out-of-range clamping, quiet-tail truth, empty-input behavior, coordinator buffer, pipeline-step caching, diagnostics export shape, and the shadow contract.

Part of #499.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE