### PR TITLE
feat(online-prior): shadow-mode incremental prior estimator (#500 phase 1)

### DIFF
--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -25,6 +25,7 @@ from homeassistant.helpers.event import (
     async_track_state_change_event,
 )
 from homeassistant.helpers.start import async_at_started
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import dt as dt_util
 
@@ -47,7 +48,9 @@ from .data.adjacency import (
 )
 from .data.analysis import run_full_analysis
 from .data.config import IntegrationConfig
+from .data.entity_type import InputType
 from .data.metrics import AccuracyMetrics, TickSample
+from .data.online_prior import OnlinePriorEstimator, OnlinePriorState
 from .data.trajectory import TrajectoryTracker
 from .db import AreaOccupancyDB
 from .db.transitions import build_adjacency_index, lookup_transition_probability
@@ -130,6 +133,14 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # Nothing here feeds back into probability or thresholds.
         self._accuracy_ticks: dict[str, deque[TickSample]] = {}
         self._accuracy_metrics: dict[str, AccuracyMetrics] = {}
+        # DB-retirement epic (#500), shadow mode: per-area online prior
+        # estimators fed from live motion evidence each tick, persisted
+        # via the HA storage helper, and diffed against the DB-computed
+        # prior each analysis cycle. Never read by the probability path.
+        self._online_priors: dict[str, OnlinePriorEstimator] = {}
+        self._online_prior_store: Store[dict[str, dict]] = Store(
+            hass, 1, f"{DOMAIN}.online_prior.{self.entry_id}"
+        )
 
     async def async_init_database(self) -> None:
         """Initialize the database asynchronously to avoid blocking the event loop.
@@ -446,6 +457,14 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             self._validate_areas_configured()
 
+            # Restore online-prior shadow state (#500) for known areas
+            stored_priors = await self._online_prior_store.async_load() or {}
+            for area_name in self.areas:
+                if area_name in stored_priors:
+                    self._online_priors[area_name] = OnlinePriorEstimator(
+                        OnlinePriorState.from_dict(stored_priors[area_name])
+                    )
+
             _LOGGER.info(
                 "Initializing Area Occupancy for %d area(s): %s",
                 len(self.areas),
@@ -583,6 +602,13 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ).append(
                 TickSample(timestamp=now, probability=probability, occupied=is_occupied)
             )
+            motion_active = any(
+                entity.evidence and entity.type.input_type == InputType.MOTION
+                for entity in area.entities.entities.values()
+            )
+            self._online_priors.setdefault(area_name, OnlinePriorEstimator()).observe(
+                motion_active=motion_active, now=now
+            )
             result[area_name] = {
                 "probability": probability,
                 "occupied": is_occupied,
@@ -636,6 +662,17 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def set_accuracy_metrics(self, area_name: str, metrics: AccuracyMetrics) -> None:
         """Cache an area's shadow accuracy snapshot (analysis pipeline)."""
         self._accuracy_metrics[area_name] = metrics
+
+    # --- Online prior (#500, shadow mode) accessors ---
+    def online_prior_for(self, area_name: str) -> OnlinePriorEstimator | None:
+        """Return the area's shadow online-prior estimator, if any ticks seen."""
+        return self._online_priors.get(area_name)
+
+    async def async_save_online_priors(self) -> None:
+        """Persist online-prior shadow state via the HA storage helper."""
+        await self._online_prior_store.async_save(
+            {name: est.state.to_dict() for name, est in self._online_priors.items()}
+        )
 
     def _compute_adjacency_state(
         self, now: datetime

--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -54,8 +54,9 @@ async def run_full_analysis(
     9. Transition learning (adjacent-areas Phase 3: count chain
        observations into ``AreaTransitions`` for the Bayesian boost
        and decay modifier)
-    10. Accuracy metrics (trust score #499, shadow mode: calibration +
-        decision stability vs motion-confirmed ground truth)
+    10. Shadow metrics (no feedback into behavior): trust-score
+        calibration + decision stability vs ground truth (#499), and
+        the online-prior diff vs the DB-computed prior (#500)
     11. Pipeline health check (per-area calc anomalies → repair issues)
     12. Save data (preserve decay state before refresh)
     13. Refresh coordinator
@@ -151,7 +152,7 @@ async def run_full_analysis(
         await _run_step(7, "recalculate_priors", _recalculate_priors())
         await _run_step(8, "correlation_analysis", _run_correlations())
         await _run_step(9, "transition_learning", _run_transition_learning(coordinator))
-        await _run_step(10, "accuracy_metrics", _run_accuracy_metrics(coordinator))
+        await _run_step(10, "shadow_metrics", _run_shadow_metrics(coordinator))
         await _run_step(11, "pipeline_health_check", _pipeline_health_check())
         await _run_step(12, "save_data_before_refresh", _save_data())
         await _run_step(13, "refresh_coordinator", _refresh())
@@ -256,7 +257,7 @@ async def _run_transition_learning(coordinator: AreaOccupancyCoordinator) -> Non
     )
 
 
-async def _run_accuracy_metrics(coordinator: AreaOccupancyCoordinator) -> None:
+async def _run_shadow_metrics(coordinator: AreaOccupancyCoordinator) -> None:
     """Score each area's probability stream against ground truth (#499).
 
     Shadow mode: computes calibration + decision-stability metrics from
@@ -300,6 +301,37 @@ async def _run_accuracy_metrics(coordinator: AreaOccupancyCoordinator) -> None:
             metrics.decision_transitions,
             metrics.truth_transitions,
         )
+
+    # Online-prior shadow diff (#500): compare the incremental estimator
+    # against the DB-computed prior that step 7 just recalculated. A
+    # persistent, growing divergence means a bug in one of them.
+    for area_name, area in coordinator.areas.items():
+        estimator = coordinator.online_prior_for(area_name)
+        if estimator is None:
+            continue
+        online = estimator.prior(now)
+        if online is None:
+            continue
+        stored = area.prior.global_prior
+        if stored is None:
+            _LOGGER.debug(
+                "Online prior (shadow) for area %s: online=%.4f db=<not yet "
+                "calculated> observed_days=%.2f",
+                area_name,
+                online,
+                estimator.observed_days(now),
+            )
+            continue
+        _LOGGER.debug(
+            "Online prior (shadow) for area %s: online=%.4f db=%.4f diff=%+.4f "
+            "observed_days=%.2f",
+            area_name,
+            online,
+            stored,
+            online - stored,
+            estimator.observed_days(now),
+        )
+    await coordinator.async_save_online_priors()
 
 
 async def _run_pipeline_health_check(

--- a/custom_components/area_occupancy/data/online_prior.py
+++ b/custom_components/area_occupancy/data/online_prior.py
@@ -1,0 +1,135 @@
+"""Shadow-mode online global-prior estimator (DB-retirement epic, #500).
+
+Production computes the global prior by replaying motion intervals from
+the sidecar SQLite database every hour:
+
+    global_prior = clamp(occupied_seconds / (now - first_interval_start))
+
+This module maintains the same ratio as **sufficient statistics updated
+incrementally** — an occupied-seconds accumulator fed from live motion
+evidence at the coordinator's tick cadence, and the first-observation
+timestamp as the period anchor. If the online value tracks the
+DB-computed value on real homes, the raw-interval replay (and eventually
+the database itself) is unnecessary for prior learning.
+
+Shadow-mode contract: the online value is computed, persisted (HA
+storage helper), diffed against the DB value each analysis cycle, and
+exported in diagnostics. It is **never read by the probability path**.
+Promotion routes through #500's 30-day shadow-diff gate.
+
+Known, accepted approximations vs the DB path (they bound the expected
+diff; see #500 step 2 for how the diff is judged):
+
+* **Sampling**: occupied time accrues in tick-sized quanta (~10s)
+  from live motion evidence, vs the DB's exact interval boundaries
+  replayed from the recorder.
+* **No motion-timeout extension**: the DB path extends each motion
+  interval by the area's motion timeout during merging; the online
+  numerator does not, so it reads slightly low on areas with sparse
+  motion.
+* **Retention**: the DB period re-anchors as old intervals are pruned
+  (365-day retention); the online period anchor is fixed at first
+  observation. Irrelevant inside the 30-day shadow window.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from ..const import MAX_PRIOR, MIN_PRIOR
+from ..time_utils import ensure_utc_datetime
+
+# A tick gap larger than this is treated as downtime for the NUMERATOR:
+# we can't know whether motion continued while HA was stopped, so no
+# occupied time accrues across the gap. The DENOMINATOR intentionally
+# keeps growing across downtime — the DB path behaves the same way
+# (recorder gaps contribute period but no intervals).
+MAX_TICK_GAP_SECONDS = 60.0
+
+
+@dataclass
+class OnlinePriorState:
+    """Serializable sufficient statistics for one area."""
+
+    occupied_seconds: float = 0.0
+    first_observation: datetime | None = None
+    last_tick: datetime | None = None
+    last_motion_active: bool = False
+
+    def to_dict(self) -> dict:
+        """Serialize for the HA storage helper (JSON-safe)."""
+        return {
+            "occupied_seconds": self.occupied_seconds,
+            "first_observation": self.first_observation.isoformat()
+            if self.first_observation
+            else None,
+            "last_tick": self.last_tick.isoformat() if self.last_tick else None,
+            "last_motion_active": self.last_motion_active,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> OnlinePriorState:
+        """Restore from storage; malformed fields fall back to empty state."""
+        try:
+            return cls(
+                occupied_seconds=float(data.get("occupied_seconds", 0.0)),
+                first_observation=ensure_utc_datetime(
+                    datetime.fromisoformat(data["first_observation"])
+                )
+                if data.get("first_observation")
+                else None,
+                last_tick=ensure_utc_datetime(datetime.fromisoformat(data["last_tick"]))
+                if data.get("last_tick")
+                else None,
+                last_motion_active=bool(data.get("last_motion_active", False)),
+            )
+        except (KeyError, TypeError, ValueError):
+            return cls()
+
+
+class OnlinePriorEstimator:
+    """Incremental global-prior estimator for one area."""
+
+    def __init__(self, state: OnlinePriorState | None = None) -> None:
+        """Initialize from persisted state (or empty)."""
+        self.state = state or OnlinePriorState()
+
+    def observe(self, *, motion_active: bool, now: datetime) -> None:
+        """Record one coordinator tick.
+
+        Occupied time accrues for the elapsed span since the previous
+        tick when motion evidence was active at the START of the span
+        (piecewise-constant assumption at tick granularity). Spans
+        longer than ``MAX_TICK_GAP_SECONDS`` contribute nothing to the
+        numerator — see module docstring on downtime.
+        """
+        now = ensure_utc_datetime(now)
+        if self.state.first_observation is None:
+            self.state.first_observation = now
+        if self.state.last_tick is not None:
+            elapsed = (now - self.state.last_tick).total_seconds()
+            if 0.0 < elapsed <= MAX_TICK_GAP_SECONDS and self.state.last_motion_active:
+                self.state.occupied_seconds += elapsed
+        self.state.last_tick = now
+        self.state.last_motion_active = motion_active
+
+    def prior(self, now: datetime) -> float | None:
+        """Return the current online prior, or None before any observation."""
+        if self.state.first_observation is None:
+            return None
+        period = (
+            ensure_utc_datetime(now) - self.state.first_observation
+        ).total_seconds()
+        if period <= 0:
+            return None
+        raw = self.state.occupied_seconds / period
+        return max(MIN_PRIOR, min(MAX_PRIOR, raw))
+
+    def observed_days(self, now: datetime) -> float:
+        """Return how long this estimator has been observing, in days."""
+        if self.state.first_observation is None:
+            return 0.0
+        return (
+            ensure_utc_datetime(now) - self.state.first_observation
+        ).total_seconds() / 86400.0

--- a/custom_components/area_occupancy/diagnostics.py
+++ b/custom_components/area_occupancy/diagnostics.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy.exc import SQLAlchemyError
 
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from .const import CONF_VERSION, CONF_VERSION_MINOR, DEVICE_SW_VERSION
 from .data.metrics import metrics_to_diagnostics
@@ -256,6 +257,21 @@ def _area_snapshot(
         accuracy = coordinator.accuracy_metrics_for(area_name)
         if accuracy is not None:
             current["accuracy"] = metrics_to_diagnostics(accuracy)
+        estimator = coordinator.online_prior_for(area_name)
+        if estimator is not None:
+            now = dt_util.utcnow()
+            online_value = estimator.prior(now)
+            if online_value is not None:
+                db_prior = area.prior.global_prior
+                current["online_prior"] = {
+                    "shadow_mode": True,
+                    "value": round(online_value, 4),
+                    "db_prior": round(db_prior, 4) if db_prior is not None else None,
+                    "diff": round(online_value - db_prior, 4)
+                    if db_prior is not None
+                    else None,
+                    "observed_days": round(estimator.observed_days(now), 2),
+                }
         snapshot["current"] = current
     except Exception as err:  # noqa: BLE001 — see docstring
         _LOGGER.warning(

--- a/tests/test_data_metrics.py
+++ b/tests/test_data_metrics.py
@@ -5,7 +5,7 @@ import json
 from unittest.mock import patch
 
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
-from custom_components.area_occupancy.data.analysis import _run_accuracy_metrics
+from custom_components.area_occupancy.data.analysis import _run_shadow_metrics
 from custom_components.area_occupancy.data.metrics import (
     AccuracyMetrics,
     TickSample,
@@ -163,7 +163,7 @@ class TestShadowWiring:
             "get_occupied_intervals",
             return_value=[],
         ):
-            await _run_accuracy_metrics(coordinator)
+            await _run_shadow_metrics(coordinator)
 
         metrics = coordinator.accuracy_metrics_for(area_name)
         assert metrics is not None
@@ -177,7 +177,7 @@ class TestShadowWiring:
         """The step is a no-op for areas with an empty tick buffer."""
         area_name = coordinator.get_area_names()[0]
 
-        await _run_accuracy_metrics(coordinator)
+        await _run_shadow_metrics(coordinator)
 
         assert coordinator.accuracy_metrics_for(area_name) is None
 

--- a/tests/test_data_online_prior.py
+++ b/tests/test_data_online_prior.py
@@ -1,0 +1,139 @@
+"""Tests for the shadow-mode online prior estimator (#500)."""
+
+from datetime import UTC, datetime, timedelta
+
+from custom_components.area_occupancy.const import MAX_PRIOR, MIN_PRIOR
+from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
+from custom_components.area_occupancy.data.online_prior import (
+    MAX_TICK_GAP_SECONDS,
+    OnlinePriorEstimator,
+    OnlinePriorState,
+)
+
+# ruff: noqa: SLF001
+
+T0 = datetime(2026, 7, 6, 12, 0, 0, tzinfo=UTC)
+
+
+def _tick(est: OnlinePriorEstimator, seconds: float, active: bool) -> datetime:
+    """Observe one tick at T0+seconds; return that timestamp."""
+    now = T0 + timedelta(seconds=seconds)
+    est.observe(motion_active=active, now=now)
+    return now
+
+
+class TestOnlinePriorEstimator:
+    """Sufficient-statistics accumulation and the prior ratio."""
+
+    def test_no_observations_yields_none(self) -> None:
+        """Before any tick the prior is unknown, not a default."""
+        est = OnlinePriorEstimator()
+        assert est.prior(T0) is None
+        assert est.observed_days(T0) == 0.0
+
+    def test_half_occupied_stream(self) -> None:
+        """Motion active for the first half of the window → prior ≈ 0.5.
+
+        Ticks every 10s for 100s; motion active at ticks 0-4 (so the
+        spans 0-10 … 40-50 accrue) and inactive from tick 5 on.
+        """
+        est = OnlinePriorEstimator()
+        for i in range(11):
+            _tick(est, 10 * i, active=i < 5)
+
+        now = T0 + timedelta(seconds=100)
+        # occupied 50s over a 100s period
+        assert abs(est.prior(now) - 0.5) < 1e-9
+
+    def test_prior_clamped_to_bounds(self) -> None:
+        """Always-active and never-active streams hit the clamps."""
+        always = OnlinePriorEstimator()
+        never = OnlinePriorEstimator()
+        for i in range(11):
+            _tick(always, 10 * i, active=True)
+            _tick(never, 10 * i, active=False)
+        now = T0 + timedelta(seconds=100)
+        assert always.prior(now) == MAX_PRIOR
+        assert never.prior(now) == MIN_PRIOR
+
+    def test_downtime_gap_adds_period_but_no_occupancy(self) -> None:
+        """A gap beyond MAX_TICK_GAP_SECONDS grows only the denominator.
+
+        Mirrors the DB path: recorder gaps contribute period, never
+        occupied time — even if motion was active before the outage.
+        """
+        est = OnlinePriorEstimator()
+        _tick(est, 0, active=True)
+        _tick(est, 10, active=True)  # 10s occupied
+        # HA restarts; next tick is one hour later
+        gap = MAX_TICK_GAP_SECONDS + 3600
+        _tick(est, 10 + gap, active=True)
+
+        now = T0 + timedelta(seconds=10 + gap)
+        expected = max(MIN_PRIOR, 10 / (10 + gap))  # raw ratio is below the floor
+        assert abs(est.prior(now) - expected) < 1e-9
+
+    def test_state_round_trip_preserves_accumulators(self) -> None:
+        """to_dict/from_dict survives a restart without drift."""
+        est = OnlinePriorEstimator()
+        _tick(est, 0, active=True)
+        _tick(est, 10, active=False)
+
+        restored = OnlinePriorEstimator(OnlinePriorState.from_dict(est.state.to_dict()))
+
+        assert restored.state.occupied_seconds == est.state.occupied_seconds
+        assert restored.state.first_observation == est.state.first_observation
+        assert restored.state.last_tick == est.state.last_tick
+        assert restored.state.last_motion_active is False
+        now = T0 + timedelta(seconds=20)
+        assert restored.prior(now) == est.prior(now)
+
+    def test_malformed_storage_falls_back_to_empty(self) -> None:
+        """Corrupt persisted state resets rather than crashing setup."""
+        restored = OnlinePriorState.from_dict({"first_observation": "not-a-date"})
+        assert restored.occupied_seconds == 0.0
+        assert restored.first_observation is None
+
+
+class TestCoordinatorShadowWiring:
+    """Tick feeding, persistence, and diagnostics exposure."""
+
+    async def test_update_feeds_estimator(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Each update() tick advances the area's estimator."""
+        area_name = coordinator.get_area_names()[0]
+
+        await coordinator.update()
+
+        estimator = coordinator.online_prior_for(area_name)
+        assert estimator is not None
+        assert estimator.state.first_observation is not None
+
+    async def test_save_and_reload_round_trip(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """async_save_online_priors persists state the Store can reload."""
+        area_name = coordinator.get_area_names()[0]
+        await coordinator.update()
+        await coordinator.async_save_online_priors()
+
+        stored = await coordinator._online_prior_store.async_load()
+
+        assert area_name in stored
+        restored = OnlinePriorState.from_dict(stored[area_name])
+        assert restored.first_observation is not None
+
+    async def test_online_prior_never_touches_probability(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Shadow contract: estimator state doesn't change area probability."""
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+        await coordinator.update()
+        before = area.probability()
+
+        estimator = coordinator.online_prior_for(area_name)
+        estimator.state.occupied_seconds = 999999.0
+
+        assert area.probability() == before


### PR DESCRIPTION
## What & Why

First gate of roadmap epic #500 (retire the sidecar DB), targeting `next`. The global prior becomes **sufficient statistics updated incrementally** — an occupied-seconds accumulator fed from live motion evidence at tick cadence, plus the first-observation anchor — running in **shadow mode** alongside the DB replay it aims to replace.

## Mechanism

- **`data/online_prior.py`** (pure, mirrors `data/adjacency.py`/`data/metrics.py`): same ratio, same `[0.01, 0.99]` clamps as production. Documented approximations vs the DB path bound the expected diff: tick quantization (~10s), no motion-timeout extension (reads slightly low on sparse-motion areas), fixed period anchor. **Downtime semantics match production**: a gap beyond 60s grows only the denominator — exactly how recorder gaps behave in the DB path.
- **Persistence via the HA storage helper** (`.storage/area_occupancy.online_prior.<entry>`) — deliberately the epic's target architecture, not the DB. Restored during `setup()`; corrupt state falls back to empty.
- **Pipeline step 10 → `shadow_metrics`**: now hosts both #499 scoring and the #500 diff — each cycle logs `online=X db=Y diff=±Z observed_days=N` per area and persists estimator state.
- **Diagnostics**: `current.online_prior` block so soak installs surface the diff without log access.

## Shadow-mode contract

Never read by the probability path (dedicated test). Promotion gate per #500: online tracks the DB value within tolerance for 30 days on two homes, **including restarts** — the storage round-trip and gap-semantics tests cover the restart half of that claim.

## Tests

9 new (1801 total): hand-computed half-occupied accumulation, both clamps, the restart-gap rule, serialization round-trip, malformed-storage fallback, coordinator feeding, Store save/reload, and the shadow contract.

Part of #500. Builds on #504's step-10 scaffold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE