### PR TITLE
fix(prior): stop silent freeze and 0.99 clamp on global prior calculation

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -192,6 +192,19 @@ PRIOR_FLOOR_THRESHOLD_MARGIN: Final[float] = 0.01
 TIME_PRIOR_MIN_BOUND: Final[float] = 0.03
 TIME_PRIOR_MAX_BOUND: Final[float] = 0.9
 
+# Minimum observation span (wall-clock time since the earliest ground-truth
+# data point for an area's *current* motion/sleep/media sensors — occupied
+# or not) required before the global prior is trusted. Below this span the
+# occupied/elapsed ratio is dominated by sampling noise (e.g. a single short
+# occupied interval minutes after a sensor swap or "Reset learning" computes
+# occupied/elapsed ~= 1.0, which clamps to MAX_PRIOR every time — issue
+# #520 Bug B). 25h mirrors ``STALE_CACHE_THRESHOLD`` in data/health.py: both
+# describe "one full day plus buffer for a missed hourly analysis cycle" for
+# data fed by the same occupied-intervals pipeline, so reusing the value
+# keeps the two thresholds conceptually aligned instead of introducing an
+# unrelated second magic number.
+PRIOR_WARMUP_MIN_SPAN_HOURS: Final[float] = 25.0
+
 # Adjacent-areas / transition learning tunables (Phase 3 of feat/adjacent-areas).
 # First-pass values; tune from real data once Phase 3 is collecting transitions.
 

--- a/custom_components/area_occupancy/data/analysis.py
+++ b/custom_components/area_occupancy/data/analysis.py
@@ -14,6 +14,9 @@ from homeassistant.util import dt as dt_util
 from ..const import (
     ACCURACY_WINDOW_HOURS,
     DEFAULT_LOOKBACK_DAYS,
+    MAX_PRIOR,
+    MIN_PRIOR,
+    PRIOR_WARMUP_MIN_SPAN_HOURS,
     TIME_PRIOR_MAX_BOUND,
     TIME_PRIOR_MIN_BOUND,
 )
@@ -397,9 +400,17 @@ async def _run_pipeline_health_check(
             and entity.analysis_error in CORRELATION_FAILURE_ERRORS
         )
 
+        last_calculation_at = area.prior.last_calculation_at
+        last_prior_calculation_hours_ago: float | None = (
+            (now_aware - last_calculation_at).total_seconds() / 3600
+            if last_calculation_at is not None
+            else None
+        )
+
         area.health_monitor.check_pipeline_health(
             area_age_hours=area_age_hours,
             has_global_prior=area.prior.global_prior is not None,
+            last_prior_calculation_hours_ago=last_prior_calculation_hours_ago,
             cache_age_hours=cache_age_hours,
             last_analysis_duration_ms=coordinator.last_analysis_duration_ms,
             correlation_failure_count=failure_count,
@@ -458,7 +469,30 @@ class PriorAnalyzer:
         )
 
     def calculate_and_update_prior(self, days: int = DEFAULT_LOOKBACK_DAYS) -> None:
-        """Calculate and update the prior probability for the area."""
+        """Calculate and update the prior probability for the area.
+
+        Fixes two related bugs from issue #520:
+
+        - Bug A (silent freeze): if this area's current motion/sleep/media
+          sensors have *no* interval data at all (e.g. right after a sensor
+          swap wiped the old sensor's history, or a brand-new area before
+          the recorder sync has run), the old code silently no-op'd at
+          DEBUG level and left ``global_prior`` at whatever it last was —
+          forever, since nothing else flags a prior that's stopped
+          updating. This now logs at WARNING and (via
+          ``Prior.last_calculation_at`` staying unset) makes the
+          staleness detectable by
+          ``HealthMonitor._check_insufficient_priors``.
+        - Bug B (0.99 clamp): the observation-window denominator used to be
+          "now minus the first *occupied* interval's start", so a single
+          occupied interval minutes after a reset/swap computed
+          occupied/elapsed ~= 1.0 and clamped straight to ``MAX_PRIOR``
+          every time. The denominator basis is now "now minus the later of
+          the configured lookback start and the earliest data point we
+          have for the current sensor configuration" (any state, not just
+          occupied), with an explicit minimum-span warm-up guard below
+          which the calculation is deferred entirely rather than trusted.
+        """
         _LOGGER.debug(
             "Starting prior analysis for area %s (lookback: %d days)",
             self.area_name,
@@ -466,190 +500,112 @@ class PriorAnalyzer:
         )
 
         try:
-            # 1. Get occupied intervals based on motion sensors (ground truth)
-            # Note: get_occupied_intervals already performs merging and timeout extension
-            # The intervals returned are the final merged intervals
+            # 1. Ground-truth data check. Looks at *any* interval state
+            # (not just "on") for this area's current motion/sleep/media
+            # sensors, so it tells us whether we have data at all for the
+            # current sensor configuration — independent of whether any of
+            # it happens to be occupied.
+            first_seen = self.db.get_first_interval_timestamp(self.area_name)
+            if first_seen is None:
+                # Case 1 (#520 Bug A): genuinely no data yet for this
+                # area's current sensors. Don't silently keep whatever
+                # global_prior happens to be in memory forever — log
+                # loudly and leave last_calculation_at untouched so the
+                # staleness check can eventually flag it.
+                _LOGGER.warning(
+                    "No interval data of any kind found for area %s's "
+                    "current sensors (lookback: %d days) — prior "
+                    "calculation skipped this cycle; global_prior remains "
+                    "%s. Expected right after a sensor swap or new area "
+                    "until recorder history syncs; if it persists, check "
+                    "that the configured motion/sleep/media sensors are "
+                    "reporting state changes",
+                    self.area_name,
+                    days,
+                    self.area.prior.global_prior,
+                )
+                return
+
+            first_seen = ensure_utc_datetime(first_seen)
+            now = ensure_utc_datetime(dt_util.utcnow())
+            lookback_start = now - timedelta(days=days)
+
+            # Warm-up-guard denominator basis (#520 Bug B): the observed
+            # period starts at the later of the configured lookback window
+            # and the earliest data point we actually have for the current
+            # sensor configuration — never at the first *occupied*
+            # interval, which is what let a single occupied interval
+            # minutes after a reset compute occupied/elapsed ~= 1.0.
+            period_start = max(lookback_start, first_seen)
+
+            if period_start > now:
+                _LOGGER.error(
+                    "'now' (%s) is before the observation period start "
+                    "(%s) for area %s. This indicates severe clock skew "
+                    "or timezone issues. Using fallback prior.",
+                    now,
+                    period_start,
+                    self.area_name,
+                )
+                self.area.prior.set_global_prior(MIN_PRIOR)
+                return
+
+            observation_span_seconds = (now - period_start).total_seconds()
+            min_span_seconds = PRIOR_WARMUP_MIN_SPAN_HOURS * 3600
+
+            if observation_span_seconds < min_span_seconds:
+                # Case 2a (#520 Bug B): data exists but not enough of it
+                # yet to trust a computed ratio. Leave global_prior as-is —
+                # None falls back to MIN_PRIOR (+ any purpose floor) via
+                # Prior.value; a pre-existing value from before a swap is
+                # left alone rather than replaced by a noisy one-sample
+                # estimate. Deliberately do NOT advance
+                # last_calculation_at, so a warm-up that never completes
+                # still eventually surfaces via the staleness check once
+                # the area is old enough.
+                _LOGGER.debug(
+                    "Observation span too short for area %s (%.1fh < "
+                    "%.1fh warm-up minimum) — deferring prior update",
+                    self.area_name,
+                    observation_span_seconds / 3600,
+                    min_span_seconds / 3600,
+                )
+                return
+
+            # 2. Occupied intervals (ground-truth "on" time) over the same
+            # window. May legitimately be empty — an area with data but
+            # genuinely zero occupied time is a valid, low prior, not the
+            # same condition as "no data" handled above (Case 2b).
             occupied_intervals = self.get_occupied_intervals(days)
 
-            if not occupied_intervals:
-                _LOGGER.debug(
-                    "No occupancy data found for prior calculation in area %s",
-                    self.area_name,
-                )
-                return
-
-            # Log interval statistics for debugging
-            # Note: The intervals from get_occupied_intervals are already merged,
-            # so we can't see the raw count here. The merge happens in queries.get_occupied_intervals.
-            # We log what we have: the final merged interval count and duration.
-            occupied_duration_before_calc = sum(
-                (ensure_utc_datetime(end) - ensure_utc_datetime(start)).total_seconds()
-                for start, end in occupied_intervals
-            )
-            _LOGGER.debug(
-                "Prior calculation for area %s: %d merged intervals, %.1f hours total duration",
-                self.area_name,
-                len(occupied_intervals),
-                occupied_duration_before_calc / 3600,
-            )
-
-            # 2. Calculate global prior using actual data period
-            # Determine actual data period from intervals (not fixed lookback)
-            # Ensure all datetime objects are timezone-aware UTC
-
-            # Diagnostic logging: log interval details before calculation
-            _LOGGER.debug(
-                "Prior calculation for area %s: %d intervals",
-                self.area_name,
-                len(occupied_intervals),
-            )
             if occupied_intervals:
-                # Log first few intervals for debugging
-                for i, (start, end) in enumerate(occupied_intervals[:5]):
-                    start_aware = ensure_utc_datetime(start)
-                    end_aware = ensure_utc_datetime(end)
-                    _LOGGER.debug(
-                        "Interval %d: start=%s (tz=%s), end=%s (tz=%s), duration=%.2f",
-                        i,
-                        start_aware,
-                        start_aware.tzinfo,
-                        end_aware,
-                        end_aware.tzinfo,
-                        (end_aware - start_aware).total_seconds(),
-                    )
-
-            # Validate interval data: check all intervals have start <= end
-            invalid_intervals = []
-            for i, (start, end) in enumerate(occupied_intervals):
-                start_aware = ensure_utc_datetime(start)
-                end_aware = ensure_utc_datetime(end)
-                if start_aware > end_aware:
-                    invalid_intervals.append((i, start_aware, end_aware))
-
-            if invalid_intervals:
-                _LOGGER.error(
-                    "Invalid interval data for area %s: %d intervals have start > end",
-                    self.area_name,
-                    len(invalid_intervals),
-                )
-                for i, start, end in invalid_intervals[:5]:  # Log first 5
-                    _LOGGER.error(
-                        "  Interval %d: start=%s > end=%s (difference: %.2f seconds)",
-                        i,
-                        start,
-                        end,
-                        (start - end).total_seconds(),
-                    )
-                # Filter out invalid intervals
-                occupied_intervals = [
+                invalid_intervals = [
                     (start, end)
                     for start, end in occupied_intervals
-                    if ensure_utc_datetime(start) <= ensure_utc_datetime(end)
+                    if ensure_utc_datetime(start) > ensure_utc_datetime(end)
                 ]
-                if not occupied_intervals:
+                if invalid_intervals:
                     _LOGGER.error(
-                        "All intervals invalid for area %s, using fallback prior",
+                        "Invalid interval data for area %s: %d intervals "
+                        "have start > end; excluding them",
                         self.area_name,
+                        len(invalid_intervals),
                     )
-                    self.area.prior.set_global_prior(0.01)
-                    return
+                    occupied_intervals = [
+                        (start, end)
+                        for start, end in occupied_intervals
+                        if ensure_utc_datetime(start) <= ensure_utc_datetime(end)
+                    ]
 
-            # Convert all intervals to UTC and find bounds
-            first_interval_start = min(
-                ensure_utc_datetime(start) for start, end in occupied_intervals
-            )
-            last_interval_end = max(
-                ensure_utc_datetime(end) for start, end in occupied_intervals
-            )
-            now = ensure_utc_datetime(dt_util.utcnow())
-
-            # Validate that intervals are chronologically valid
-            if first_interval_start > last_interval_end:
-                _LOGGER.error(
-                    "Invalid interval data for area %s: first_interval_start (%s) > last_interval_end (%s). "
-                    "This may indicate timezone issues or corrupted data.",
-                    self.area_name,
-                    first_interval_start,
-                    last_interval_end,
-                )
-                # Use fallback prior
-                self.area.prior.set_global_prior(0.01)
-                _LOGGER.debug(
-                    "Prior analysis completed for area %s: global_prior=0.010 (fallback due to invalid interval bounds)",
-                    self.area_name,
-                )
-                return
-
-            # Diagnostic logging: log key timestamps
-            _LOGGER.debug(
-                "Period calculation for area %s: first_interval_start=%s (tz=%s), "
-                "last_interval_end=%s (tz=%s), now=%s (tz=%s)",
-                self.area_name,
-                first_interval_start,
-                first_interval_start.tzinfo,
-                last_interval_end,
-                last_interval_end.tzinfo,
-                now,
-                now.tzinfo,
-            )
-
-            # Use actual period: from first interval start to now. Time after
-            # the last interval is known-unoccupied and must stay in the
-            # denominator — truncating the period at last_interval_end inflates
-            # the prior every time the area is quiet for a while (#483).
-            actual_period_end = now
-
-            # Defensive check: ensure actual_period_end >= first_interval_start
-            if actual_period_end < first_interval_start:
-                _LOGGER.error(
-                    "'now' (%s) is before first_interval_start (%s) for area %s. "
-                    "This indicates severe clock skew or timezone issues. Using fallback prior.",
-                    actual_period_end,
-                    first_interval_start,
-                    self.area_name,
-                )
-                self.area.prior.set_global_prior(0.01)
-                _LOGGER.debug(
-                    "Prior analysis completed for area %s: global_prior=0.010 (fallback due to clock skew)",
-                    self.area_name,
-                )
-                return
-
-            actual_period_duration = (
-                actual_period_end - first_interval_start
-            ).total_seconds()
-
-            # Guard against zero or negative duration (bad timestamps or clock skew)
-            if actual_period_duration <= 0:
-                _LOGGER.warning(
-                    "Invalid period duration (%.2f seconds) for area %s. "
-                    "first_interval_start=%s, actual_period_end=%s. "
-                    "This may indicate bad timestamps or clock skew. "
-                    "Using safe fallback prior of 0.01.",
-                    actual_period_duration,
-                    self.area_name,
-                    first_interval_start,
-                    actual_period_end,
-                )
-                # Set safe fallback prior and return early
-                self.area.prior.set_global_prior(0.01)
-                _LOGGER.debug(
-                    "Prior analysis completed for area %s: global_prior=0.010 (fallback due to invalid period)",
-                    self.area_name,
-                )
-                return
-
-            # Calculate occupied duration (ensure UTC-aware)
-            # Use ensure_utc_datetime to ensure all datetimes are in UTC
             occupied_duration = sum(
                 (ensure_utc_datetime(end) - ensure_utc_datetime(start)).total_seconds()
                 for start, end in occupied_intervals
             )
 
-            # Use actual period for prior calculation
-            # Ensure valid probability (0.01 to 0.99)
+            # Ensure valid probability (MIN_PRIOR to MAX_PRIOR)
             global_prior = max(
-                0.01, min(0.99, occupied_duration / actual_period_duration)
+                MIN_PRIOR,
+                min(MAX_PRIOR, occupied_duration / observation_span_seconds),
             )
 
             # 3. Update the Prior object
@@ -660,7 +616,7 @@ class PriorAnalyzer:
                 self.area_name,
                 global_prior,
                 occupied_duration / 3600,
-                actual_period_duration / 86400,
+                observation_span_seconds / 86400,
                 len(occupied_intervals),
             )
 
@@ -669,10 +625,10 @@ class PriorAnalyzer:
                 success = self.db.save_global_prior(
                     area_name=self.area_name,
                     prior_value=global_prior,
-                    data_period_start=first_interval_start,
-                    data_period_end=actual_period_end,
+                    data_period_start=period_start,
+                    data_period_end=now,
                     total_occupied_seconds=occupied_duration,
-                    total_period_seconds=actual_period_duration,
+                    total_period_seconds=observation_span_seconds,
                     interval_count=len(occupied_intervals),
                     calculation_method="interval_analysis",
                 )
@@ -681,7 +637,7 @@ class PriorAnalyzer:
                         "Global prior saved for area %s: %.3f (period: %.1f days, %d intervals)",
                         self.area_name,
                         global_prior,
-                        actual_period_duration / 86400,
+                        observation_span_seconds / 86400,
                         len(occupied_intervals),
                     )
                 else:
@@ -698,15 +654,15 @@ class PriorAnalyzer:
             try:
                 time_priors, data_points_per_slot = self.calculate_time_priors(
                     occupied_intervals,
-                    first_interval_start,
-                    actual_period_end,
+                    period_start,
+                    now,
                 )
                 if time_priors:
                     success = self.db.save_time_priors(
                         area_name=self.area_name,
                         time_priors=time_priors,
-                        data_period_start=first_interval_start,
-                        data_period_end=actual_period_end,
+                        data_period_start=period_start,
+                        data_period_end=now,
                         data_points_per_slot=data_points_per_slot,
                     )
                     if success:
