### PR TITLE
refactor(entities): name all entities via translation_key

### DIFF
--- a/custom_components/area_occupancy/binary_sensor.py
+++ b/custom_components/area_occupancy/binary_sensor.py
@@ -100,7 +100,7 @@ class Occupancy(CoordinatorEntity, BinarySensorEntity):
             ),
             NAME_BINARY_SENSOR,
         )
-        self._attr_name = NAME_BINARY_SENSOR
+        self._attr_translation_key = "occupancy_status"
         self._attr_device_class = BinarySensorDeviceClass.OCCUPANCY
         # Get device_info directly from Area or AllAreas
         self._attr_device_info = (
@@ -204,7 +204,7 @@ class WaspInBoxSensor(RestoreEntity, BinarySensorEntity):
             area.device_info(),
             NAME_WASP_IN_BOX,
         )
-        self._attr_name = NAME_WASP_IN_BOX
+        self._attr_translation_key = "wasp_in_box"
         self._attr_device_class = BinarySensorDeviceClass.OCCUPANCY
         # Get device_info directly from Area
         self._attr_device_info = area.device_info() if area is not None else None
@@ -761,7 +761,7 @@ class SleepPresenceSensor(RestoreEntity, BinarySensorEntity):
             area.device_info(),
             NAME_SLEEP_PRESENCE,
         )
-        self._attr_name = NAME_SLEEP_PRESENCE
+        self._attr_translation_key = "sleeping"
         self._attr_device_class = BinarySensorDeviceClass.OCCUPANCY
         self._attr_icon = "mdi:sleep"
         self._attr_device_info = area.device_info()

--- a/custom_components/area_occupancy/number.py
+++ b/custom_components/area_occupancy/number.py
@@ -43,7 +43,7 @@ class Threshold(CoordinatorEntity, NumberEntity):
         self._area_name = area_handle.area_name
         self._area_handle = area_handle
         self._attr_has_entity_name = True
-        self._attr_name = "Threshold"
+        self._attr_translation_key = "threshold"
         # Unique ID: use entry_id, device_id, and entity_name
         self._attr_unique_id = generate_entity_unique_id(
             area_handle.coordinator.entry_id,

--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -112,7 +112,7 @@ class PriorsSensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the priors sensor."""
         super().__init__(area_handle, all_areas)
-        self._attr_name = NAME_PRIORS_SENSOR
+        self._attr_translation_key = "prior_probability"
         # Unique ID: use entry_id, device_id, and entity_name
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
@@ -180,7 +180,7 @@ class ProbabilitySensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the probability sensor."""
         super().__init__(area_handle, all_areas)
-        self._attr_name = NAME_PROBABILITY_SENSOR
+        self._attr_translation_key = "occupancy_probability"
         # Unique ID: use entry_id, device_id, and entity_name
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
@@ -245,7 +245,7 @@ class EvidenceSensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the entities sensor."""
         super().__init__(area_handle, all_areas)
-        self._attr_name = NAME_EVIDENCE_SENSOR
+        self._attr_translation_key = "evidence"
         # Unique ID: use entry_id, device_id, and entity_name
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
@@ -332,7 +332,7 @@ class DecaySensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the decay sensor."""
         super().__init__(area_handle, all_areas)
-        self._attr_name = NAME_DECAY_SENSOR
+        self._attr_translation_key = "decay_status"
         # Unique ID: use entry_id, device_id, and entity_name
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
@@ -406,7 +406,7 @@ class PresenceProbabilitySensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the presence probability sensor."""
         super().__init__(area_handle, all_areas)
-        self._attr_name = NAME_PRESENCE_PROBABILITY_SENSOR
+        self._attr_translation_key = "presence_confidence"
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
             self.device_info,
@@ -441,7 +441,7 @@ class EnvironmentalConfidenceSensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the environmental confidence sensor."""
         super().__init__(area_handle, all_areas)
-        self._attr_name = NAME_ENVIRONMENTAL_CONFIDENCE_SENSOR
+        self._attr_translation_key = "environmental_confidence"
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
             self.device_info,
@@ -560,7 +560,7 @@ class SensorHealthSensor(AreaOccupancySensorBase):
     ) -> None:
         """Initialize the sensor health sensor."""
         super().__init__(area_handle=area_handle)
