### PR TITLE
fix(config): door active state should default to open, not closed

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -115,7 +115,7 @@ DEFAULT_THRESHOLD: Final = 50.0
 DEFAULT_PURPOSE: Final = "social"  # Default area purpose
 DEFAULT_DECAY_ENABLED: Final = True
 DEFAULT_DECAY_HALF_LIFE: Final = 0  # 0 means "use purpose value"
-DEFAULT_DOOR_ACTIVE_STATE: Final = STATE_CLOSED
+DEFAULT_DOOR_ACTIVE_STATE: Final = STATE_OPEN
 DEFAULT_WINDOW_ACTIVE_STATE: Final = STATE_OPEN
 DEFAULT_MEDIA_ACTIVE_STATES: Final[list[str]] = [STATE_PLAYING, STATE_PAUSED]
 DEFAULT_APPLIANCE_ACTIVE_STATES: Final[list[str]] = [STATE_ON, STATE_STANDBY]
@@ -377,7 +377,7 @@ DOOR_STATES: Final[PlatformStates] = {
         StateOption(STATE_CLOSED, "Closed", "mdi:door"),
         StateOption(STATE_CLOSING, "Closing", "mdi:door"),
     ],
-    "default": STATE_CLOSED,
+    "default": STATE_OPEN,
 }
 
 # Window states configuration

--- a/custom_components/area_occupancy/data/entity_type.py
+++ b/custom_components/area_occupancy/data/entity_type.py
@@ -5,7 +5,6 @@ import logging
 from typing import Any
 
 from homeassistant.const import (
-    STATE_CLOSED,
     STATE_CLOSING,
     STATE_ON,
     STATE_OPEN,
@@ -249,7 +248,7 @@ DEFAULT_TYPES: dict[InputType, dict[str, Any]] = {
         "weight": 0.3,
         "prob_given_true": 0.2,
         "prob_given_false": 0.02,
-        "active_states": [STATE_CLOSED],
+        "active_states": [STATE_OPEN],
         "active_range": None,
         "strength_multiplier": 2.0,
     },

--- a/custom_components/area_occupancy/strings.json
+++ b/custom_components/area_occupancy/strings.json
@@ -89,7 +89,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",
@@ -252,7 +252,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",
@@ -486,7 +486,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",
@@ -649,7 +649,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",

--- a/custom_components/area_occupancy/translations/en.json
+++ b/custom_components/area_occupancy/translations/en.json
@@ -89,7 +89,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",
@@ -252,7 +252,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",
@@ -487,7 +487,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",
@@ -650,7 +650,7 @@
                             "weight_cover": "Cover Weight"
                         },
                         "data_description": {
-                            "door_active_state": "This is the value your sensors report when the door is closed.",
+                            "door_active_state": "This is the state of the door that will be used to detect occupancy.",
                             "weight_door": "The weight given to door sensor inputs in the occupancy calculation.",
                             "window_active_state": "This is the state of the window that will be used to detect occupancy.",
                             "weight_window": "The weight given to window sensor inputs in the occupancy calculation.",


### PR DESCRIPTION
## Problem (#510)

Home Assistant's door `binary_sensor` convention is `on` = open. AOD's door active-state default was the odd one out among the door/window/cover trio — window already defaults to `open` (matching convention) and cover to `opening`, but door defaulted to `closed`. That meant a newly configured door sensor counted as **evidence of occupancy while closed**, and only started decaying once the door was opened — backwards from the intent (a door being used/open is the activity signal, not a door sitting shut).

The config field's description compounded the confusion: "This is the value your sensors report when the door is closed" described the inverted behavior as if it were correct.

Reported and diagnosed by @cryptk in #510 with clear repro steps.

## Fix

- `DEFAULT_DOOR_ACTIVE_STATE` and `DOOR_STATES["default"]` (`const.py`): `STATE_CLOSED` → `STATE_OPEN`
- `DEFAULT_TYPES[InputType.DOOR]["active_states"]` (`data/entity_type.py`): `[STATE_CLOSED]` → `[STATE_OPEN]`
- `door_active_state` description (`strings.json`, `translations/en.json`, all 4 occurrences each): reworded to the same neutral, accurate phrasing already used for `window_active_state`

## Config-safety note (Law 2)

`CONF_DOOR_ACTIVE_STATE` is read via `data.get(CONF_DOOR_ACTIVE_STATE, DEFAULT_DOOR_ACTIVE_STATE)` everywhere it's consulted. Existing areas that already have this key explicitly stored in their config entry are unaffected — this only changes the default offered to newly configured door sensors (fresh areas, or a legacy entry that somehow never persisted the key).

Closes #510.

## Test plan
- [x] `uv run pytest -k door -q` — 33 passed
- [x] Full suite: `uv run pytest -q` — 1789 passed
- [x] `ruff format` / `ruff check --fix` clean
- [x] Verified `strings.json` / `translations/en.json` still valid JSON