### PR TITLE
chore: promote 2026.7.1-pre1 to 2026.7.1 GA

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -29,7 +29,7 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
 # Device information
 DEVICE_MANUFACTURER: Final = "Hankanman"
 DEVICE_MODEL: Final = "Area Occupancy Detector"
-DEVICE_SW_VERSION: Final = "2026.7.1-pre1"
+DEVICE_SW_VERSION: Final = "2026.7.1"
 CONF_VERSION: Final = 18
 CONF_VERSION_MINOR: Final = 0
 HA_RECORDER_DAYS: Final = 10  # days

--- a/custom_components/area_occupancy/manifest.json
+++ b/custom_components/area_occupancy/manifest.json
@@ -17,5 +17,5 @@
   "issue_tracker": "https://github.com/Hankanman/Area-Occupancy-Detection/issues",
   "quality_scale": "silver",
   "requirements": [],
-  "version": "2026.7.1-pre1"
+  "version": "2026.7.1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "area-occupancy-detection"
-version = "2026.7.1-pre1"
+version = "2026.7.1"
 license = "Apache-2.0"
 description = "Home Assistant integration for intelligent room occupancy detection using Bayesian probability."
 readme = "README.md"  # Assuming you'll have a README.md


### PR DESCRIPTION
Bumps the version triple from `2026.7.1-pre1` to `2026.7.1` ahead of cutting the GA release.

## Why now
`2026.7.1-pre1` has soaked on the maintainer's own install with no regressions. Only two docs-only commits landed since the pre1 tag (`#498` stale-docs refresh + a skills-library edit) — no runtime code changed, so GA is functionally identical to the soaked pre-release.

## What changed
- `pyproject.toml`, `custom_components/area_occupancy/const.py` (`DEVICE_SW_VERSION`), `custom_components/area_occupancy/manifest.json` — all three moved `2026.7.1-pre1` → `2026.7.1`.

This must merge before the GA GitHub Release is published, because `release.yml` hard-fails if `manifest.json`'s version doesn't equal the release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integration version from the pre-release build to the stable 2026.7.1 release.
  * Ensured the displayed software and package versions consistently show 2026.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->