### PR TITLE
fix: make environmental evidence an additive update instead of an average

### DIFF
--- a/.claude/skills/aod-architecture-contract/SKILL.md
+++ b/.claude/skills/aod-architecture-contract/SKILL.md
@@ -46,7 +46,7 @@ Two-phase calculation in `area/area.py`, all math in `utils.py`:
 1. **`_base_probability()`** — sensor-only, logit-space weighted evidence, no activity/adjacency:
    - `presence = presence_probability()` — combines MOTION/MEDIA/APPLIANCE/DOOR/WINDOW/COVER/POWER/SLEEP evidence in logit space, each entity's contribution scaled by `effective_weight (weight × information_gain) × strength_multiplier`.
    - `env = environmental_confidence()` — same mechanism over environmental sensor types; returns exactly `0.5` (neutral) when the area has zero environmental sensors configured.
-   - If `env == 0.5` exactly, `_base_probability()` returns `presence` directly — the 80/20 logit blend (`combined_probability`, weights presence 0.8 / env 0.2) is **skipped** so a no-env-sensor area is never compressed toward neutral (`area/area.py::_base_probability`, comment explains this explicitly).
+   - Otherwise `combined_probability(presence, env)` applies env as an **additive** logit-space update damped to 20%: `sigmoid(logit(presence) + 0.2×logit(env))`. It is *not* an average — averaging (the pre-2026-07 `0.8×logit(presence) + 0.2×logit(env)`) let supporting environmental data lower a motion-confirmed probability. If `env == 0.5` exactly, `_base_probability()` short-circuits and returns `presence`, which is what the formula yields anyway (`logit(0.5) == 0`).
 2. **`probability()`** — activity boost:
    - `base = _base_probability()`; `is_occupied = base >= config.threshold`.
    - `activity = detect_activity(self, base_probability=base, is_occupied=is_occupied)`.

--- a/.claude/skills/bayesian-occupancy-reference/SKILL.md
+++ b/.claude/skills/bayesian-occupancy-reference/SKILL.md
@@ -82,11 +82,19 @@ Two composition layers sit on top of `sigmoid_probability()`, both also in logit
 - `environmental_confidence()` (utils.py:236) filters to `ENVIRONMENTAL_INPUT_TYPES` (temperature,
   humidity, illuminance, co2, co, sound_pressure, pressure, air_quality, voc, pm25, pm10,
   environmental) with `prior=0.5` so the result is pure environmental signal.
