### PR TITLE
fix(shadow-mode): correct 4 real bugs in trust-score/online-prior estimators

### DIFF
--- a/custom_components/area_occupancy/__init__.py
+++ b/custom_components/area_occupancy/__init__.py
@@ -22,7 +22,16 @@ from homeassistant.helpers import (
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_AREA_ID, CONF_AREAS, CONF_VERSION, DB_NAME, DOMAIN, PLATFORMS
+from .const import (
+    CONF_AREA_ID,
+    CONF_AREAS,
+    CONF_VERSION,
+    DB_NAME,
+    DOMAIN,
+    ONLINE_PRIOR_STORE_KEY_PREFIX,
+    ONLINE_PRIOR_STORE_VERSION,
+    PLATFORMS,
+)
 from .coordinator import AreaOccupancyCoordinator
 from .db.operations import delete_area_data as _delete_area_data
 from .db.schema import (
@@ -411,7 +420,9 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         # files, so a stale one would otherwise survive removal forever.
         try:
             await Store(
-                hass, 1, f"{DOMAIN}.online_prior.{entry.entry_id}"
+                hass,
+                ONLINE_PRIOR_STORE_VERSION,
+                f"{ONLINE_PRIOR_STORE_KEY_PREFIX}.{entry.entry_id}",
             ).async_remove()
         except Exception:
             _LOGGER.exception(

--- a/custom_components/area_occupancy/__init__.py
+++ b/custom_components/area_occupancy/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
 )
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_AREA_ID, CONF_AREAS, CONF_VERSION, DB_NAME, DOMAIN, PLATFORMS
@@ -404,6 +405,19 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
                     "Failed to purge learned history during entry removal %s",
                     entry.entry_id,
                 )
+
+        # Drop the shadow-mode online-prior Store (#500) — it's keyed by
+        # entry_id and DB purging above doesn't touch HA's storage helper
+        # files, so a stale one would otherwise survive removal forever.
+        try:
+            await Store(
+                hass, 1, f"{DOMAIN}.online_prior.{entry.entry_id}"
+            ).async_remove()
+        except Exception:
+            _LOGGER.exception(
+                "Failed to remove online-prior storage during entry removal %s",
+                entry.entry_id,
+            )
 
         # When no other entries remain, drop the whole database so a re-install
         # starts clean.

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -309,6 +309,13 @@ ACCURACY_TICK_BUFFER_MAXLEN: Final = 8640
 # Hours of tick history scored against ground truth each analysis cycle.
 ACCURACY_WINDOW_HOURS: Final = 24
 
+# --- Online prior (#500, shadow mode) ---
+# Store version and key prefix for the per-entry online-prior estimator
+# state. Shared between the coordinator (persistence) and __init__.py
+# (removal cleanup) so the two never drift apart.
+ONLINE_PRIOR_STORE_VERSION: Final = 1
+ONLINE_PRIOR_STORE_KEY_PREFIX: Final = f"{DOMAIN}.online_prior"
+
 MIN_CORRELATION_SAMPLES: Final = 50
 # Minimum confidence for correlation to be considered significant
 CORRELATION_CONFIDENCE_THRESHOLD: Final = 0.7

--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -300,7 +300,11 @@ AGGREGATION_LEVEL_RAW: Final = "raw"
 # Correlation analysis constants
 # Minimum samples needed for reliable correlation
 # --- Trust score (#499, shadow mode) ---
-# Rolling tick-buffer depth per area: ~24h at the 10s decay cadence.
+# Rolling tick-buffer depth per area: 8640 = ~24h *if* ticks landed
+# exactly on the 10s decay cadence. In practice evidence-triggered
+# refreshes add extra ticks between decay ticks, so busy areas cover
+# less than 24h of wall-clock time; see metrics.py's time-weighting for
+# why that no longer biases the accuracy stats computed from it.
 ACCURACY_TICK_BUFFER_MAXLEN: Final = 8640
 # Hours of tick history scored against ground truth each analysis cycle.
 ACCURACY_WINDOW_HOURS: Final = 24

--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -600,18 +600,7 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 is_occupied=is_occupied,
                 now=now,
             )
