### PR TITLE
fix(sensor): stop misrepresenting probability sensors as POWER_FACTOR

### DIFF
--- a/custom_components/area_occupancy/sensor.py
+++ b/custom_components/area_occupancy/sensor.py
@@ -119,7 +119,6 @@ class PriorsSensor(AreaOccupancySensorBase):
             self.device_info,
             NAME_PRIORS_SENSOR,
         )
-        self._attr_device_class = SensorDeviceClass.POWER_FACTOR
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -187,7 +186,6 @@ class ProbabilitySensor(AreaOccupancySensorBase):
             self.device_info,
             NAME_PROBABILITY_SENSOR,
         )
-        self._attr_device_class = SensorDeviceClass.POWER_FACTOR
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -339,7 +337,6 @@ class DecaySensor(AreaOccupancySensorBase):
             self.device_info,
             NAME_DECAY_SENSOR,
         )
-        self._attr_device_class = SensorDeviceClass.POWER_FACTOR
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -412,7 +409,6 @@ class PresenceProbabilitySensor(AreaOccupancySensorBase):
             self.device_info,
             NAME_PRESENCE_PROBABILITY_SENSOR,
         )
-        self._attr_device_class = SensorDeviceClass.POWER_FACTOR
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -447,7 +443,6 @@ class EnvironmentalConfidenceSensor(AreaOccupancySensorBase):
             self.device_info,
             NAME_ENVIRONMENTAL_CONFIDENCE_SENSOR,
         )
-        self._attr_device_class = SensorDeviceClass.POWER_FACTOR
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -531,7 +526,6 @@ class ActivityConfidenceSensor(AreaOccupancySensorBase):
             self.device_info,
             NAME_ACTIVITY_CONFIDENCE_SENSOR,
         )
-        self._attr_device_class = SensorDeviceClass.POWER_FACTOR
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC


### PR DESCRIPTION
## Problem

Several sensors (priors, probability, and others in `sensor.py`) set `device_class = SensorDeviceClass.POWER_FACTOR` solely to get percentage display. `POWER_FACTOR` supports `%` as a unit, but these sensors have nothing to do with electrical power factor — as reported in #511, this causes them to show up when a user collects/templates over "all my power factor sensors."

## Fix

Removed the six `self._attr_device_class = SensorDeviceClass.POWER_FACTOR` lines. `native_unit_of_measurement = PERCENTAGE` (already set on each) renders the value as a percentage without any device_class — no other change needed, per the reporter's suggested fix.

Closes #511.

## Test plan
- [x] `uv run pytest tests/test_sensor.py -q` — 82 passed
- [x] `ruff format` / `ruff check --fix` clean
- [x] `grep -rn POWER_FACTOR custom_components/ tests/` — no remaining references