-- `combined_probability(presence, environmental)` (utils.py:267) blends them with an **80/20
-  logit-space weighted average**: `z = 0.8×logit(presence) + 0.2×logit(environmental)`. Called
-  from `Area._base_probability()` (`area/area.py:216`) — **skipped** (returns `presence` directly)
-  when there are zero environmental entities configured, so the 80/20 blend never needlessly
-  compresses a presence-only area toward 0.5 (`area/area.py:240-241`).
+- `combined_probability(presence, environmental)` (utils.py:267) applies environmental as an
+  **additive logit-space update damped to 20%**: `z = logit(presence) + 0.2×logit(environmental)`.
+  Called from `Area._base_probability()` (`area/area.py:216`) — short-circuited (returns
+  `presence` directly) when there are zero environmental entities configured, which is exactly
+  what the formula yields anyway since `logit(0.5) == 0` (`area/area.py:240-241`).
+  **This was an 80/20 weighted average until 2026-07 (PR "additive environmental evidence").**
+  Averaging pulled the result toward the less-confident channel, and the environmental channel is
+  structurally low-confidence (one env sensor contributes ~0.018 logits at defaults: `weight 0.1
+  × prob_given_true 0.09 × strength_multiplier 2.0`), so supporting environmental data *lowered*
+  the probability — one motion sensor gave 94.5%, adding a CO2 sensor at a normal 450 ppm dropped
+  it to 90.8%. Environmental contributions are non-negative by construction (evidence ∈ [0,1],
+  weights ≥ 0, learned correlations clamped to [0,1] at `db/correlation.py:1537,1548`), so
+  `environmental_confidence()` ≥ 0.5 always and the additive form can only raise or hold.
 
 After `_base_probability()`, `Area.probability()` (`area/area.py:245-274`) applies, in order:
 1. **Activity boost** (`apply_activity_boost`, utils.py:293) — if `detect_activity()` finds a

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ AOD is extensively documented [here](https://hankanman.github.io/Area-Occupancy-
 ## Features
 
 - **Bayesian Occupancy Detection**: Combines multiple sensor inputs using Bayesian probability for accurate occupancy detection.
-- **Dual-Model Approach**: Separates presence indicators (motion, media, appliances, doors, windows, covers, power, sleep — 80% weight) from environmental support (temperature, humidity, CO2, etc. — 20% weight) for more accurate results.
+- **Dual-Model Approach**: Separates presence indicators (motion, media, appliances, doors, windows, covers, power, sleep) from environmental support (temperature, humidity, CO2, etc.). Presence sets the probability; environmental readings adjust it, damped to 20% influence.
 - **Multiple Sensor Support**:
   - **Motion/Occupancy Sensors**: Primary input and ground truth for detecting presence.
   - **Media Devices**: TV, media players, and similar devices as activity indicators.

--- a/custom_components/area_occupancy/area/area.py
+++ b/custom_components/area_occupancy/area/area.py
@@ -217,8 +217,8 @@ class Area:
         """Calculate sensor-only occupancy probability (no activity boost).
 
         Combines presence probability (from strong binary indicators) with
-        environmental confidence (from environmental sensors) using weighted
-        averaging in logit space.
+        environmental confidence (from environmental sensors) as an additive
+        update in logit space.
 
         This is the first phase of the two-phase probability calculation.
         Activity detection receives this value to avoid circular dependency.
@@ -233,10 +233,11 @@ class Area:
         presence = self.presence_probability()
         env = self.environmental_confidence()
 
-        # Skip the 80/20 blend when no environmental sensors are configured.
+        # Short-circuit when no environmental sensors are configured.
         # environmental_confidence() returns exactly 0.5 only when there are no
-        # environmental entities, and blending with neutral would compress
-        # presence toward 0.5 unnecessarily.
+        # environmental entities. calc_combined() is continuous at that point
+        # (logit(0.5) == 0, so it returns presence unchanged) — this just skips
+        # a redundant logit/sigmoid round-trip.
         if env == 0.5:
             return presence
 

--- a/custom_components/area_occupancy/area/area.py
+++ b/custom_components/area_occupancy/area/area.py
@@ -233,9 +233,10 @@ class Area:
         presence = self.presence_probability()
         env = self.environmental_confidence()
 
-        # Short-circuit when no environmental sensors are configured.
-        # environmental_confidence() returns exactly 0.5 only when there are no
-        # environmental entities. calc_combined() is continuous at that point
+        # Short-circuit on neutral environmental confidence. 0.5 is what
+        # environmental_confidence() returns whenever the environmental channel
+        # contributes nothing — no environmental sensors configured, or none of
+        # them currently active. calc_combined() is continuous at that point
         # (logit(0.5) == 0, so it returns presence unchanged) — this just skips
         # a redundant logit/sigmoid round-trip.
         if env == 0.5:

--- a/custom_components/area_occupancy/utils.py
+++ b/custom_components/area_occupancy/utils.py
@@ -268,10 +268,14 @@ def combined_probability(
     presence: float,
     environmental: float,
 ) -> float:
-    """Combine presence and environmental using weighted average in logit space.
+    """Combine presence and environmental as an evidence update in logit space.
 
-    This preserves the smooth sigmoid properties while combining both signals.
-    Presence is weighted more heavily (80%) than environmental (20%).
+    Environmental data adjusts the presence estimate rather than being averaged
+    with it. Averaging pulls the result toward whichever channel is less
+    confident, so a weakly-supportive environmental reading used to *lower* a
+    motion-confirmed probability. Environmental contributions are non-negative
+    by construction, so an additive update can only raise the result or leave
+    it unchanged. Environmental influence stays damped at 20%.
 
     Args:
         presence: Presence probability (0.0-1.0)
@@ -284,8 +288,8 @@ def combined_probability(
     z_presence = logit(presence)
     z_env = logit(environmental)
 
-    # Weighted combination (presence dominates at 80%, environmental at 20%)
-    z_combined = 0.8 * z_presence + 0.2 * z_env
+    # Additive update (environmental damped to 20% of its logit contribution)
+    z_combined = z_presence + 0.2 * z_env
 
     return clamp_probability(sigmoid(z_combined))
 

--- a/custom_components/area_occupancy/utils.py
+++ b/custom_components/area_occupancy/utils.py
@@ -273,9 +273,14 @@ def combined_probability(
     Environmental data adjusts the presence estimate rather than being averaged
     with it. Averaging pulls the result toward whichever channel is less
     confident, so a weakly-supportive environmental reading used to *lower* a
-    motion-confirmed probability. Environmental contributions are non-negative
-    by construction, so an additive update can only raise the result or leave
-    it unchanged. Environmental influence stays damped at 20%.
+    motion-confirmed probability. Environmental influence stays damped at 20%.
+
+    Direction follows ``environmental``: at 0.5 (neutral) presence passes
+    through unchanged, above 0.5 it is raised, and below 0.5 it is lowered.
+    Within this integration the lowering case does not arise —
+    ``environmental_confidence()`` builds its result from per-entity
+    contributions that are non-negative by construction, so it never returns
+    below 0.5 — but the function itself does not assume that.
 
     Args:
         presence: Presence probability (0.0-1.0)

--- a/docs/docs/features/calculation.md
+++ b/docs/docs/features/calculation.md
@@ -140,7 +140,7 @@ The result is exposed as the **Environmental Confidence** diagnostic sensor.
 
 Environmental data is applied as an **additive update** to the presence estimate in **logit space**, damped to 20% of its own contribution:
 
-```
+```text
 z_combined = logit(presence) + 0.2 × logit(environmental)
 probability = sigmoid(z_combined)
 ```

--- a/docs/docs/features/calculation.md
+++ b/docs/docs/features/calculation.md
@@ -138,14 +138,16 @@ The result is exposed as the **Environmental Confidence** diagnostic sensor.
 
 ### Combined Probability (Occupancy Probability)
 
-The two models are combined in **logit space** with an 80/20 weighting:
+Environmental data is applied as an **additive update** to the presence estimate in **logit space**, damped to 20% of its own contribution:
 
 ```
-z_combined = 0.8 × logit(presence) + 0.2 × logit(environmental)
+z_combined = logit(presence) + 0.2 × logit(environmental)
 probability = sigmoid(z_combined)
 ```
 
-This means presence indicators dominate the final probability, while environmental data provides supporting or opposing evidence. The combination in logit space (rather than simple averaging) preserves the probabilistic meaning of the values.
+Presence indicators set the level; environmental data nudges it. Because environmental contributions are non-negative by construction (a sensor is either inside its active range or contributes nothing), environmental confidence never falls below 50% in practice, so environmental data can only raise the probability or leave it unchanged.
+
+An earlier version of this formula averaged the two channels (`0.8 × logit(presence) + 0.2 × logit(environmental)`). Averaging pulls the result toward whichever channel is less confident, and the environmental channel is structurally low-confidence, so adding a *supporting* environmental sensor could lower the probability — one active motion sensor gave 94.5%, and adding a CO2 sensor reading a normal 450 ppm dropped it to 90.8%. The additive form removes that.
 
 ## Output
 

--- a/docs/docs/getting-started/why.md
+++ b/docs/docs/getting-started/why.md
@@ -164,7 +164,7 @@ Home Assistant can analyze historical data, but you must manually query APIs, wr
 **AOD Approach:**
 
 - Automatically combines motion, media, appliances, doors, windows, covers, power sensors, sleep presence, and environmental sensors
-- Separates presence indicators (80% weight) from environmental support (20% weight) for more accurate results
+- Separates presence indicators (which set the probability) from environmental support (which adjusts it at 20% influence) for more accurate results
 - Each sensor type has learned reliability with weighted contributions
 - See [Bayesian Calculation](../features/calculation.md) for details
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -9,7 +9,7 @@ Area Occupancy Detection aims to improve occupancy accuracy beyond single motion
 ### Core Features
 
 - **[Bayesian Probability Calculation](features/calculation.md)**: Uses learned sensor reliability to calculate occupancy probability
-- **[Dual-Model Approach](features/calculation.md#dual-model-approach-presence-environmental)**: Separates presence indicators (80% weight) from environmental support (20% weight) for more accurate results
+- **[Dual-Model Approach](features/calculation.md#dual-model-approach-presence-environmental)**: Presence indicators set the probability; environmental support adjusts it at 20% influence
 - **[Historical Learning](features/prior-learning.md)**: Automatically learns from your sensor history to improve accuracy
 - **[Probability Decay](features/decay.md)**: Gradually reduces probability when no activity is detected
 - **[Multiple Sensor Types](features/entities.md)**: Supports motion, media, door, window, cover, appliance, and environmental sensors (temperature, humidity, illuminance, CO2, sound pressure, atmospheric pressure, air quality, VOC, PM2.5, PM10)

--- a/tests/test_area_area.py
+++ b/tests/test_area_area.py
@@ -584,8 +584,14 @@ class TestTwoPhaseActivityBoost:
         base = default_area._base_probability()
         presence = default_area.presence_probability()
 
-        # With env sensors, base should differ from raw presence (combined blend applied)
+        # With env sensors, base should differ from raw presence (calc_combined applied).
         assert base != presence
+
+        # Direction matters: the temperature sensor is inside its active range, so it
+        # is *supporting* evidence and must raise the estimate. A bare `!=` passed
+        # equally under the old averaging formula, which drove base ~3.8pp BELOW
+        # presence for exactly this configuration.
+        assert base > presence
 
     def test_detected_activity_uses_base_probability(self, default_area: Area) -> None:
         """detected_activity() should use _base_probability() for cache key."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1131,6 +1131,17 @@ class TestCombinedProbability:
         assert MIN_PROBABILITY <= result_extreme_high <= MAX_PROBABILITY
         assert MIN_PROBABILITY <= result_extreme_low <= MAX_PROBABILITY
 
+    def test_combined_probability_supporting_env_never_lowers(self) -> None:
+        """Supporting environmental evidence must never lower the presence estimate."""
+        # Environmental contributions are non-negative, so environmental >= 0.5
+        # always. Averaging used to pull confident presence back toward 0.5,
+        # so adding a supporting environmental sensor reduced the probability.
+        for presence in (0.6, 0.8, 0.9, 0.95, 0.99):
+            for environmental in (0.5, 0.505, 0.6, 0.9):
+                combined = combined_probability(presence, environmental)
+                # 1e-9 absorbs logit/sigmoid float round-trip error.
+                assert combined >= min(presence, MAX_PROBABILITY) - 1e-9
+
 
 class TestSigmoidVsBayesian:
     """Compare sigmoid vs Bayesian behavior to verify expected differences."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1110,8 +1110,8 @@ class TestCombinedProbability:
         # High presence should result in higher overall probability
         assert result_high_presence > result_high_env
 
-        # With 80/20 weighting, presence should dominate
-        # result_high_presence should be closer to 0.8 than 0.2
+        # The environmental term is a damped logit contribution, so presence
+        # decides which side of 0.5 the result lands on.
         assert result_high_presence > 0.5
 
     def test_combined_probability_environmental_influence(self) -> None:
@@ -1119,7 +1119,7 @@ class TestCombinedProbability:
         result_env_low = combined_probability(presence=0.5, environmental=0.2)
         result_env_high = combined_probability(presence=0.5, environmental=0.8)
 
-        # Environmental should have some effect (20% weight)
+        # Environmental still moves the result via its damped logit contribution
         assert result_env_high > result_env_low
 
     def test_combined_probability_clamping(self) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1101,7 +1101,7 @@ class TestCombinedProbability:
         assert abs(result - 0.5) < 1e-6
 
     def test_combined_probability_presence_dominant(self) -> None:
-        """Test that presence is weighted more heavily (80%) than environmental."""
+        """Test that presence dominates the environmental adjustment."""
         # High presence, low environmental
         result_high_presence = combined_probability(presence=0.8, environmental=0.2)
         # Low presence, high environmental
@@ -1130,6 +1130,18 @@ class TestCombinedProbability:
         # Should be within MIN/MAX bounds
         assert MIN_PROBABILITY <= result_extreme_high <= MAX_PROBABILITY
         assert MIN_PROBABILITY <= result_extreme_low <= MAX_PROBABILITY
+
+    def test_combined_probability_neutral_env_returns_presence(self) -> None:
+        """Neutral environmental (0.5) must leave presence untouched.
+
+        Area._base_probability() short-circuits to presence when there are no
+        environmental sensors (env == 0.5 exactly). This asserts the formula
+        agrees with that short-circuit, so the two branches stay continuous.
+        """
+        for presence in (0.01, 0.2, 0.5, 0.8, 0.945, 0.99):
+            assert combined_probability(presence, 0.5) == pytest.approx(
+                presence, abs=1e-9
+            )
 
     def test_combined_probability_supporting_env_never_lowers(self) -> None:
         """Supporting environmental evidence must never lower the presence estimate."""


### PR DESCRIPTION
## Problem

`combined_probability()` blended the presence and environmental channels as a weighted average in logit space:

```
z = 0.8 × logit(presence) + 0.2 × logit(environmental)
```

Averaging pulls the result toward whichever channel is less confident. The environmental channel is structurally low-confidence — with shipped defaults each environmental sensor contributes about **0.016 logits** (`weight 0.1 × prob_given_true 0.09 × strength_multiplier 2.0`, scaled by information gain), so `environmental_confidence()` sits just barely above 0.5 even when every environmental sensor is firing.

The practical effect: environmental data the model itself classified as *supporting* occupancy **lowered** the probability. This is visible to users because `Area._base_probability()` short-circuits to raw `presence` when an area has no environmental sensors, so configuring the first environmental sensor crosses a discontinuity.

With shipped defaults, one active motion sensor and one CO2 sensor reading a normal 450 ppm (inside the default 400–1200 active range, so counted as supporting):

| | probability |
|---|---|
| motion only (short-circuit path) | **94.45%** |
| motion + supporting CO2, old formula | **90.65%** (−3.81 pp) |

Over the whole `(presence, environmental ≥ 0.5)` input grid, the old formula lowered the presence estimate in **24.7%** of cases.

## Fix

Combine additively instead:

```
z = logit(presence) + 0.2 × logit(environmental)
```

Environmental contributions are non-negative by construction — evidence ∈ [0,1], type weights ≥ 0, and learned correlations are clamped to [0,1] (`db/correlation.py:1537,1548`) — so `environmental_confidence()` is always ≥ 0.5 and environmental data can now only raise the result or leave it unchanged. Environmental influence stays damped at 20% via the coefficient on `z_env`; because `environmental_confidence()` uses a neutral prior, `logit(env)` recovers the raw environmental evidence sum, so this is equivalent to scaling each environmental contribution by 0.2 before the sigmoid.

Same case under the new formula: **94.47%** (+0.02 pp vs presence alone). Violations of "supporting evidence never lowers the estimate" go from 24.7% of the grid to **0%**.

A side effect worth calling out: the formula is now continuous at `environmental == 0.5`, which is exactly what `_base_probability()`'s short-circuit already returns. The short-circuit stays (it skips a redundant logit/sigmoid round-trip) but its stale justification comment is corrected, and a new test asserts the two branches agree so they can't silently diverge.

## Validation (no silent math changes)

Numbers were predicted by hand from `DEFAULT_TYPES` **before** running anything, then measured:

| Quantity | Predicted | Measured |
|---|---|---|
| presence, 1 motion sensor, prior 0.5 | 0.94445 | 0.94454 |
| environmental, 1 CO2 @ 450 ppm | 0.50400 | 0.50400 |
| combined, OLD (average) | 0.90644 | 0.90646 |
| combined, NEW (additive) | 0.94462 | 0.94471 |

(Prediction gaps are hand-rounding of the information-gain term.) Continuity was checked numerically: `max |combined(p, 0.5) − p|` over `p ∈ [0.01, 0.99]` is `1.11e-16`.

No runaway risk on the upside: even 10 environmental sensors at maximum user weight add only ~0.28 logits, and `logit()`'s clamp at `MAX_PROBABILITY` caps total environmental influence at 0.92 logits.

## Test adequacy

The pre-existing suite could not distinguish the bug from the fix, so passing tests were not treated as evidence:

- The only test covering the env path, `test_base_probability_with_env_sensors_uses_combined`, asserted `base != presence` — true under both formulas. It now asserts `base > presence`.
- The four pre-existing `TestCombinedProbability` cases pass under both formulas (verified), confirming they were non-discriminating. They are kept and pass unchanged.
- The three new/strengthened assertions were each verified to **fail** when the formula is reverted to the average.

Remaining known gap, not addressed here: no test asserts a threshold *crossing* for an area with environmental sensors.

## Impact on users

Areas **without** environmental sensors are unaffected (they already took the short-circuit path). Areas **with** environmental sensors will read slightly higher than before — the ~4 pp suppression is removed. Anyone who lowered their threshold to compensate for that suppression may want to raise it back.

## Changes

- `custom_components/area_occupancy/utils.py` — the formula, plus a docstring explaining why it isn't an average
- `custom_components/area_occupancy/area/area.py` — corrected docstring and short-circuit comment
- `tests/test_utils.py` — regression test that supporting environmental evidence never lowers presence; continuity test against the short-circuit; refreshed a stale "80%" docstring
- `tests/test_area_area.py` — direction assertion on the env-sensor base-probability test
- `README.md`, `docs/docs/features/calculation.md`, `docs/docs/index.md`, `docs/docs/getting-started/why.md` — describe the additive form
- `.claude/skills/bayesian-occupancy-reference`, `.claude/skills/aod-architecture-contract` — same, with the incident recorded so the old formula isn't reintroduced

No config schema, DB schema, or `CONF_VERSION` changes. `CHANGELOG.md` untouched (retired in favor of GitHub Releases).

## Test results

`1781 passed` (full suite), `ruff format --check` and `ruff check` clean.

---
_Generated by [Claude Code](https://claude.ai/code)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Environmental confidence now updates occupancy using an additive, damped contribution in logit space rather than a fixed weighted average.
  * Neutral environmental input leaves the presence-based estimate unchanged.
  * Supporting environmental evidence can raise or maintain the occupancy estimate, without reducing it.
* **Documentation**
  * Updated feature descriptions and calculation guidance to match the revised probability-combination behaviour.
* **Tests**
  * Added and strengthened assertions for neutral and supporting environmental inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->