-            self._accuracy_ticks.setdefault(
-                area_name, deque(maxlen=ACCURACY_TICK_BUFFER_MAXLEN)
-            ).append(
-                TickSample(timestamp=now, probability=probability, occupied=is_occupied)
-            )
-            motion_active = any(
-                entity.evidence and entity.type.input_type == InputType.MOTION
-                for entity in area.entities.entities.values()
-            )
-            self._online_priors.setdefault(area_name, OnlinePriorEstimator()).observe(
-                motion_active=motion_active, now=now
-            )
+            self._record_shadow_tick(area_name, area, now, probability, is_occupied)
             result[area_name] = {
                 "probability": probability,
                 "occupied": is_occupied,
@@ -621,6 +610,41 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "last_updated": now,
             }
         return result
+
+    def _record_shadow_tick(
+        self,
+        area_name: str,
+        area: Area,
+        now: datetime,
+        probability: float,
+        is_occupied: bool,
+    ) -> None:
+        """Record one shadow-mode accuracy/online-prior sample for an area.
+
+        Read-only: does not touch ``self.data`` or notify listeners, so
+        calling it outside a full ``update()`` (see
+        ``_handle_decay_timer``) has no effect on entity state or the
+        production refresh cadence.
+        """
+        self._accuracy_ticks.setdefault(
+            area_name, deque(maxlen=ACCURACY_TICK_BUFFER_MAXLEN)
+        ).append(
+            TickSample(timestamp=now, probability=probability, occupied=is_occupied)
+        )
+        # Match db.queries.get_occupied_intervals' ground-truth definition
+        # (motion ∪ media ∪ sleep) rather than motion alone, so the online
+        # numerator and the DB-computed prior it's being diffed against
+        # measure the same thing. Motion's timeout extension isn't
+        # replicated here — see module docstring's known approximations.
+        presence_active = any(
+            entity.evidence
+            and entity.type.input_type
+            in (InputType.MOTION, InputType.MEDIA, InputType.SLEEP)
+            for entity in area.entities.entities.values()
+        )
+        self._online_priors.setdefault(area_name, OnlinePriorEstimator()).observe(
+            motion_active=presence_active, now=now
+        )
 
     # --- Adjacent-areas (Phase 4) accessors ---
     @property
@@ -786,6 +810,20 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except (HomeAssistantError, OSError, RuntimeError) as err:
             _LOGGER.error(
                 "Failed final save for areas: %s: %s",
+                format_area_names(self),
+                err,
+            )
+
+        # Step 2b: Persist online-prior shadow state so a restart doesn't
+        # silently drop the occupied-seconds numerator while the period
+        # denominator (anchored at first_observation) keeps growing —
+        # previously this was only saved once per hour by the analysis
+        # pipeline, biasing the online prior low across every restart.
+        try:
+            await self.async_save_online_priors()
+        except (HomeAssistantError, OSError, RuntimeError) as err:
+            _LOGGER.warning(
+                "Failed to save online-prior shadow state for areas: %s: %s",
                 format_area_names(self),
                 err,
             )
@@ -1353,6 +1391,20 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         decay_enabled = any(area.config.decay.enabled for area in self.areas.values())
         if decay_enabled:
             await self.async_refresh()
+        else:
+            # Shadow-mode estimators (#499/#500) still need a steady tick
+            # cadence even when no area has decay enabled — without this,
+            # they'd only observe on evidence-triggered refreshes, whose
+            # gaps routinely exceed the online-prior's downtime threshold
+            # and starve its occupied-seconds numerator. Record ticks
+            # directly rather than going through ``async_refresh()`` so
+            # this doesn't change entity refresh cadence for users who
+            # disabled decay to reduce state churn.
+            now = dt_util.utcnow()
+            for area_name, area in self.areas.items():
+                probability = area.probability()
+                is_occupied = probability >= area.threshold()
+                self._record_shadow_tick(area_name, area, now, probability, is_occupied)
 
         # Reschedule the timer — but not if shutdown was signalled
         # during ``async_refresh``. Same rearm-leak avoidance as the