-        self._attr_name = NAME_SENSOR_HEALTH_SENSOR
+        self._attr_translation_key = "sensor_health"
         self._attr_unique_id = generate_entity_unique_id(
             self._entry_id,
             self.device_info,

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -902,6 +902,18 @@
             },
             "activity_confidence": {
                 "name": "Activity Confidence"
+            },
+            "evidence": {
+                "name": "Evidence"
+            },
+            "presence_confidence": {
+                "name": "Presence Confidence"
+            },
+            "environmental_confidence": {
+                "name": "Environmental Confidence"
+            },
+            "sensor_health": {
+                "name": "Sensor Health"
             }
         },
         "number": {

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -904,6 +904,18 @@
             },
             "activity_confidence": {
                 "name": "Activity Confidence"
+            },
+            "evidence": {
+                "name": "Evidence"
+            },
+            "presence_confidence": {
+                "name": "Presence Confidence"
+            },
+            "environmental_confidence": {
+                "name": "Environmental Confidence"
+            },
+            "sensor_health": {
+                "name": "Sensor Health"
             }
         },
         "number": {

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -38,7 +38,7 @@ class TestOccupancy:
         device_id = next(iter(area.device_info()["identifiers"]))[1]
         expected_unique_id = f"{entry_id}_{device_id}_occupancy_status"
         assert entity.unique_id == expected_unique_id
-        assert entity.name == "Occupancy Status"
+        assert entity.translation_key == "occupancy_status"
 
     async def test_async_added_to_hass(
         self, hass: HomeAssistant, coordinator: AreaOccupancyCoordinator
@@ -210,7 +210,7 @@ class TestWaspInBoxSensor:
         device_id = next(iter(area.device_info()["identifiers"]))[1]
         expected_unique_id = f"{entry_id}_{device_id}_wasp_in_box"
         assert entity.unique_id == expected_unique_id
-        assert entity.name == "Wasp in Box"
+        assert entity.translation_key == "wasp_in_box"
         assert entity.should_poll is False
 
     async def test_async_added_to_hass(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -105,7 +105,7 @@ class TestThreshold:
         """Test that all initialization attributes are set correctly."""
         # Assert: Verify all __init__ attributes
         assert threshold_entity._attr_has_entity_name is True
-        assert threshold_entity._attr_name == "Threshold"
+        assert threshold_entity._attr_translation_key == "threshold"
         assert threshold_entity._attr_native_min_value == 1.0
         assert threshold_entity._attr_native_max_value == 99.0
         assert threshold_entity._attr_native_step == 1.0

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -19,8 +19,22 @@ from custom_components.area_occupancy.utils import generate_entity_unique_id
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 
-
 # ruff: noqa: SLF001, PLC0415, TID251
+
+# Entities name via translation_key + strings.json, so entity.name does not
+# resolve to the literal in a bare unit test. Assert the translation_key
+# instead; unique_id (built from the NAME_* constant) still guards stability.
+_NAME_TO_TRANSLATION_KEY = {
+    "Prior Probability": "prior_probability",
+    "Occupancy Probability": "occupancy_probability",
+    "Decay Status": "decay_status",
+    "Evidence": "evidence",
+    "Presence Confidence": "presence_confidence",
+    "Environmental Confidence": "environmental_confidence",
+    "Sensor Health": "sensor_health",
+}
+
+
 class TestAreaOccupancySensorBase:
     """Test AreaOccupancySensorBase class."""
 
@@ -107,7 +121,7 @@ class TestPercentageSensors:
             expected_name,
         )
         assert sensor.unique_id == expected_unique_id_new
-        assert sensor.name == expected_name
+        assert sensor.translation_key == _NAME_TO_TRANSLATION_KEY[expected_name]
         assert sensor.native_unit_of_measurement == "%"
         assert sensor.suggested_display_precision == 1
 
@@ -166,7 +180,7 @@ class TestEvidenceSensor:
         device_id = next(iter(area.device_info()["identifiers"]))[1]
         expected_unique_id = f"{entry_id}_{device_id}_evidence"
         assert sensor.unique_id == expected_unique_id
-        assert sensor.name == "Evidence"
+        assert sensor.translation_key == "evidence"
         assert sensor.entity_category == EntityCategory.DIAGNOSTIC
 
     def test_native_value_property(
@@ -327,7 +341,7 @@ class TestDecaySensor:
         device_id = next(iter(area.device_info()["identifiers"]))[1]
         expected_unique_id = f"{entry_id}_{device_id}_decay_status"
         assert sensor.unique_id == expected_unique_id
-        assert sensor.name == "Decay Status"
+        assert sensor.translation_key == "decay_status"
         assert sensor.native_unit_of_measurement == "%"
         assert sensor.suggested_display_precision == 1
         assert sensor.entity_category == EntityCategory.DIAGNOSTIC
@@ -494,7 +508,7 @@ class TestAllAreasSensors:
         assert sensor._area_name == ALL_AREAS_IDENTIFIER
         assert sensor._all_areas == all_areas
         assert sensor.coordinator == coordinator
-        assert sensor.name == expected_name
+        assert sensor.translation_key == _NAME_TO_TRANSLATION_KEY[expected_name]
         assert sensor.native_unit_of_measurement == "%"
 
         if has_entity_category:


### PR DESCRIPTION
## Summary

Fixes the Threshold number entity displaying the literal **\"Threshold\"** instead of its strings.json name **\"Occupancy Threshold\"**, and standardizes every entity onto the `translation_key` naming mechanism the two activity sensors already used.

## Why it's law-2 safe (no broken configs)

- The `NAME_*` constants are unchanged and still passed to `generate_entity_unique_id`, so **unique_ids are byte-identical** → existing installs keep their entity_ids and history.
- The four newly-added strings.json/en.json entries (`evidence`, `presence_confidence`, `environmental_confidence`, `sensor_health`) use name strings **identical to the old `_attr_name` literals**, so auto-generated entity_ids don't shift for new installs either.
- Threshold's strings.json entry already declared \"Occupancy Threshold\" — switching it to translation_key is the intended, now-applied display-name fix. Existing installs keep their entity_id (unique_id unchanged); only the friendly name updates.

## Changes

- `sensor.py` / `binary_sensor.py` / `number.py`: `_attr_name` literal → `_attr_translation_key`
- `strings.json` + `translations/en.json`: add the four missing sensor keys (entity sections verified identical)
- tests: `entity.name` no longer resolves to the literal in bare unit tests, so assert `translation_key`; unique_id assertions unchanged as the stability guard

Full suite: **1789 passed**, lint clean. Verified every declared `translation_key` has a matching strings.json entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Woqg6xK584pVJyKjnUvKE