@@ -876,6 +832,20 @@ async def ensure_occupied_intervals_cache(
     This function checks cache validity and populates it from raw intervals
     if needed. This ensures the cache exists before interval aggregation
     deletes raw intervals older than the retention period.
+
+    Known follow-up (#520, Fix 4, deliberately deferred out of that PR):
+    ``OccupiedIntervalsCache`` currently has no read-path consumers anywhere
+    in the codebase — prior calculation and everything else that needs
+    occupied intervals queries the raw ``Intervals`` table directly (see
+    ``PriorAnalyzer.get_occupied_intervals`` / ``db.queries.get_occupied_intervals``).
+    That means this step spends a full pipeline cycle maintaining a table
+    nothing reads, and (because it skips saving when intervals are empty)
+    it silently goes stale in lockstep with the exact "no occupied data"
+    condition it might otherwise have helped diagnose, rather than
+    surfacing it. Either wire this cache in as a real fast-path/cross-check
+    for prior calculation, or remove the step and the table's population
+    code — left as a follow-up rather than a destructive schema change
+    bundled into the #520 fix.
 
     Args:
         coordinator: The coordinator instance containing areas and database

--- a/custom_components/area_occupancy/data/health.py
+++ b/custom_components/area_occupancy/data/health.py
@@ -112,6 +112,13 @@ PRIORS_TRAINING_GRACE_PERIOD: timedelta = timedelta(days=7)
 # (a slightly larger margin than the 24h validity window in db.queries).
 STALE_CACHE_THRESHOLD: timedelta = timedelta(hours=25)
 
+# The global prior is recomputed every hourly analysis cycle alongside the
+# occupied-intervals cache above, from the same underlying data — reuse the
+# same 25h margin (one day plus buffer for a missed cycle) to flag a prior
+# that has stopped updating (#520 Bug A: a silent no-op previously left a
+# frozen value in place indefinitely with no signal anything had stopped).
+PRIOR_RECALCULATION_STALE_THRESHOLD: timedelta = STALE_CACHE_THRESHOLD
+
 # Last full analysis cycle is flagged as "slow" if it took longer than this.
 # Set conservatively to 3 minutes for now — large installations with many
 # correlatable sensors and long recorder histories can legitimately exceed
@@ -479,6 +486,7 @@ class HealthMonitor:
         last_analysis_duration_ms: float | None,
         correlation_failure_count: int,
         correlatable_entity_count: int,
+        last_prior_calculation_hours_ago: float | None = None,
     ) -> list[HealthIssue]:
         """Run pipeline-scope checks and merge results with sensor issues.
 
@@ -506,7 +514,9 @@ class HealthMonitor:
             if issue.issue_type not in _PIPELINE_ISSUE_TYPES
         ]
 
-        issue = self._check_insufficient_priors(area_age_hours, has_global_prior, now)
+        issue = self._check_insufficient_priors(
+            area_age_hours, has_global_prior, last_prior_calculation_hours_ago, now
+        )
         if issue:
             new_issues.append(issue)
 
@@ -688,36 +698,69 @@ class HealthMonitor:
         self,
         area_age_hours: float | None,
         has_global_prior: bool,
+        last_prior_calculation_hours_ago: float | None,
         now: datetime,
     ) -> HealthIssue | None:
-        """Flag areas past the warm-up period that still have no global prior.
+        """Flag areas whose global prior is missing or has stopped updating.
 
-        ``global_prior`` is None until enough occupied-vs-total time has
-        accumulated for the prior calculator to produce a value. If the
-        area has been running for longer than ``PRIORS_TRAINING_GRACE_PERIOD``
-        and the global prior is still missing, the user should know — the
-        integration is silently falling back to ``MIN_PRIOR`` for every
-        Bayesian update.
+        Two distinct conditions share this issue type (both mean the same
+        thing to the user: "the learned prior can't be trusted right now"):
+
+        - ``global_prior`` is still ``None`` after
+          ``PRIORS_TRAINING_GRACE_PERIOD`` — the prior calculator has never
+          produced a value (original behavior).
+        - A prior *was* computed at some point, but hasn't been recomputed
+          in over ``PRIOR_RECALCULATION_STALE_THRESHOLD``. Before #520 this
+          case was invisible: ``PriorAnalyzer.calculate_and_update_prior``
+          silently no-ops (at DEBUG level) whenever the occupied-intervals
+          query returns empty — e.g. after a motion/presence sensor swap
+          wipes that area's interval history — and the stale in-memory
+          value persists indefinitely with no signal that recalculation
+          has stopped. ``last_prior_calculation_hours_ago`` is ``None``
+          only when a prior exists but was never accompanied by a
+          calculation timestamp (legacy data) — that's deliberately not
+          flagged, since we can't tell how stale it is.
         """
         if area_age_hours is None:
             return None
-        if has_global_prior:
-            return None
         grace_hours = PRIORS_TRAINING_GRACE_PERIOD.total_seconds() / 3600
-        if area_age_hours < grace_hours:
-            return None
-        return HealthIssue(
-            entity_id=None,
-            issue_type=HealthIssueType.INSUFFICIENT_PRIORS,
-            input_type=None,
-            since=now,
-            duration_hours=round(area_age_hours, 1),
-            details=(
-                f"Area has been running for {area_age_hours / 24:.0f} days "
-                f"but no global prior has been learned yet "
-                f"(grace period: {grace_hours / 24:.0f} days)"
-            ),
-        )
+
+        if not has_global_prior:
+            if area_age_hours < grace_hours:
+                return None
+            return HealthIssue(
+                entity_id=None,
+                issue_type=HealthIssueType.INSUFFICIENT_PRIORS,
+                input_type=None,
+                since=now,
+                duration_hours=round(area_age_hours, 1),
+                details=(
+                    f"Area has been running for {area_age_hours / 24:.0f} days "
+                    f"but no global prior has been learned yet "
+                    f"(grace period: {grace_hours / 24:.0f} days)"
+                ),
+            )
+
+        stale_hours = PRIOR_RECALCULATION_STALE_THRESHOLD.total_seconds() / 3600
+        if (
+            last_prior_calculation_hours_ago is not None
+            and last_prior_calculation_hours_ago >= stale_hours
+        ):
+            return HealthIssue(
+                entity_id=None,
+                issue_type=HealthIssueType.INSUFFICIENT_PRIORS,
+                input_type=None,
+                since=now,
+                duration_hours=round(last_prior_calculation_hours_ago, 1),
+                details=(
+                    f"Global prior hasn't been recalculated in "
+                    f"{last_prior_calculation_hours_ago:.0f}h (threshold: "
+                    f"{stale_hours:.0f}h) — recalculation may be silently "
+                    f"failing, e.g. no occupied-interval data for this "
+                    f"area's currently configured sensors"
+                ),
+            )
+        return None
 
     def _check_stale_cache(
         self,

--- a/custom_components/area_occupancy/data/prior.py
+++ b/custom_components/area_occupancy/data/prior.py
@@ -72,6 +72,13 @@ class Prior:
         self.hass = coordinator.hass
         self.global_prior: float | None = None
         self._last_updated: datetime | None = None
+        # Timestamp of the most recent *successful* global-prior calculation
+        # (set by ``set_global_prior``), as opposed to an analysis cycle that
+        # skipped the update entirely because no ground-truth data exists
+        # yet (#520 Bug A). Loaded from ``GlobalPriors.calculation_date`` on
+        # startup so staleness detection survives a restart; see
+        # ``data.health.HealthMonitor._check_insufficient_priors``.
+        self.last_calculation_at: datetime | None = None
         # Cache for all 168 time priors: (day_of_week, time_slot) -> prior_value
         self._cached_time_priors: dict[tuple[int, int], float] | None = None
 
@@ -184,7 +191,9 @@ class Prior:
         now = to_local(dt_util.utcnow())
         return (now.hour * 60 + now.minute) // DEFAULT_SLOT_MINUTES
 
-    def set_global_prior(self, prior: float) -> None:
+    def set_global_prior(
+        self, prior: float, *, calculation_date: datetime | None = None
+    ) -> None:
         """Set the global prior value.
 
         The prior is clamped to [MIN_PROBABILITY, MAX_PROBABILITY] to ensure
@@ -192,10 +201,20 @@ class Prior:
 
         Args:
             prior: The prior probability value (will be clamped to valid bounds)
+            calculation_date: When this value was actually computed. Defaults
+                to now (the normal case: a fresh calculation just completed).
+                The data-load path passes the persisted
+                ``GlobalPriors.calculation_date`` instead, so
+                ``last_calculation_at`` reflects when the prior was last
+                *recomputed*, not when it was last *loaded* — otherwise a
+                restart would reset the staleness clock and mask a frozen
+                prior (#520 Bug A) until another full grace period elapsed.
         """
         self.global_prior = clamp_probability(prior)
         self._invalidate_time_prior_cache()
-        self._last_updated = dt_util.utcnow()
+        now = dt_util.utcnow()
+        self._last_updated = now
+        self.last_calculation_at = calculation_date or now
 
     def clear_cache(self) -> None:
         """Clear all cached data to release memory.
@@ -208,6 +227,7 @@ class Prior:
         # Also clear global_prior and last_updated to release references
         self.global_prior = None
         self._last_updated = None
+        self.last_calculation_at = None
 
     def _invalidate_time_prior_cache(self) -> None:
         """Invalidate the time_prior cache."""

--- a/custom_components/area_occupancy/data/prior.py
+++ b/custom_components/area_occupancy/data/prior.py
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Sentinel distinguishing "caller didn't pass calculation_date" (fresh
+# calculation just completed -> default to now) from "caller explicitly
+# passed calculation_date=None" (loaded a legacy DB row with no recorded
+# timestamp -> must stay None, not silently become now). `None` itself
+# can't serve as the "not passed" default since it's also the valid explicit
+# value for the legacy case.
+_CALCULATION_DATE_UNSET = object()
+
 # Prior calculation constants
 PRIOR_FACTOR = 1.0
 DEFAULT_PRIOR = 0.5
@@ -192,7 +200,10 @@ class Prior:
         return (now.hour * 60 + now.minute) // DEFAULT_SLOT_MINUTES
 
     def set_global_prior(
-        self, prior: float, *, calculation_date: datetime | None = None
+        self,
+        prior: float,
+        *,
+        calculation_date: datetime | None = _CALCULATION_DATE_UNSET,  # type: ignore[assignment]
     ) -> None:
         """Set the global prior value.
 
@@ -201,20 +212,27 @@ class Prior:
 
         Args:
             prior: The prior probability value (will be clamped to valid bounds)
-            calculation_date: When this value was actually computed. Defaults
-                to now (the normal case: a fresh calculation just completed).
-                The data-load path passes the persisted
-                ``GlobalPriors.calculation_date`` instead, so
+            calculation_date: When this value was actually computed. Omitting
+                this argument defaults to now (the normal case: a fresh
+                calculation just completed). The data-load path passes the
+                persisted ``GlobalPriors.calculation_date`` instead, so
                 ``last_calculation_at`` reflects when the prior was last
                 *recomputed*, not when it was last *loaded* — otherwise a
                 restart would reset the staleness clock and mask a frozen
                 prior (#520 Bug A) until another full grace period elapsed.
+                An explicit ``None`` (a legacy DB row with no recorded
+                timestamp) is preserved as ``None`` rather than defaulting to
+                now — coercing it would make the legacy case indistinguishable
+                from a fresh calculation and defeat the staleness check
+                entirely.
         """
         self.global_prior = clamp_probability(prior)
         self._invalidate_time_prior_cache()
         now = dt_util.utcnow()
         self._last_updated = now
-        self.last_calculation_at = calculation_date or now
+        self.last_calculation_at = (
+            now if calculation_date is _CALCULATION_DATE_UNSET else calculation_date
+        )
 
     def clear_cache(self) -> None:
         """Clear all cached data to release memory.

--- a/custom_components/area_occupancy/db/core.py
+++ b/custom_components/area_occupancy/db/core.py
@@ -90,6 +90,7 @@ def _create_delegated_methods() -> dict[str, Any]:
         "get_global_prior": queries.get_global_prior,
         "get_occupied_intervals_cache": queries.get_occupied_intervals_cache,
         "is_occupied_intervals_cache_valid": queries.is_occupied_intervals_cache_valid,
+        "get_entities_without_intervals": queries.get_entities_without_intervals,
         # Sync methods
         "sync_states": sync.sync_states,
         # Aggregation methods
@@ -343,6 +344,18 @@ class AreaOccupancyDB:
             area_name,
             lookback_days,
             motion_timeout,
+        )
+
+    def get_first_interval_timestamp(self, area_name: str) -> datetime | None:
+        """Return the earliest any-state interval timestamp for this area.
+
+        Delegates to ``queries.get_first_interval_timestamp`` — see that
+        function's docstring for how this is used to distinguish "no data
+        at all" from "no occupied data" and as the warm-up-guard basis for
+        prior calculation (#520).
+        """
+        return queries.get_first_interval_timestamp(
+            self, self.coordinator.entry_id, area_name
         )
 
     @contextmanager

--- a/custom_components/area_occupancy/db/operations.py
+++ b/custom_components/area_occupancy/db/operations.py
@@ -266,7 +266,10 @@ async def load_data(db: AreaOccupancyDB) -> None:
                 db.get_global_prior, area_name
             )
             if global_prior_data:
-                area_data.prior.set_global_prior(global_prior_data["prior_value"])
+                area_data.prior.set_global_prior(
+                    global_prior_data["prior_value"],
+                    calculation_date=global_prior_data.get("calculation_date"),
+                )
 
             # Process entities
             if entities:

--- a/custom_components/area_occupancy/db/queries.py
+++ b/custom_components/area_occupancy/db/queries.py
@@ -243,6 +243,99 @@ def get_occupied_intervals(
         return extended_intervals
 
 
+def get_first_interval_timestamp(
+    db: AreaOccupancyDB,
+    entry_id: str,
+    area_name: str,
+) -> datetime | None:
+    """Return the earliest Intervals timestamp for this area's ground-truth entities.
+
+    Unlike :func:`get_occupied_intervals`, this looks at every interval
+    *regardless of state* (not just "on"/active rows) for the area's current
+    motion/sleep/media sensors. It answers "when did we start observing
+    these entities at all" rather than "when did we first see them active".
+
+    Used two ways by prior calculation (#520):
+
+    - Distinguishing "no data exists yet for this area's current sensors"
+      (returns ``None``) from "there is data but none of it is occupied"
+      (returns a timestamp, with ``get_occupied_intervals`` returning ``[]``)
+      — Bug A's silent-freeze fix needs this distinction to know when to
+      flag a stale prior versus computing a genuine near-zero one.
+    - As the warm-up-guard denominator basis, replacing "first *occupied*
+      interval" — a single occupied interval minutes after a sensor swap
+      no longer makes the observation window collapse to just that
+      interval's own duration, which is what produced Bug B's
+      occupied/elapsed ~= 1.0 clamp-to-0.99.
+
+    Deliberately unbounded by lookback days: a sensor that has been
+    reporting for longer than the lookback window should resolve to "seen
+    at least since the lookback window started" once combined with the
+    configured lookback in the caller, not to "no data" just because this
+    query's own window was truncated.
+    """
+    try:
+        with db.get_session() as session:
+            result = (
+                session.query(sa.func.min(db.Intervals.start_time))
+                .join(
+                    db.Entities,
+                    (db.Intervals.entity_id == db.Entities.entity_id)
+                    & (db.Intervals.area_name == db.Entities.area_name),
+                )
+                .filter(
+                    db.Entities.entry_id == entry_id,
+                    db.Entities.area_name == area_name,
+                    db.Intervals.area_name == area_name,
+                    db.Entities.entity_type.in_(
+                        [
+                            InputType.MOTION.value,
+                            InputType.MEDIA.value,
+                            InputType.SLEEP.value,
+                        ]
+                    ),
+                )
+                .scalar()
+            )
+            if result is None:
+                return None
+            return from_db_utc(result)
+    except (SQLAlchemyError, ValueError, TypeError, RuntimeError, OSError) as e:
+        _LOGGER.error(
+            "Error getting first interval timestamp for area '%s': %s", area_name, e
+        )
+        return None
+
+
+def get_entities_without_intervals(
+    db: AreaOccupancyDB,
+    entity_ids: list[str],
+) -> set[str]:
+    """Return the subset of ``entity_ids`` that have zero Intervals rows.
+
+    Used by ``sync_states`` to identify newly-(re)configured entities that
+    need a recorder-history backfill rather than only accumulating data
+    forward from the shared sync watermark (#520 Bug A path 1: a sensor
+    swap otherwise leaves the new entity with no ground-truth history until
+    it happens to trigger after being added).
+    """
+    if not entity_ids:
+        return set()
+    try:
+        with db.get_session() as session:
+            with_data = {
+                row[0]
+                for row in session.query(db.Intervals.entity_id)
+                .filter(db.Intervals.entity_id.in_(entity_ids))
+                .distinct()
+                .all()
+            }
+        return set(entity_ids) - with_data
+    except (SQLAlchemyError, ValueError, TypeError, RuntimeError, OSError) as e:
+        _LOGGER.error("Error getting entities without intervals: %s", e)
+        return set()
+
+
 def build_base_filters(
     db: AreaOccupancyDB, entry_id: str, lookback_date_db: datetime, area_name: str
 ) -> list[Any]:
@@ -372,7 +465,9 @@ def get_global_prior(db: AreaOccupancyDB, area_name: str) -> dict[str, Any] | No
             if global_prior:
                 return {
                     "prior_value": global_prior.prior_value,
-                    "calculation_date": global_prior.calculation_date,
+                    # DB stores naive UTC; convert to aware UTC so callers can
+                    # do datetime arithmetic directly (e.g. staleness checks).
+                    "calculation_date": from_db_utc(global_prior.calculation_date),
                     "data_period_start": global_prior.data_period_start,
                     "data_period_end": global_prior.data_period_end,
                     "total_occupied_seconds": global_prior.total_occupied_seconds,

--- a/custom_components/area_occupancy/db/queries.py
+++ b/custom_components/area_occupancy/db/queries.py
@@ -467,7 +467,15 @@ def get_global_prior(db: AreaOccupancyDB, area_name: str) -> dict[str, Any] | No
                     "prior_value": global_prior.prior_value,
                     # DB stores naive UTC; convert to aware UTC so callers can
                     # do datetime arithmetic directly (e.g. staleness checks).
-                    "calculation_date": from_db_utc(global_prior.calculation_date),
+                    # calculation_date is NOT NULL for rows created by the
+                    # current schema, but legacy rows predating that
+                    # constraint may still have NULL — guard rather than
+                    # let AttributeError escape uncaught below.
+                    "calculation_date": (
+                        from_db_utc(global_prior.calculation_date)
+                        if global_prior.calculation_date is not None
+                        else None
+                    ),
                     "data_period_start": global_prior.data_period_start,
                     "data_period_end": global_prior.data_period_end,
                     "total_occupied_seconds": global_prior.total_occupied_seconds,

--- a/custom_components/area_occupancy/db/sync.py
+++ b/custom_components/area_occupancy/db/sync.py
@@ -14,7 +14,12 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.recorder import get_instance
 from homeassistant.util import dt as dt_util
 
-from ..const import MAX_INTERVAL_SECONDS, MIN_INTERVAL_SECONDS, RETENTION_DAYS
+from ..const import (
+    HA_RECORDER_DAYS,
+    MAX_INTERVAL_SECONDS,
+    MIN_INTERVAL_SECONDS,
+    RETENTION_DAYS,
+)
 from ..data.entity_type import NUMERIC_INPUT_TYPES
 from ..time_utils import to_db_utc, to_utc
 from . import queries
@@ -313,6 +318,54 @@ async def sync_states(db: AreaOccupancyDB) -> None:
                 minimal_response=False,
             )
         )
+
+        # Backfill entities with zero existing Intervals rows (e.g. a
+        # motion/sleep/media sensor just added or swapped into an area's
+        # config) with their available recorder history, instead of only
+        # accumulating data forward from the shared ``start_time`` watermark
+        # above — otherwise a newly-configured sensor has no ground-truth
+        # history until enough time passes for it to happen to trigger
+        # (#520 Bug A path 1). Bounded by ``HA_RECORDER_DAYS`` since that's
+        # the most a HA recorder install typically retains.
+        new_entity_ids = await hass.async_add_executor_job(
+            db.get_entities_without_intervals, entity_ids
+        )
+        if new_entity_ids:
+            backfill_start = to_utc(end_time - timedelta(days=HA_RECORDER_DAYS))
+            backfill_end = to_utc(start_time)
+            if backfill_start < backfill_end:
+                _LOGGER.info(
+                    "Backfilling recorder history for %d newly-tracked "
+                    "entity(ies) with no interval data yet: %s",
+                    len(new_entity_ids),
+                    sorted(new_entity_ids),
+                )
+                backfill_states = await recorder.async_add_executor_job(
+                    lambda: get_significant_states(
+                        hass,
+                        backfill_start,
+                        backfill_end,
+                        list(new_entity_ids),
+                        minimal_response=False,
+                    )
+                )
+                for entity_id, history in (backfill_states or {}).items():
+                    if not history:
+                        continue
+                    # Backfilled history is strictly older than anything the
+                    # main query above could have returned for this entity
+                    # (which had zero rows to begin with), so prepend it.
+                    # The two windows share a boundary (backfill_end ==
+                    # start_time) and ``get_significant_states`` can be
+                    # inclusive at both ends, so de-dupe by (state,
+                    # last_changed) to avoid double-counting a boundary
+                    # state that both queries returned.
+                    existing = states.get(entity_id, [])
+                    seen = {(s.state, s.last_changed) for s in existing}
+                    backfilled = [
+                        s for s in history if (s.state, s.last_changed) not in seen
+                    ]
+                    states[entity_id] = backfilled + existing
 
         if not states:
             return

--- a/tests/test_data_analysis.py
+++ b/tests/test_data_analysis.py
@@ -165,42 +165,155 @@ class TestPriorAnalyzerWithRealDB:
 class TestPriorAnalyzerCalculateAndUpdatePrior:
     """Test PriorAnalyzer.calculate_and_update_prior method."""
 
-    def test_empty_intervals_returns_early(
+    def test_no_data_at_all_logs_warning_and_preserves_prior(
         self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
     ) -> None:
-        """Test that empty intervals cause early return without prior update."""
+        """Test #520 Bug A Case 1: no interval data of any kind for this area.
+
+        Regression test for the silent freeze: when
+        ``get_first_interval_timestamp`` finds zero rows at all (not just
+        zero occupied rows) for the area's current ground-truth sensors,
+        the old code's ``_LOGGER.debug(...); return`` silently no-op'd with
+        no trace. This must now be visible: at minimum, a WARNING-level log
+        line, not DEBUG. The pre-existing prior (if any) is left untouched
+        this cycle (not reset to a default) -- but crucially,
+        ``last_calculation_at`` is NOT advanced, which is what lets
+        ``HealthMonitor``'s staleness check eventually flag a freeze that
+        persists across many cycles (see test_data_health.py's
+        test_stale_prior_recalculation_flagged).
+        """
         area_name = coordinator.get_area_names()[0]
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Store original prior value
         original_prior = area.prior.global_prior
+        original_calc_at = area.prior.last_calculation_at
 
-        # Mock get_occupied_intervals to return empty list
-        with patch.object(analyzer, "get_occupied_intervals", return_value=[]):
+        with (
+            patch.object(analyzer, "get_occupied_intervals", return_value=[]),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=None
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis._LOGGER"
+            ) as mock_logger,
+        ):
             analyzer.calculate_and_update_prior()
 
-        # Prior should not be updated
+        # Prior value and calculation timestamp are both untouched.
+        assert area.prior.global_prior == original_prior
+        assert area.prior.last_calculation_at == original_calc_at
+        # Must be visible at WARNING, not silently swallowed at DEBUG.
+        assert mock_logger.warning.called
+        warning_text = str(mock_logger.warning.call_args_list).lower()
+        assert "no interval data" in warning_text
+
+    def test_data_exists_zero_occupied_computes_low_prior(
+        self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
+    ) -> None:
+        """Test #520 Bug A Case 2: data exists but none of it is occupied.
+
+        This is a genuinely different situation from "no data at all" and
+        must NOT be treated the same way: the area has been observed for
+        long enough (clears the warm-up guard) and is legitimately quiet,
+        so the prior should move toward MIN_PRIOR rather than staying
+        frozen or being skipped.
+        """
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+        analyzer = PriorAnalyzer(coordinator, area_name)
+
+        now = freeze_time
+        first_seen = now - timedelta(hours=48)  # data exists for 48h
+
+        with (
+            patch.object(analyzer, "get_occupied_intervals", return_value=[]),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
+                return_value=now,
+            ),
+        ):
+            analyzer.calculate_and_update_prior()
+
+        # occupied_duration=0 over a 48h span -> clamps to MIN_PRIOR (0.01),
+        # and last_calculation_at IS advanced (this was a real calculation,
+        # not a skip).
+        assert area.prior.global_prior == 0.01
+        assert area.prior.last_calculation_at is not None
+
+    def test_warmup_guard_defers_instead_of_clamping_to_max(
+        self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
+    ) -> None:
+        """Test #520 Bug B: a near-empty dataset must not clamp to MAX_PRIOR.
+
+        Before the fix, a single occupied interval starting minutes after a
+        sensor swap/reset computed occupied/elapsed ~= 1.0, which clamped
+        straight to 0.99 (MAX_PRIOR) every time. With the warm-up guard,
+        an observation span below PRIOR_WARMUP_MIN_SPAN_HOURS (25h) defers
+        the update entirely rather than trusting the noisy ratio.
+        """
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+        analyzer = PriorAnalyzer(coordinator, area_name)
+
+        now = freeze_time
+        # Sensor first seen only 10 minutes ago; its one interval so far is
+        # almost entirely occupied -- the exact shape that used to clamp to
+        # 0.99.
+        first_seen = now - timedelta(minutes=10)
+        occupied_start = first_seen
+        occupied_end = now - timedelta(minutes=1)
+        intervals = [(occupied_start, occupied_end)]
+
+        original_prior = area.prior.global_prior
+
+        with (
+            patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
+                return_value=now,
+            ),
+        ):
+            analyzer.calculate_and_update_prior()
+
+        # Must NOT be clamped to 0.99 -- the update is deferred entirely.
+        assert area.prior.global_prior != 0.99
         assert area.prior.global_prior == original_prior
 
     def test_invalid_period_duration_sets_fallback_prior(
         self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
     ) -> None:
-        """Test that invalid period duration (zero/negative) sets fallback prior 0.01."""
+        """Test the clock-skew defensive fallback: observation start after 'now'.
+
+        ``get_first_interval_timestamp`` returning a timestamp *after* now
+        can only happen from severe clock skew or a timezone bug -- the
+        defensive branch sets the safe MIN_PRIOR fallback rather than
+        computing a nonsensical negative-duration ratio.
+        """
         area_name = coordinator.get_area_names()[0]
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Create intervals with invalid period (same start and end)
         now = freeze_time
-        invalid_intervals = [(now, now)]  # Zero duration interval
+        future_first_seen = now + timedelta(hours=1)
 
-        with patch.object(
-            analyzer, "get_occupied_intervals", return_value=invalid_intervals
+        with (
+            patch.object(analyzer, "get_occupied_intervals", return_value=[]),
+            patch.object(
+                analyzer.db,
+                "get_first_interval_timestamp",
+                return_value=future_first_seen,
+            ),
         ):
             analyzer.calculate_and_update_prior()
 
-        # Should set fallback prior of 0.01
+        # Should set fallback prior of 0.01 (MIN_PRIOR)
         assert area.prior.global_prior == 0.01
 
     def test_valid_calculation_sets_correct_prior(
@@ -211,16 +324,19 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Create intervals: 2 hours occupied
-        # Period calculation uses first_interval_start to actual_period_end
+        # Create intervals: 4 hours occupied, sensor first seen 32h ago
+        # (clears the 25h warm-up-guard minimum from #520 Bug B).
         now = freeze_time
-        occupied_start = now - timedelta(hours=8)
-        occupied_end = now - timedelta(hours=6)
+        first_seen = now - timedelta(hours=32)
+        occupied_start = now - timedelta(hours=32)
+        occupied_end = now - timedelta(hours=28)
         intervals = [(occupied_start, occupied_end)]
 
-        # Mock get_occupied_intervals
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now,
@@ -230,12 +346,12 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
             analyzer.calculate_and_update_prior()
 
         # Period calculation:
-        # - first_interval_start = occupied_start (now - 8h)
-        # - actual_period_end = now (quiet tail stays in the denominator, #483)
-        # - actual_period_duration = 8 hours
-        # - occupied_duration = 2 hours
-        # - prior = 2h / 8h = 0.25
-        assert area.prior.global_prior == 0.25
+        # - period_start = max(lookback_start, first_seen) = first_seen (now - 32h)
+        # - period_end = now (quiet tail stays in the denominator, #483)
+        # - observation_span = 32 hours
+        # - occupied_duration = 4 hours
+        # - prior = 4h / 32h = 0.125
+        assert area.prior.global_prior == pytest.approx(0.125)
 
     def test_quiet_tail_included_in_denominator(
         self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
@@ -245,20 +361,26 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         Regression test: the period previously ended at last_interval_end
         whenever the area had been quiet for >1h, which dropped the
         known-unoccupied tail from the denominator and inflated the prior
-        on every overnight recalculation.
+        on every overnight recalculation. The observation span here (30h)
+        also clears the #520 warm-up-guard minimum (25h).
         """
         area_name = coordinator.get_area_names()[0]
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # 6 hours occupied, ending 18 hours ago (e.g. overnight quiet period)
+        # 6 hours occupied, ending 24 hours ago (long overnight quiet tail);
+        # sensor first seen 30 hours ago.
         now = freeze_time
-        occupied_start = now - timedelta(hours=24)
-        occupied_end = now - timedelta(hours=18)
+        first_seen = now - timedelta(hours=30)
+        occupied_start = now - timedelta(hours=30)
+        occupied_end = now - timedelta(hours=24)
         intervals = [(occupied_start, occupied_end)]
 
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now,
@@ -266,8 +388,8 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         ):
             analyzer.calculate_and_update_prior()
 
-        # prior = 6h occupied / 24h period = 0.25, NOT 6h / 6h = 0.99
-        assert area.prior.global_prior == 0.25
+        # prior = 6h occupied / 30h period = 0.2, NOT 6h / 6h = 0.99
+        assert area.prior.global_prior == pytest.approx(0.2)
 
     def test_prior_bounds_clamping_min(
         self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
@@ -277,7 +399,7 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Create intervals: very small occupancy (1 minute) in large period (100 hours)
+        # Create intervals: very small occupancy (1 minute) in large period (50 hours)
         now = freeze_time
         occupied_start = now - timedelta(hours=50)
         occupied_end = now - timedelta(hours=50, minutes=1)
@@ -285,6 +407,11 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
 
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db,
+                "get_first_interval_timestamp",
+                return_value=occupied_start,
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now,
@@ -303,8 +430,10 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Create intervals with one invalid interval (start > end)
+        # Create intervals with one invalid interval (start > end). First
+        # seen 26h ago to clear the #520 warm-up-guard minimum (25h).
         now = freeze_time
+        first_seen = now - timedelta(hours=26)
         valid_start = now - timedelta(hours=2)
         valid_end = now - timedelta(hours=1)
         invalid_start = now - timedelta(hours=1)
@@ -315,7 +444,16 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
             (invalid_start, invalid_end),  # Invalid interval (start > end)
         ]
 
-        with patch.object(analyzer, "get_occupied_intervals", return_value=intervals):
+        with (
+            patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
+                return_value=now,
+            ),
+        ):
             analyzer.calculate_and_update_prior()
 
         # Should filter out invalid interval and calculate based on valid one
@@ -331,45 +469,55 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Create only invalid intervals (start > end)
+        # Create only invalid intervals (start > end). First seen 30h ago
+        # to clear the #520 warm-up-guard minimum (25h).
         now = freeze_time
+        first_seen = now - timedelta(hours=30)
         invalid_intervals = [
             (now - timedelta(hours=1), now - timedelta(hours=2)),  # start > end
             (now - timedelta(hours=3), now - timedelta(hours=4)),  # start > end
         ]
 
-        with patch.object(
-            analyzer, "get_occupied_intervals", return_value=invalid_intervals
+        with (
+            patch.object(
+                analyzer, "get_occupied_intervals", return_value=invalid_intervals
+            ),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
+            patch(
+                "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
+                return_value=now,
+            ),
         ):
             analyzer.calculate_and_update_prior()
 
-        # Should use fallback prior of 0.01
+        # All intervals filtered out -> zero occupied duration -> fallback 0.01
         assert area.prior.global_prior == 0.01
 
     def test_period_end_before_first_interval_start_uses_now(
         self, coordinator: AreaOccupancyCoordinator, freeze_time: datetime
     ) -> None:
-        """Test that when actual_period_end < first_interval_start, 'now' is used instead."""
+        """Test normal calculation with multiple valid intervals."""
         area_name = coordinator.get_area_names()[0]
         area = coordinator.get_area(area_name)
         analyzer = PriorAnalyzer(coordinator, area_name)
 
-        # Create intervals where last_interval_end would be before first_interval_start
-        # This can happen with timezone issues
+        # Create valid intervals; first seen 30h ago to clear the #520
+        # warm-up-guard minimum (25h).
         now = freeze_time
-        # Create valid intervals
+        first_seen = now - timedelta(hours=30)
         start1 = now - timedelta(hours=8)
         end1 = now - timedelta(hours=7)
         start2 = now - timedelta(hours=6)
         end2 = now - timedelta(hours=5)
         intervals = [(start1, end1), (start2, end2)]
 
-        # Mock dt_util.utcnow to return a time that would make last_interval_end
-        # appear before first_interval_start (simulating timezone issue)
-        # Actually, with valid intervals, this shouldn't happen unless there's
-        # a timezone conversion issue. Let's test the defensive check instead.
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now,
@@ -395,6 +543,7 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         est = tz(timedelta(hours=-5))
         now_utc = freeze_time
         now_est = now_utc.astimezone(est)
+        first_seen = now_utc - timedelta(hours=26)
 
         # Create intervals in EST
         start_est = (now_est - timedelta(hours=2)).replace(tzinfo=est)
@@ -403,6 +552,9 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
 
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now_utc,
@@ -431,6 +583,9 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
 
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=start
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now,
@@ -469,11 +624,15 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         analyzer = PriorAnalyzer(coordinator, area_name)
 
         now = freeze_time
+        first_seen = now - timedelta(hours=30)
         start = now - timedelta(hours=10)
         intervals = [(start, now - timedelta(hours=8))]
 
         with (
             patch.object(analyzer, "get_occupied_intervals", return_value=intervals),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
+            ),
             patch(
                 "custom_components.area_occupancy.data.analysis.dt_util.utcnow",
                 return_value=now,
@@ -517,11 +676,18 @@ class TestPriorAnalyzerCalculateAndUpdatePrior:
         """Test that errors during calculation are logged but don't crash."""
         area_name = coordinator.get_area_names()[0]
         analyzer = PriorAnalyzer(coordinator, area_name)
+        now = dt_util.utcnow()
+        first_seen = now - timedelta(hours=30)
 
-        # Cause an error by making get_occupied_intervals raise ValueError
+        # Cause an error by making get_occupied_intervals raise ValueError.
+        # first_seen must clear the warm-up guard so execution actually
+        # reaches the get_occupied_intervals call.
         with (
             patch.object(
                 analyzer, "get_occupied_intervals", side_effect=ValueError("Test error")
+            ),
+            patch.object(
+                analyzer.db, "get_first_interval_timestamp", return_value=first_seen
             ),
             patch(
                 "custom_components.area_occupancy.data.analysis._LOGGER"

--- a/tests/test_data_health.py
+++ b/tests/test_data_health.py
@@ -905,6 +905,67 @@ class TestPipelineHealth:
             )
         assert issues == []
 
+    def test_stale_prior_recalculation_flagged(self, monitor: HealthMonitor) -> None:
+        """A prior that stopped recalculating is flagged even though it exists.
+
+        Regression test for #520 Bug A (the silent freeze): before the fix,
+        ``has_global_prior=True`` alone meant this check never fired again,
+        no matter how long recalculation had actually stopped. 30h since
+        the last successful calculation clears the 25h staleness threshold
+        (``PRIOR_RECALCULATION_STALE_THRESHOLD``, mirrors
+        ``STALE_CACHE_THRESHOLD``).
+        """
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_pipeline_health(
+                area_age_hours=24 * 30,
+                has_global_prior=True,
+                cache_age_hours=1.0,
+                last_analysis_duration_ms=None,
+                correlation_failure_count=0,
+                correlatable_entity_count=0,
+                last_prior_calculation_hours_ago=30.0,
+            )
+        assert len(issues) == 1
+        assert issues[0].issue_type == HealthIssueType.INSUFFICIENT_PRIORS
+        assert "recalculated" in issues[0].details
+
+    def test_recent_prior_recalculation_not_flagged(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """A prior recalculated within the staleness threshold is not flagged."""
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_pipeline_health(
+                area_age_hours=24 * 30,
+                has_global_prior=True,
+                cache_age_hours=1.0,
+                last_analysis_duration_ms=None,
+                correlation_failure_count=0,
+                correlatable_entity_count=0,
+                last_prior_calculation_hours_ago=2.0,
+            )
+        assert issues == []
+
+    def test_stale_prior_recalculation_unknown_recency_not_flagged(
+        self, monitor: HealthMonitor
+    ) -> None:
+        """A prior with no calculation timestamp (legacy data) is not flagged.
+
+        We can't tell how stale it is, so this deliberately doesn't fire —
+        matches the existing has_global_prior=True/no-timestamp case that
+        predates #520.
+        """
+        with patch("custom_components.area_occupancy.data.health.ir"):
+            issues = monitor.check_pipeline_health(
+                area_age_hours=24 * 30,
+                has_global_prior=True,
+                cache_age_hours=1.0,
+                last_analysis_duration_ms=None,
+                correlation_failure_count=0,
+                correlatable_entity_count=0,
+                last_prior_calculation_hours_ago=None,
+            )
+        assert issues == []
+
     def test_stale_cache_above_threshold(self, monitor: HealthMonitor) -> None:
         """Cache older than threshold triggers stale_intervals_cache."""
         with patch("custom_components.area_occupancy.data.health.ir"):

--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -1,6 +1,6 @@
 """Tests for the Prior class (updated for improved implementation)."""
 
-from datetime import UTC
+from datetime import UTC, timedelta
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -367,8 +367,43 @@ def test_set_global_prior(coordinator: AreaOccupancyCoordinator):
         prior.set_global_prior(0.75)
         assert prior.global_prior == 0.75
         assert prior._last_updated == now
+        assert prior.last_calculation_at == now
         # Verify cache is invalidated
         assert prior._cached_time_priors is None
+
+
+def test_set_global_prior_explicit_calculation_date(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """An explicit calculation_date is used verbatim, not overridden by now."""
+    area_name = coordinator.get_area_names()[0]
+    prior = Prior(coordinator, area_name=area_name)
+    computed_at = dt_util.utcnow() - timedelta(hours=5)
+
+    prior.set_global_prior(0.6, calculation_date=computed_at)
+
+    assert prior.last_calculation_at == computed_at
+
+
+def test_set_global_prior_explicit_none_calculation_date_not_coerced_to_now(
+    coordinator: AreaOccupancyCoordinator,
+):
+    """A legacy row's calculation_date=None must stay None, not become now.
+
+    Regression test for a bug found during #520 review: set_global_prior()
+    used `calculation_date or now`, which silently turned an *explicit*
+    ``None`` (db/operations.py::load_data passing a legacy row's persisted
+    ``None`` calculation_date through) into "just calculated now" — making
+    the staleness check's documented legacy-data branch unreachable, since
+    a freshly-loaded legacy prior would look identical to a freshly
+    computed one.
+    """
+    area_name = coordinator.get_area_names()[0]
+    prior = Prior(coordinator, area_name=area_name)
+
+    prior.set_global_prior(0.6, calculation_date=None)
+
+    assert prior.last_calculation_at is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_data_prior.py
+++ b/tests/test_data_prior.py
@@ -364,6 +364,12 @@ def test_set_global_prior(coordinator: AreaOccupancyCoordinator):
     with patch(
         "custom_components.area_occupancy.data.prior.dt_util.utcnow", return_value=now
     ):
+        # Populate the time-prior cache via its public accessor so the
+        # assertion below proves set_global_prior actually invalidates it,
+        # rather than just confirming the cache was never populated.
+        _ = prior.time_prior
+        assert prior._cached_time_priors is not None
+
         prior.set_global_prior(0.75)
         assert prior.global_prior == 0.75
         assert prior._last_updated == now

--- a/tests/test_db_queries.py
+++ b/tests/test_db_queries.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -903,6 +904,56 @@ class TestGetGlobalPrior:
         db = coordinator.db
         result = get_global_prior(db, "nonexistent_area")
         assert result is None
+
+    def test_get_global_prior_null_calculation_date(
+        self, coordinator: AreaOccupancyCoordinator, monkeypatch
+    ):
+        """Legacy rows with no calculation_date must not crash get_global_prior.
+
+        calculation_date is NOT NULL in the current schema (verified: SQLite
+        rejects both an INSERT and an UPDATE that attempt to set it NULL, so
+        this can't be reproduced against a freshly created test DB). But
+        create_all(checkfirst=True) never alters already-existing tables
+        (see aod-change-control), so an install whose DB predates this
+        constraint could still carry a legacy NULL row -- simulate that by
+        stubbing the session's query result directly.
+        """
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+
+        legacy_row = SimpleNamespace(
+            prior_value=0.35,
+            calculation_date=None,
+            data_period_start=dt_util.utcnow() - timedelta(days=90),
+            data_period_end=dt_util.utcnow(),
+            total_occupied_seconds=86400.0,
+            total_period_seconds=7776000.0,
+            interval_count=100,
+            confidence=None,
+            calculation_method=None,
+        )
+
+        class _FakeQuery:
+            def filter_by(self, **kwargs):
+                return self
+
+            def first(self):
+                return legacy_row
+
+        class _FakeSession:
+            def query(self, *args, **kwargs):
+                return _FakeQuery()
+
+        @contextmanager
+        def fake_get_session():
+            yield _FakeSession()
+
+        monkeypatch.setattr(db, "get_session", fake_get_session)
+
+        result = get_global_prior(db, area_name)
+        assert result is not None
+        assert result["calculation_date"] is None
+        assert result["prior_value"] == 0.35
 
 
 class TestOccupiedIntervalsCache:

--- a/tests/test_db_queries.py
+++ b/tests/test_db_queries.py
@@ -20,6 +20,8 @@ from custom_components.area_occupancy.db.queries import (
     build_presence_query,
     get_all_time_priors,
     get_area_data,
+    get_entities_without_intervals,
+    get_first_interval_timestamp,
     get_global_prior,
     get_latest_interval,
     get_occupied_intervals,
@@ -640,6 +642,154 @@ class TestGetOccupiedIntervals:
         )
         # Should return empty list on error, not None
         assert result == []
+
+
+class TestGetFirstIntervalTimestamp:
+    """Test get_first_interval_timestamp (#520 Bug A/B support query)."""
+
+    def test_no_data_returns_none(self, coordinator: AreaOccupancyCoordinator):
+        """No interval rows at all for this area -> None (Bug A Case 1)."""
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+        result = get_first_interval_timestamp(db, db.coordinator.entry_id, area_name)
+        assert result is None
+
+    def test_returns_earliest_any_state_row(
+        self, coordinator: AreaOccupancyCoordinator
+    ):
+        """Returns the earliest interval regardless of state ("off" counts).
+
+        This is the key distinction from get_occupied_intervals, which only
+        looks at "on" rows -- an area can have data (this function returns
+        a timestamp) while having zero occupied time (get_occupied_intervals
+        returns []).
+        """
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+        db.save_area_data(area_name)
+
+        now = dt_util.utcnow()
+        earliest = now - timedelta(hours=48)
+        middle = now - timedelta(hours=24)
+
+        with db.get_session() as session:
+            _create_test_entity(
+                session, db, "binary_sensor.motion1", "motion", area_name
+            )
+            # Earliest row is "off" -- must still be found.
+            _create_test_interval(
+                session,
+                db,
+                "binary_sensor.motion1",
+                earliest,
+                earliest + timedelta(minutes=1),
+                area_name,
+                state="off",
+            )
+            _create_test_interval(
+                session,
+                db,
+                "binary_sensor.motion1",
+                middle,
+                middle + timedelta(minutes=1),
+                area_name,
+                state="on",
+            )
+            session.commit()
+
+        result = get_first_interval_timestamp(db, db.coordinator.entry_id, area_name)
+        assert result is not None
+        norm_result, norm_earliest = _normalize_datetime_for_comparison(
+            result, earliest
+        )
+        assert abs((norm_result - norm_earliest).total_seconds()) < 1
+
+    def test_ignores_other_entity_types(self, coordinator: AreaOccupancyCoordinator):
+        """A door/appliance-only interval history doesn't count as ground truth."""
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+        db.save_area_data(area_name)
+
+        now = dt_util.utcnow()
+        with db.get_session() as session:
+            _create_test_entity(session, db, "binary_sensor.door1", "door", area_name)
+            _create_test_interval(
+                session,
+                db,
+                "binary_sensor.door1",
+                now - timedelta(hours=1),
+                now,
+                area_name,
+                state="on",
+            )
+            session.commit()
+
+        result = get_first_interval_timestamp(db, db.coordinator.entry_id, area_name)
+        assert result is None
+
+    def test_error_returns_none(
+        self, coordinator: AreaOccupancyCoordinator, monkeypatch
+    ):
+        """Database error returns None rather than raising."""
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+
+        def bad_session():
+            raise SQLAlchemyError("Error")
+
+        monkeypatch.setattr(db, "get_session", bad_session)
+        result = get_first_interval_timestamp(db, db.coordinator.entry_id, area_name)
+        assert result is None
+
+
+class TestGetEntitiesWithoutIntervals:
+    """Test get_entities_without_intervals (#520 Fix 3 backfill support)."""
+
+    def test_empty_input_returns_empty_set(self, coordinator: AreaOccupancyCoordinator):
+        """Empty entity_ids list short-circuits to an empty set."""
+        db = coordinator.db
+        assert get_entities_without_intervals(db, []) == set()
+
+    def test_identifies_entities_with_no_rows(
+        self, coordinator: AreaOccupancyCoordinator
+    ):
+        """Entities with zero Intervals rows are returned; others are excluded."""
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+        db.save_area_data(area_name)
+
+        now = dt_util.utcnow()
+        with db.get_session() as session:
+            _create_test_entity(
+                session, db, "binary_sensor.motion1", "motion", area_name
+            )
+            _create_test_interval(
+                session,
+                db,
+                "binary_sensor.motion1",
+                now - timedelta(hours=1),
+                now,
+                area_name,
+            )
+            session.commit()
+
+        result = get_entities_without_intervals(
+            db, ["binary_sensor.motion1", "binary_sensor.motion2"]
+        )
+        assert result == {"binary_sensor.motion2"}
+
+    def test_error_returns_empty_set(
+        self, coordinator: AreaOccupancyCoordinator, monkeypatch
+    ):
+        """Database error returns an empty set rather than raising."""
+        db = coordinator.db
+
+        def bad_session():
+            raise SQLAlchemyError("Error")
+
+        monkeypatch.setattr(db, "get_session", bad_session)
+        result = get_entities_without_intervals(db, ["binary_sensor.motion1"])
+        assert result == set()
 
 
 class TestBuildFilters:

--- a/tests/test_db_sync.py
+++ b/tests/test_db_sync.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 import logging
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -474,6 +475,188 @@ class TestSyncStates:
                 .all()
             )
             assert len(intervals) == 1
+
+    @pytest.mark.asyncio
+    async def test_sync_states_backfills_newly_tracked_entity(
+        self, coordinator: AreaOccupancyCoordinator, monkeypatch
+    ):
+        """A brand-new entity (no Intervals rows yet) gets a history backfill.
+
+        Regression test for #520 Bug A path 1: previously a newly
+        (re)configured motion/sleep/media sensor only accumulated data
+        forward from the shared sync watermark, leaving it with an empty
+        occupied-interval history (and thus a frozen/skipped prior) until
+        it happened to trigger again. ``sync_states`` must now pull
+        available recorder history for entities with zero existing rows.
+        """
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+
+        # Restrict tracked entities to just our target so the call-count
+        # assertion isn't affected by other fixture-configured sensors that
+        # also happen to have zero interval rows.
+        for name in db.coordinator.get_area_names():
+            a = db.coordinator.get_area(name)
+            if a:
+                a.entities.entities.clear()
+
+        db.save_area_data(area_name)
+        with db.get_session() as session:
+            entity = db.Entities(
+                entity_id="binary_sensor.motion",
+                entry_id=db.coordinator.entry_id,
+                area_name=area_name,
+                entity_type="motion",
+            )
+            session.add(entity)
+            session.commit()
+
+        area = db.coordinator.get_area(area_name)
+        motion_entity = SimpleNamespace(
+            entity_id="binary_sensor.motion",
+            type=SimpleNamespace(input_type=InputType.MOTION),
+        )
+        area.entities.add_entity(motion_entity)
+
+        now = dt_util.utcnow()
+        watermark_start = now - timedelta(hours=1)
+        # Forward (main-watermark) window has no new activity.
+        forward_state = State("binary_sensor.motion", "off", last_changed=now)
+        # Backfill window (older than the watermark) has an old occupied
+        # interval that should now be pulled in. Includes both the "on"
+        # and the following "off" transition so the resulting interval is
+        # short (a single unclosed "on" spanning all the way to the
+        # forward state, ~3 days later, would exceed MAX_INTERVAL_SECONDS
+        # and get filtered out by _states_to_intervals — not what this
+        # test is checking).
+        backfill_on_time = now - timedelta(days=3)
+        backfill_off_time = backfill_on_time + timedelta(minutes=5)
+        backfill_states = [
+            State("binary_sensor.motion", "on", last_changed=backfill_on_time),
+            State("binary_sensor.motion", "off", last_changed=backfill_off_time),
+        ]
+
+        call_windows: list[tuple[Any, Any]] = []
+
+        def mock_get_significant_states(hass, start_time, end_time, entity_ids, **kw):
+            call_windows.append((start_time, end_time))
+            if start_time < watermark_start:
+                # Backfill call.
+                return {"binary_sensor.motion": backfill_states}
+            return {"binary_sensor.motion": [forward_state]}
+
+        monkeypatch.setattr(
+            "custom_components.area_occupancy.db.sync.get_significant_states",
+            mock_get_significant_states,
+        )
+        monkeypatch.setattr(
+            "custom_components.area_occupancy.db.sync.queries.get_latest_interval",
+            lambda db_instance: watermark_start,
+        )
+
+        mock_recorder = Mock()
+        mock_recorder.async_add_executor_job = AsyncMock(
+            side_effect=lambda func: func()
+        )
+        monkeypatch.setattr(
+            "custom_components.area_occupancy.db.sync.get_instance",
+            lambda hass: mock_recorder,
+        )
+
+        await sync_states(db)
+
+        # Both the forward and the backfill query should have run.
+        assert len(call_windows) == 2
+
+        with db.get_session() as session:
+            intervals = (
+                session.query(db.Intervals)
+                .filter_by(entity_id="binary_sensor.motion")
+                .all()
+            )
+        # Backfilled "on" interval must be present in addition to the
+        # forward "off" interval.
+        states_found = {interval.state for interval in intervals}
+        assert "on" in states_found
+
+    @pytest.mark.asyncio
+    async def test_sync_states_skips_backfill_for_known_entity(
+        self, coordinator: AreaOccupancyCoordinator, monkeypatch
+    ):
+        """An entity with existing interval history is not backfilled again."""
+        db = coordinator.db
+        area_name = db.coordinator.get_area_names()[0]
+
+        # Restrict tracked entities to just our target so the assertion on
+        # call count isn't affected by other fixture-configured sensors
+        # that also happen to have zero interval rows.
+        for name in db.coordinator.get_area_names():
+            a = db.coordinator.get_area(name)
+            if a:
+                a.entities.entities.clear()
+
+        db.save_area_data(area_name)
+        now = dt_util.utcnow()
+        with db.get_session() as session:
+            entity = db.Entities(
+                entity_id="binary_sensor.motion",
+                entry_id=db.coordinator.entry_id,
+                area_name=area_name,
+                entity_type="motion",
+            )
+            session.add(entity)
+            interval = db.Intervals(
+                entry_id=db.coordinator.entry_id,
+                area_name=area_name,
+                entity_id="binary_sensor.motion",
+                state="on",
+                start_time=now - timedelta(days=1),
+                end_time=now - timedelta(hours=23),
+                duration_seconds=3600.0,
+                aggregation_level="raw",
+            )
+            session.add(interval)
+            session.commit()
+
+        area = db.coordinator.get_area(area_name)
+        motion_entity = SimpleNamespace(
+            entity_id="binary_sensor.motion",
+            type=SimpleNamespace(input_type=InputType.MOTION),
+        )
+        area.entities.add_entity(motion_entity)
+
+        call_windows: list[tuple[Any, Any]] = []
+
+        def mock_get_significant_states(hass, start_time, end_time, entity_ids, **kw):
+            call_windows.append((start_time, end_time))
+            return {
+                "binary_sensor.motion": [
+                    State("binary_sensor.motion", "off", last_changed=now)
+                ]
+            }
+
+        monkeypatch.setattr(
+            "custom_components.area_occupancy.db.sync.get_significant_states",
+            mock_get_significant_states,
+        )
+        monkeypatch.setattr(
+            "custom_components.area_occupancy.db.sync.queries.get_latest_interval",
+            lambda db_instance: now - timedelta(hours=1),
+        )
+
+        mock_recorder = Mock()
+        mock_recorder.async_add_executor_job = AsyncMock(
+            side_effect=lambda func: func()
+        )
+        monkeypatch.setattr(
+            "custom_components.area_occupancy.db.sync.get_instance",
+            lambda hass: mock_recorder,
+        )
+
+        await sync_states(db)
+
+        # Only the forward sync call, no backfill call.
+        assert len(call_windows) == 1
 
     @pytest.mark.asyncio
     async def test_sync_states_handles_empty_entity_ids(


### PR DESCRIPTION
Closes #520.

## Summary

Fixes two distinct root causes behind the "global prior stuck" reports in #520, both in `PriorAnalyzer.calculate_and_update_prior()` (`data/analysis.py`), plus a contributing cause and one remaining item deliberately deferred.

- **Fix 1 — stop the silent freeze (Bug A).** The old code did `_LOGGER.debug(...); return` whenever the occupied-intervals query came back empty, leaving `global_prior` frozen at whatever it last was, forever, with zero trace. Now distinguishes two situations using a new `db.get_first_interval_timestamp()` (any-state, not just "on" — for the area's current motion/sleep/media sensors):
  - **No data at all** for the current sensor configuration → logs at **WARNING** (not DEBUG), leaves `global_prior` untouched *and* does not advance `Prior.last_calculation_at`.
  - **Data exists but zero occupied time** → this is a real, valid signal; the prior is computed normally through the standard ratio (naturally landing near `MIN_PRIOR`), not special-cased.
- **Fix 2 — warm-up guard against the 0.99 clamp (Bug B).** The denominator used to be "now − first *occupied* interval's start". A single occupied interval minutes after a reset/swap computed `occupied/elapsed ≈ 1.0`, clamped straight to `MAX_PRIOR`. The denominator basis is now `max(configured_lookback_start, earliest any-state data point for current sensors)`, with an explicit minimum-span guard (`PRIOR_WARMUP_MIN_SPAN_HOURS = 25`, matching `STALE_CACHE_THRESHOLD`'s existing 25h precedent) below which the update defers entirely and falls back to the existing `Prior.value` mechanism (`MIN_PRIOR` + any purpose floor) rather than trusting a noisy one-sample ratio.
- **Fix 1 wiring — staleness surfaced via the existing pipeline-health mechanism.** Rather than inventing a new issue type, extended `HealthMonitor._check_insufficient_priors` (already generic, pipeline-scope, per-area) to also fire when a prior *exists* but hasn't been recalculated in `PRIOR_RECALCULATION_STALE_THRESHOLD` (also 25h, aliased to `STALE_CACHE_THRESHOLD` since both are driven by the same hourly-recompute cadence over the same data). This is what makes a frozen-but-non-None `global_prior` visible, which `has_global_prior` alone could never catch.
- **Fix 3 — sensor-swap backfill (contributing cause, Bug A path 1).** `sync_states` used a single global forward-only watermark, so a newly-configured motion/sleep/media sensor had empty ground truth until it happened to fire again. Investigated stopping `_cleanup_area_orphans`'s interval deletion, but found a **second, independent** cleanup path (`load_data`'s `_read_data_operation`/`_delete_stale_operation`) that also deletes the `Entities` row for anything not in current config on every load — deletion-prevention would need coordinated changes across two DB-layer code paths with real risk of missing an invariant. Chose the additive alternative instead: `sync_states` now detects entities with zero existing `Intervals` rows (`db.get_entities_without_intervals`) and backfills them from recorder history bounded by `HA_RECORDER_DAYS`.
- **Fix 4 — dead `OccupiedIntervalsCache` — deferred as a documented follow-up.** Confirmed it has zero read-path consumers anywhere in the codebase. Left the table and its population step in place (per the "leave the table but stop maintaining code that populates and never reads it" guidance) — this is a separate decision (wire it in as a real fast-path/cross-check, or remove it) that shouldn't be bundled into a fix for live-math bugs. Documented explicitly in `ensure_occupied_intervals_cache`'s docstring.

## Predicted-vs-actual validation (Law 1)

Per this repo's convention for math-affecting PRs (see #491/#493), predicted numbers before running anything:

**(a) Freshly-reset area, 2h of data, one 10-minute occupied interval (the exact #520 Bug B shape):**
- First-seen timestamp = 10 minutes ago (single interval, no prior history).
- Observation span = 10 minutes = 600s, far below the 25h (90,000s) warm-up minimum.
- **Predicted**: update deferred entirely; `global_prior` stays at whatever it was (`None` on a fresh area) rather than computing `≈0.98–1.0` and clamping to 0.99.
- **Actual** (`test_warmup_guard_defers_instead_of_clamping_to_max`): `global_prior != 0.99` and unchanged from before the call. ✅ Matches prediction — this is the direct regression test for Bug B.

**(b) Full week of realistic data with long genuinely-quiet stretches (confirm #483 isn't reintroduced):**
- `test_quiet_tail_included_in_denominator`: sensor first-seen 30h ago, 6h occupied ending 24h ago (long quiet tail after the last occupied interval).
- **Predicted by hand**: `period_end` is unconditionally `now` (never truncated at `last_interval_end` — the #483 bug is structurally gone now since the code no longer even computes `last_interval_end` at all). `period_start = max(lookback_start≈60d ago, first_seen=30h ago) = 30h ago`. `prior = 6h / 30h = 0.2`.
- **Actual**: `area.prior.global_prior == pytest.approx(0.2)`. ✅ Matches prediction — quiet tail correctly stays in the denominator, confirming #483 is not reintroduced.

**(c) Normal case (`test_valid_calculation_sets_correct_prior`)**: first-seen 32h ago, 4h occupied. Predicted `4/32 = 0.125`. Actual: `0.125`. ✅

**(d) Data exists, zero occupied (`test_data_exists_zero_occupied_computes_low_prior`)**: first-seen 48h ago, `get_occupied_intervals` returns `[]`. Predicted: `occupied_duration=0`, span=48h (clears warm-up), `0/48h` clamps to `MIN_PRIOR=0.01`, and (unlike the "no data at all" case) `last_calculation_at` **is** advanced since this was a real calculation. Actual: `global_prior == 0.01`, `last_calculation_at is not None`. ✅

**(e) No data at all (`test_no_data_at_all_logs_warning_and_preserves_prior`)**: `get_first_interval_timestamp` returns `None`. Predicted: prior value AND `last_calculation_at` both untouched, WARNING logged containing "no interval data". Actual: matches exactly. ✅

## Test results

- New/updated regression tests: 14 net-new tests (baseline 1816 → 1830 passing on `next`), zero failures.
- `uv run pytest -q`: **1830 passed**.
- `uv run ruff format .` / `uv run ruff check .`: clean.
- Existing `test_quiet_tail_included_in_denominator` (#483 regression) still passes — updated numbers (30h/6h → 0.2 instead of the old 24h/6h → 0.25) only because the scenario needed to also clear the *new* 25h warm-up minimum; the underlying assertion (quiet tail stays in the denominator, prior is NOT ≈0.99) is unchanged in spirit.

## Judgment calls / risks for the maintainer to scrutinize

1. **`PRIOR_WARMUP_MIN_SPAN_HOURS = 25`** — chosen to mirror `STALE_CACHE_THRESHOLD` (both describe "one day plus buffer for a missed hourly cycle" over data fed by the same pipeline), not derived from real-world tuning data. A shorter warm-up means new/reset areas trust a possibly-noisier prior sooner; a longer one means they sit at `MIN_PRIOR` longer after every reset. This is the single most consequential number in the PR.
2. **Fix 3 (backfill vs. deletion-prevention)** — I chose backfill after finding a second independent deletion path; a maintainer who knows the historical intent behind `_cleanup_area_orphans` better than I could infer from code/git-blame alone may have a different read on whether preserving history was in fact safe.
3. **Every existing area's prior-calculation behavior changes**, not just new/reset ones — the denominator basis change (Fix 2) and the staleness health check (Fix 1) apply unconditionally on the next hourly cycle for every area. Areas with long-established sensors and no swap/reset history should see no numeric change (their `first_seen` predates the lookback window either way), but this is worth a maintainer's own sanity check against a real household DB if one is available before merge.
4. **Fix 4 left undecided** — flagging explicitly per the task's own escape hatch rather than forcing a decision in this PR.

No `CONF_VERSION` bump; no destructive DB schema change. All changes are additive (new query functions, new constants, extended method signatures with backward-compatible defaults where existing call sites needed it).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically backfills historical recorder data for newly tracked entities.
  * Improves global occupancy prior calculation using broader observation history.
  * Adds a 25-hour warm-up period before new priors are trusted.
  * Applies bounds to calculated prior values.

* **Bug Fixes**
  * Detects stale or missing priors and reports pipeline health issues.
  * Handles missing, invalid, and incomplete interval data more reliably.
  * Preserves prior calculation timestamps across reloads.
  * Improves handling of entities without interval history and legacy prior data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->