--- a/custom_components/area_occupancy/coordinator.py
+++ b/custom_components/area_occupancy/coordinator.py
@@ -37,6 +37,8 @@ from .const import (
     CONF_AREAS,
     DEFAULT_NAME,
     DOMAIN,
+    ONLINE_PRIOR_STORE_KEY_PREFIX,
+    ONLINE_PRIOR_STORE_VERSION,
     SAVE_INTERVAL,
 )
 from .data.adjacency import (
@@ -139,7 +141,9 @@ class AreaOccupancyCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # prior each analysis cycle. Never read by the probability path.
         self._online_priors: dict[str, OnlinePriorEstimator] = {}
         self._online_prior_store: Store[dict[str, dict]] = Store(
-            hass, 1, f"{DOMAIN}.online_prior.{self.entry_id}"
+            hass,
+            ONLINE_PRIOR_STORE_VERSION,
+            f"{ONLINE_PRIOR_STORE_KEY_PREFIX}.{self.entry_id}",
         )
 
     async def async_init_database(self) -> None:

--- a/custom_components/area_occupancy/data/metrics.py
+++ b/custom_components/area_occupancy/data/metrics.py
@@ -3,7 +3,10 @@
 Pure math over two inputs the coordinator already produces:
 
 * **Tick samples** — the per-refresh ``(timestamp, probability, occupied)``
-  triples the coordinator records for each area (10s decay-timer cadence).
+  triples the coordinator records for each area, at roughly the 10s
+  decay-timer cadence plus extra ticks on evidence-triggered refreshes.
+  Every metric below is time-weighted (see ``_tick_weights``) so that
+  irregular cadence doesn't bias the result.
 * **Occupied intervals** — the motion-confirmed ground truth the prior
   learning already uses (``db.get_occupied_intervals``).
 
@@ -65,7 +68,7 @@ class AccuracyMetrics:
     # Calibration
     expected_calibration_error: float | None = None
     bins: list[CalibrationBin] = field(default_factory=list)
-    # Decision stability (sample-weighted at the fixed tick cadence)
+    # Decision stability (time-weighted — see _tick_weights)
     decision_transitions: int = 0
     truth_transitions: int = 0
     false_on_rate: float | None = None  # P(decision on | truth off)
@@ -82,6 +85,36 @@ def _is_occupied_at(ts: datetime, intervals: list[tuple[datetime, datetime]]) ->
     return any(start <= ts < end for start, end in intervals)
 
 
+def _tick_weights(samples: list[TickSample]) -> list[float]:
+    """Return each sample's duration weight (seconds it represents).
+
+    Ticks do not land at a fixed cadence — the coordinator also ticks on
+    every evidence-triggered refresh, on top of the decay timer — so a
+    busy period (frequent evidence changes) contributes disproportionately
+    many samples relative to the wall-clock time it spans. Weighting each
+    sample by the gap to the next tick (piecewise-constant, matching
+    ``OnlinePriorEstimator.observe``'s assumption) makes every metric
+    below a time-weighted average instead of a sample-weighted one.
+
+    The last sample has no "next tick" to measure a gap to; it reuses the
+    preceding gap as an estimate. Out-of-order or duplicate timestamps
+    clamp to a zero gap. If every gap is zero (e.g. a single sample, or
+    all samples share one timestamp), falls back to uniform weight-1 per
+    sample so callers never divide by zero.
+    """
+    n = len(samples)
+    if n == 1:
+        return [1.0]
+    weights = [0.0] * n
+    for i in range(n - 1):
+        gap = (samples[i + 1].timestamp - samples[i].timestamp).total_seconds()
+        weights[i] = max(gap, 0.0)
+    weights[-1] = weights[-2]
+    if not any(weights):
+        return [1.0] * n
+    return weights
+
+
 def compute_accuracy_metrics(
     samples: list[TickSample],
     occupied_intervals: list[tuple[datetime, datetime]],
@@ -94,7 +127,9 @@ def compute_accuracy_metrics(
         samples: Tick observations ordered oldest-first. Samples outside
             the intervals' coverage are still scored (truth = not
             occupied), matching how the prior denominator treats
-            quiet time (#483 lesson: unobserved-quiet counts).
+            quiet time (#483 lesson: unobserved-quiet counts). Every
+            metric is time-weighted (see ``_tick_weights``), not
+            sample-weighted, since ticks land at an irregular cadence.
         occupied_intervals: Motion-confirmed ``(start, end)`` ground
             truth, same source the prior learning uses.
         bins: Number of equal-width probability bands for calibration.
@@ -111,36 +146,47 @@ def compute_accuracy_metrics(
     out.window_start = samples[0].timestamp
     out.window_end = samples[-1].timestamp
 
-    bin_count = [0] * bins
-    bin_prob_sum = [0.0] * bins
-    bin_hits = [0] * bins
+    weights = _tick_weights(samples)
+    total_weight = sum(weights)
 
-    true_on = true_off = false_on = false_off = 0
+    bin_count = [0] * bins
+    bin_weight = [0.0] * bins
+    bin_prob_weight_sum = [0.0] * bins
+    bin_hit_weight = [0.0] * bins
+
+    true_on = true_off = false_on = false_off = 0.0
     prev_decision: bool | None = None
     prev_truth: bool | None = None
 
-    for sample in samples:
+    for sample, weight in zip(samples, weights, strict=True):
         truth = _is_occupied_at(sample.timestamp, occupied_intervals)
 
-        # Calibration accumulation
+        # Calibration accumulation. ``bin_count`` stays a raw sample
+        # count for diagnostics readability; the reliability stats below
+        # (mean_probability, observed_rate, ECE) use the time-weighted
+        # sum so an evidence-triggered burst of ticks doesn't outweigh a
+        # single quiet-hour decay tick that spans the same wall-clock time.
         p = min(max(sample.probability, 0.0), 1.0)
         idx = min(int(p * bins), bins - 1)
         bin_count[idx] += 1
-        bin_prob_sum[idx] += p
+        bin_weight[idx] += weight
+        bin_prob_weight_sum[idx] += p * weight
         if truth:
-            bin_hits[idx] += 1
+            bin_hit_weight[idx] += weight
 
         # Confusion accumulation
         if sample.occupied and truth:
-            true_on += 1
+            true_on += weight
         elif sample.occupied and not truth:
-            false_on += 1
+            false_on += weight
         elif not sample.occupied and truth:
-            false_off += 1
+            false_off += weight
         else:
-            true_off += 1
+            true_off += weight
 
-        # Flip counting
+        # Flip counting — event counts, not time-weighted: each flip is a
+        # discrete occurrence regardless of how long the tick before it
+        # lasted.
         if prev_decision is not None and sample.occupied != prev_decision:
             out.decision_transitions += 1
         if prev_truth is not None and truth != prev_truth:
@@ -153,10 +199,10 @@ def compute_accuracy_metrics(
     for i in range(bins):
         row = CalibrationBin(lower=i / bins, upper=(i + 1) / bins)
         row.count = bin_count[i]
-        if row.count:
-            row.mean_probability = bin_prob_sum[i] / row.count
-            row.observed_rate = bin_hits[i] / row.count
-            ece += (row.count / out.sample_count) * abs(
+        if bin_count[i] and bin_weight[i]:
+            row.mean_probability = bin_prob_weight_sum[i] / bin_weight[i]
+            row.observed_rate = bin_hit_weight[i] / bin_weight[i]
+            ece += (bin_weight[i] / total_weight) * abs(
                 row.mean_probability - row.observed_rate
             )
         out.bins.append(row)
@@ -168,7 +214,7 @@ def compute_accuracy_metrics(
         out.false_on_rate = false_on / truth_off_total
     if truth_on_total:
         out.false_off_rate = false_off / truth_on_total
-    out.agreement = (true_on + true_off) / out.sample_count
+    out.agreement = (true_on + true_off) / total_weight
 
     return out
 

--- a/custom_components/area_occupancy/data/online_prior.py
+++ b/custom_components/area_occupancy/data/online_prior.py
@@ -20,9 +20,12 @@ Promotion routes through #500's 30-day shadow-diff gate.
 Known, accepted approximations vs the DB path (they bound the expected
 diff; see #500 step 2 for how the diff is judged):
 
-* **Sampling**: occupied time accrues in tick-sized quanta (~10s)
-  from live motion evidence, vs the DB's exact interval boundaries
-  replayed from the recorder.
+* **Sampling**: occupied time accrues in tick-sized quanta from live
+  presence evidence (piecewise-constant between ticks), vs the DB's
+  exact interval boundaries replayed from the recorder. Ticks are not
+  perfectly uniform — see ``coordinator._record_shadow_tick`` and
+  ``_handle_decay_timer`` for how a steady cadence is maintained even
+  when decay is disabled for every area.
 * **No motion-timeout extension**: the DB path extends each motion
   interval by the area's motion timeout during merging; the online
   numerator does not, so it reads slightly low on areas with sparse
@@ -30,6 +33,12 @@ diff; see #500 step 2 for how the diff is judged):
 * **Retention**: the DB period re-anchors as old intervals are pruned
   (365-day retention); the online period anchor is fixed at first
   observation. Irrelevant inside the 30-day shadow window.
+
+The numerator's presence definition mirrors
+``db.queries.get_occupied_intervals``'s ground truth — motion ∪ media ∪
+sleep evidence, not motion alone (see the ``observe`` caller in
+``coordinator.py``) — so the two paths are measuring the same thing
+modulo the two approximations above.
 """
 
 from __future__ import annotations

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -497,6 +497,39 @@ class TestAreaOccupancyCoordinator:
             else:
                 mock_refresh.assert_not_called()
 
+    async def test_handle_decay_timer_still_ticks_shadow_estimators_when_decay_disabled(
+        self,
+        hass: HomeAssistant,
+        mock_realistic_config_entry: Mock,
+    ) -> None:
+        """With decay disabled everywhere, shadow estimators must still tick.
+
+        Regression test: previously the timer only recorded accuracy/
+        online-prior samples as a side effect of ``async_refresh``, which
+        this path skips entirely when no area has decay enabled — starving
+        the online-prior numerator on any home that disables decay.
+        """
+        coordinator = AreaOccupancyCoordinator(hass, mock_realistic_config_entry)
+        coordinator._global_decay_timer = Mock()
+
+        area_name = "Test Area"
+        area = create_test_area(coordinator, area_name=area_name)
+        coordinator.get_area = Mock(return_value=area)
+        area.config.decay.enabled = False
+
+        with (
+            patch.object(coordinator, "async_refresh", new=AsyncMock()) as mock_refresh,
+            patch(
+                "custom_components.area_occupancy.coordinator.async_track_point_in_time",
+                return_value=None,
+            ),
+        ):
+            await coordinator._handle_decay_timer(dt_util.utcnow())
+
+        mock_refresh.assert_not_called()
+        assert len(coordinator.accuracy_samples_for(area_name)) == 1
+        assert coordinator.online_prior_for(area_name) is not None
+
     async def test_run_analysis(
         self, hass: HomeAssistant, mock_realistic_config_entry: Mock
     ) -> None:

--- a/tests/test_data_metrics.py
+++ b/tests/test_data_metrics.py
@@ -4,6 +4,8 @@ from datetime import UTC, datetime, timedelta
 import json
 from unittest.mock import patch
 
+import pytest
+
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
 from custom_components.area_occupancy.data.analysis import _run_shadow_metrics
 from custom_components.area_occupancy.data.metrics import (
@@ -138,6 +140,17 @@ class TestComputeAccuracyMetrics:
 
         assert out.sample_count == 10
         assert out.agreement > 0.9
+        assert out.false_on_rate == 1.0  # all 9 wrong ticks predict occupied=True
+        # All 10 samples share one calibration bin (p=0.9). Sample-weighted,
+        # observed_rate would be 1/10 = 0.1 (only the first tick is truth=True);
+        # time-weighted it should be ~990/999 ≈ 0.991, since that first tick
+        # covers nearly the whole window.
+        populated = [b for b in out.bins if b.count]
+        assert len(populated) == 1
+        assert populated[0].observed_rate == pytest.approx(990 / 999, abs=1e-5)
+        # ECE = |mean_probability(0.9) - observed_rate(~0.991)| ≈ 0.091, far
+        # below the ~0.8 a sample-weighted computation would produce.
+        assert out.expected_calibration_error == pytest.approx(0.0910, abs=1e-3)
         # bin_count still reflects raw sample counts for diagnostics
         assert sum(b.count for b in out.bins) == 10
 

--- a/tests/test_data_metrics.py
+++ b/tests/test_data_metrics.py
@@ -114,6 +114,61 @@ class TestComputeAccuracyMetrics:
         assert out.agreement == 1 / 6
         assert out.false_on_rate == 1.0
 
+    def test_non_uniform_ticks_are_time_weighted_not_sample_weighted(self) -> None:
+        """A burst of evidence-triggered ticks must not outweigh a long quiet span.
+
+        One correct tick spanning 990s vs nine wrong ticks crammed into the
+        following 9s (1s apart, as evidence-triggered refreshes would be).
+        Sample-weighted agreement would read 1/10 = 0.1; time-weighted
+        agreement should read ~990/999 ≈ 0.99.
+        """
+        intervals = [(T0, T0 + timedelta(seconds=990))]
+        samples = [
+            TickSample(timestamp=T0, probability=0.9, occupied=True),
+        ] + [
+            TickSample(
+                timestamp=T0 + timedelta(seconds=990 + i),
+                probability=0.9,
+                occupied=True,
+            )
+            for i in range(1, 10)
+        ]
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        assert out.sample_count == 10
+        assert out.agreement > 0.9
+        # bin_count still reflects raw sample counts for diagnostics
+        assert sum(b.count for b in out.bins) == 10
+
+    def test_last_tick_reuses_preceding_gap_as_weight(self) -> None:
+        """The final sample (no 'next tick' gap) is weighted like its predecessor."""
+        intervals = [(T0, T0 + timedelta(seconds=100))]
+        samples = [
+            TickSample(timestamp=T0, probability=0.9, occupied=True),
+            TickSample(
+                timestamp=T0 + timedelta(seconds=50), probability=0.9, occupied=True
+            ),
+        ]
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        # Both ticks correct and equally weighted (50s each) -> agreement 1.0
+        assert out.agreement == 1.0
+
+    def test_all_duplicate_timestamps_falls_back_to_uniform_weight(self) -> None:
+        """Zero-gap samples don't divide by zero; each counts equally instead."""
+        intervals = [(T0, T0 + timedelta(seconds=10))]
+        samples = [
+            TickSample(timestamp=T0, probability=0.9, occupied=True),
+            TickSample(timestamp=T0, probability=0.9, occupied=True),
+        ]
+
+        out = compute_accuracy_metrics(samples, intervals)
+
+        assert out.agreement == 1.0
+        assert out.sample_count == 2
+
 
 class TestDiagnosticsShape:
     """metrics_to_diagnostics output contract."""

--- a/tests/test_data_online_prior.py
+++ b/tests/test_data_online_prior.py
@@ -1,9 +1,11 @@
 """Tests for the shadow-mode online prior estimator (#500)."""
 
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 from custom_components.area_occupancy.const import MAX_PRIOR, MIN_PRIOR
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
+from custom_components.area_occupancy.data.entity_type import InputType
 from custom_components.area_occupancy.data.online_prior import (
     MAX_TICK_GAP_SECONDS,
     OnlinePriorEstimator,
@@ -137,3 +139,63 @@ class TestCoordinatorShadowWiring:
         estimator.state.occupied_seconds = 999999.0
 
         assert area.probability() == before
+
+    async def test_async_shutdown_persists_online_prior_state(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Shutdown must save shadow state, not just the hourly pipeline.
+
+        Regression test: previously only the hourly analysis pipeline
+        called ``async_save_online_priors``, so a restart between pipeline
+        runs silently dropped the occupied-seconds numerator while the
+        period denominator (anchored at ``first_observation``, reloaded
+        from the DB-backed prior on next setup) kept growing — biasing
+        the online prior low across every restart.
+        """
+        area_name = coordinator.get_area_names()[0]
+        await coordinator.update()
+        estimator = coordinator.online_prior_for(area_name)
+        assert estimator is not None
+        occupied_seconds_before = estimator.state.occupied_seconds
+        first_observation_before = estimator.state.first_observation
+
+        await coordinator.async_shutdown()
+
+        stored = await coordinator._online_prior_store.async_load()
+        assert area_name in stored
+        restored = OnlinePriorState.from_dict(stored[area_name])
+        assert restored.occupied_seconds == occupied_seconds_before
+        assert restored.first_observation == first_observation_before
+
+    async def test_presence_definition_includes_media_and_sleep(
+        self, coordinator: AreaOccupancyCoordinator
+    ) -> None:
+        """Numerator must match get_occupied_intervals' truth: motion ∪ media ∪ sleep.
+
+        Regression test: previously only ``InputType.MOTION`` evidence
+        counted, so an area occupied purely by media/sleep evidence (no
+        motion sensor firing) would silently accrue zero occupied_seconds
+        even though the DB ground truth it's diffed against counts it as
+        occupied.
+        """
+        area_name = coordinator.get_area_names()[0]
+        area = coordinator.get_area(area_name)
+
+        media_only_entity = SimpleNamespace(
+            evidence=True,
+            type=SimpleNamespace(input_type=InputType.MEDIA),
+        )
+
+        # way to stub one evidence-bearing entity without a full config.
+        original_entities = area.entities._entities
+        area.entities._entities = {"media.fake": media_only_entity}
+        try:
+            coordinator._record_shadow_tick(
+                area_name, area, T0, probability=0.5, is_occupied=True
+            )
+        finally:
+            area.entities._entities = original_entities
+
+        estimator = coordinator.online_prior_for(area_name)
+        assert estimator is not None
+        assert estimator.state.last_motion_active is True

--- a/tests/test_data_online_prior.py
+++ b/tests/test_data_online_prior.py
@@ -3,6 +3,8 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+import pytest
+
 from custom_components.area_occupancy.const import MAX_PRIOR, MIN_PRIOR
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
 from custom_components.area_occupancy.data.entity_type import InputType
@@ -156,6 +158,10 @@ class TestCoordinatorShadowWiring:
         await coordinator.update()
         estimator = coordinator.online_prior_for(area_name)
         assert estimator is not None
+        # Force a known nonzero numerator so this test can't pass by
+        # "saving zero" — asserting equality with whatever update() happened
+        # to accrue wouldn't catch a save that silently dropped the value.
+        estimator.state.occupied_seconds = 42.0
         occupied_seconds_before = estimator.state.occupied_seconds
         first_observation_before = estimator.state.first_observation
 
@@ -167,8 +173,9 @@ class TestCoordinatorShadowWiring:
         assert restored.occupied_seconds == occupied_seconds_before
         assert restored.first_observation == first_observation_before
 
+    @pytest.mark.parametrize("input_type", [InputType.MEDIA, InputType.SLEEP])
     async def test_presence_definition_includes_media_and_sleep(
-        self, coordinator: AreaOccupancyCoordinator
+        self, coordinator: AreaOccupancyCoordinator, input_type: InputType
     ) -> None:
         """Numerator must match get_occupied_intervals' truth: motion ∪ media ∪ sleep.
 
@@ -181,14 +188,14 @@ class TestCoordinatorShadowWiring:
         area_name = coordinator.get_area_names()[0]
         area = coordinator.get_area(area_name)
 
-        media_only_entity = SimpleNamespace(
+        evidence_only_entity = SimpleNamespace(
             evidence=True,
-            type=SimpleNamespace(input_type=InputType.MEDIA),
+            type=SimpleNamespace(input_type=input_type),
         )
 
         # way to stub one evidence-bearing entity without a full config.
         original_entities = area.entities._entities
-        area.entities._entities = {"media.fake": media_only_entity}
+        area.entities._entities = {"fake.entity": evidence_only_entity}
         try:
             coordinator._record_shadow_tick(
                 area_name, area, T0, probability=0.5, is_occupied=True

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -30,6 +30,7 @@ from custom_components.area_occupancy.db.schema import Areas, Entities
 from custom_components.area_occupancy.service import async_setup_services
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers.storage import Store
 
 
 class TestAsyncSetupEntry:
@@ -771,6 +772,35 @@ class TestAsyncRemoveEntry:
                 session.close()
         finally:
             engine.dispose()
+
+    async def test_removes_online_prior_store(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: Mock,
+        isolated_db: Path,
+    ) -> None:
+        """Removal deletes the shadow-mode online-prior Store file (#500).
+
+        Regression test: DB purging above doesn't touch HA's storage helper
+        files, so without explicit cleanup a stale online-prior Store would
+        survive entry removal forever.
+        """
+        entry_id = mock_config_entry.entry_id
+        object.__setattr__(mock_config_entry, "data", {CONF_AREAS: []})
+        object.__setattr__(mock_config_entry, "options", {})
+        hass.config_entries.async_entries = Mock(return_value=[mock_config_entry])
+
+        store_key = f"{DOMAIN_CONST}.online_prior.{entry_id}"
+        store: Store[dict[str, dict]] = Store(hass, 1, store_key)
+        await store.async_save({"Kitchen": {"occupied_seconds": 10.0}})
+        # A fresh Store instance avoids Store's own load-result cache, so this
+        # actually re-reads the backing (mocked) storage rather than the
+        # in-memory value from the async_save above.
+        assert await Store(hass, 1, store_key).async_load() is not None
+
+        await async_remove_entry(hass, mock_config_entry)
+
+        assert await Store(hass, 1, store_key).async_load() is None
 
     async def test_never_raises_even_when_db_missing(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -22,6 +22,8 @@ from custom_components.area_occupancy.const import (
     CONF_VERSION,
     DB_NAME,
     DOMAIN as DOMAIN_CONST,
+    ONLINE_PRIOR_STORE_KEY_PREFIX,
+    ONLINE_PRIOR_STORE_VERSION,
     PLATFORMS,
 )
 from custom_components.area_occupancy.coordinator import AreaOccupancyCoordinator
@@ -790,17 +792,25 @@ class TestAsyncRemoveEntry:
         object.__setattr__(mock_config_entry, "options", {})
         hass.config_entries.async_entries = Mock(return_value=[mock_config_entry])
 
-        store_key = f"{DOMAIN_CONST}.online_prior.{entry_id}"
-        store: Store[dict[str, dict]] = Store(hass, 1, store_key)
+        store_key = f"{ONLINE_PRIOR_STORE_KEY_PREFIX}.{entry_id}"
+        store: Store[dict[str, dict]] = Store(
+            hass, ONLINE_PRIOR_STORE_VERSION, store_key
+        )
         await store.async_save({"Kitchen": {"occupied_seconds": 10.0}})
         # A fresh Store instance avoids Store's own load-result cache, so this
         # actually re-reads the backing (mocked) storage rather than the
         # in-memory value from the async_save above.
-        assert await Store(hass, 1, store_key).async_load() is not None
+        assert (
+            await Store(hass, ONLINE_PRIOR_STORE_VERSION, store_key).async_load()
+            is not None
+        )
 
         await async_remove_entry(hass, mock_config_entry)
 
-        assert await Store(hass, 1, store_key).async_load() is None
+        assert (
+            await Store(hass, ONLINE_PRIOR_STORE_VERSION, store_key).async_load()
+            is None
+        )
 
     async def test_never_raises_even_when_db_missing(
         self,


### PR DESCRIPTION
## Summary

Self-review of the `next..main` diff (my own review + 3 parallel agent reviews covering all 12 commits ahead of `main`) turned up 4 real bugs confined to the #499/#500 phase-1 shadow-mode features (trust-score accuracy metrics and the online-prior estimator). All are confirmed **shadow-mode only** — nothing here feeds back into live probability, thresholds, or decay — but they'd corrupt the exact numbers the #499/#500 promotion gates are meant to judge before these features are ever promoted out of shadow mode.

1. **Sample-weighted, not time-weighted metrics** (`data/metrics.py`) — ticks land at an irregular cadence (10s decay timer *plus* every evidence-triggered refresh), so a busy period with a burst of ticks could dominate accuracy/calibration stats over a long quiet span covering the same wall-clock time. Every metric is now weighted by each tick's duration.
2. **Estimator collapse when decay is disabled** (`coordinator.py`) — the online-prior estimator only ticked as a side effect of `async_refresh()`, which the decay timer skips entirely when no area has decay enabled. Any home with decay off everywhere would starve the numerator. The timer now records shadow ticks directly on that path, without changing entity refresh cadence.
3. **Numerator lost on restart** (`coordinator.py`) — online-prior state was only persisted once per hour by the analysis pipeline, not on shutdown, so a restart between pipeline runs silently dropped the occupied-seconds numerator while the period denominator kept growing. Now saved in `async_shutdown()` too.
4. **Ground-truth mismatch** (`coordinator.py`) — the online numerator only counted `InputType.MOTION` evidence, while the DB ground truth it's diffed against (`get_occupied_intervals`) unions motion + media + sleep. Now matches.

## Test plan

- [x] 6 new regression tests covering each fix (non-uniform tick weighting, decay-disabled ticking, shutdown persistence, presence-type matching)
- [x] Full suite: 1839 passed
- [x] `ruff format` / `ruff check --fix` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Accuracy and calibration statistics now account for uneven sampling intervals.
  - Occupancy evaluation includes motion, media, and sleep activity evidence.
  - Online occupancy-prior data is preserved during shutdown.
  - Accuracy tracking continues during decay-only operation without unnecessary refreshes.

- **Bug Fixes**
  - Improved handling of irregular, duplicate, and invalid timestamps.
  - Ensured evidence-driven and decay samples are recorded consistently.
  - Removed stored online-prior data when the final configuration is removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->