### PR TITLE
fix(db): scope aggregation and raw dedup by entry_id

### DIFF
--- a/custom_components/area_occupancy/const.py
+++ b/custom_components/area_occupancy/const.py
@@ -31,7 +31,14 @@ PLATFORMS = [Platform.BINARY_SENSOR, Platform.NUMBER, Platform.SENSOR]
 DEVICE_MANUFACTURER: Final = "Hankanman"
 DEVICE_MODEL: Final = "Area Occupancy Detector"
 DEVICE_SW_VERSION: Final = "2026.8.1"
-CONF_VERSION: Final = 18
+# v18->v19: widened the aggregation/interval/numeric-sample unique constraints
+# and grouping keys to include entry_id (#533) — two config entries sharing a
+# physical entity_id no longer collide. This is a genuine constraint change,
+# not additive, so it intentionally triggers the destructive
+# _ensure_schema_up_to_date path (delete + recreate the DB) — unlike the
+# adjacent_areas case documented in migrations.py, an in-place ALTER isn't
+# possible here since the old constraint is narrower than the new one.
+CONF_VERSION: Final = 19
 CONF_VERSION_MINOR: Final = 0
 HA_RECORDER_DAYS: Final = 10  # days
 

--- a/custom_components/area_occupancy/db/aggregation.py
+++ b/custom_components/area_occupancy/db/aggregation.py
@@ -157,8 +157,8 @@ def aggregate_raw_to_daily(
                 _LOGGER.debug("No raw intervals to aggregate to daily")
                 return 0, []
 
-            # Group by entity_id, state, and day
-            aggregates: dict[tuple[str, str, datetime], dict[str, Any]] = {}
+            # Group by entry_id, entity_id, state, and day
+            aggregates: dict[tuple[str, str, str, datetime], dict[str, Any]] = {}
 
             for interval in raw_intervals:
                 # DB stores naive UTC; bucket by local day boundary and persist naive UTC.
@@ -169,7 +169,12 @@ def aggregate_raw_to_daily(
                 period_start = to_db_utc(day_start_local)
                 period_end = to_db_utc(day_start_local + timedelta(days=1))
 
-                key = (interval.entity_id, interval.state, period_start)
+                key = (
+                    interval.entry_id,
+                    interval.entity_id,
+                    interval.state,
+                    period_start,
+                )
 
                 if key not in aggregates:
                     aggregates[key] = {
@@ -234,6 +239,7 @@ def aggregate_raw_to_daily(
                 existing = (
                     session.query(db.IntervalAggregates)
                     .filter_by(
+                        entry_id=agg_data["entry_id"],
                         entity_id=agg_data["entity_id"],
                         aggregation_period=AGGREGATION_PERIOD_DAILY,
                         period_start=agg_data["period_start"],
@@ -320,8 +326,8 @@ def aggregate_daily_to_weekly(
                 _LOGGER.debug("No daily aggregates to aggregate to weekly")
                 return 0, []
 
-            # Group by entity_id, state, and week
-            aggregates: dict[tuple[str, str, datetime], dict[str, Any]] = {}
+            # Group by entry_id, entity_id, state, and week
+            aggregates: dict[tuple[str, str, str, datetime], dict[str, Any]] = {}
 
             for daily in daily_aggregates:
                 # DB stores naive UTC; bucket by local week boundary and persist naive UTC.
@@ -335,7 +341,7 @@ def aggregate_daily_to_weekly(
                 week_start = to_db_utc(week_start_local)
                 week_end = to_db_utc(week_end_local)
 
-                key = (daily.entity_id, daily.state, week_start)
+                key = (daily.entry_id, daily.entity_id, daily.state, week_start)
 
                 if key not in aggregates:
                     aggregates[key] = {
@@ -400,6 +406,7 @@ def aggregate_daily_to_weekly(
                 existing = (
                     session.query(db.IntervalAggregates)
                     .filter_by(
+                        entry_id=agg_data["entry_id"],
                         entity_id=agg_data["entity_id"],
                         aggregation_period=AGGREGATION_PERIOD_WEEKLY,
                         period_start=agg_data["period_start"],
@@ -486,8 +493,8 @@ def aggregate_weekly_to_monthly(
                 _LOGGER.debug("No weekly aggregates to aggregate to monthly")
                 return 0
 
-            # Group by entity_id, state, and month
-            aggregates: dict[tuple[str, str, datetime], dict[str, Any]] = {}
+            # Group by entry_id, entity_id, state, and month
+            aggregates: dict[tuple[str, str, str, datetime], dict[str, Any]] = {}
 
             for weekly in weekly_aggregates:
                 # DB stores naive UTC; bucket by local month boundary and persist naive UTC.
@@ -506,7 +513,7 @@ def aggregate_weekly_to_monthly(
                 month_start = to_db_utc(month_start_local)
                 month_end = to_db_utc(month_end_local)
 
-                key = (weekly.entity_id, weekly.state, month_start)
+                key = (weekly.entry_id, weekly.entity_id, weekly.state, month_start)
 
                 if key not in aggregates:
                     aggregates[key] = {
@@ -571,6 +578,7 @@ def aggregate_weekly_to_monthly(
                 existing = (
                     session.query(db.IntervalAggregates)
                     .filter_by(
+                        entry_id=agg_data["entry_id"],
                         entity_id=agg_data["entity_id"],
                         aggregation_period=AGGREGATION_PERIOD_MONTHLY,
                         period_start=agg_data["period_start"],
@@ -849,9 +857,9 @@ def aggregate_numeric_samples_to_hourly(
                 _LOGGER.debug("No numeric samples to aggregate to hourly")
                 return 0, []
 
-            # Group by entity_id and hour
-            aggregates: dict[tuple[str, datetime], dict[str, Any]] = {}
-            sample_ids_by_hour: dict[tuple[str, datetime], list[int]] = {}
+            # Group by entry_id, entity_id, and hour
+            aggregates: dict[tuple[str, str, datetime], dict[str, Any]] = {}
+            sample_ids_by_hour: dict[tuple[str, str, datetime], list[int]] = {}
 
             for sample in raw_samples:
                 # DB stores naive UTC; bucket by local hour boundary and persist naive UTC.
@@ -862,7 +870,7 @@ def aggregate_numeric_samples_to_hourly(
                 period_start = to_db_utc(hour_start_local)
                 period_end = to_db_utc(hour_start_local + timedelta(hours=1))
 
-                key = (sample.entity_id, period_start)
+                key = (sample.entry_id, sample.entity_id, period_start)
 
                 if key not in aggregates:
                     aggregates[key] = {
@@ -917,6 +925,7 @@ def aggregate_numeric_samples_to_hourly(
                 existing = (
                     session.query(db.NumericAggregates)
                     .filter_by(
+                        entry_id=agg_data["entry_id"],
                         entity_id=agg_data["entity_id"],
                         aggregation_period=AGGREGATION_PERIOD_HOURLY,
                         period_start=agg_data["period_start"],
@@ -1010,8 +1019,8 @@ def aggregate_hourly_to_weekly(
                 _LOGGER.debug("No hourly aggregates to aggregate to weekly")
                 return 0, []
 
-            # Group by entity_id and week
-            aggregates: dict[tuple[str, datetime], dict[str, Any]] = {}
+            # Group by entry_id, entity_id, and week
+            aggregates: dict[tuple[str, str, datetime], dict[str, Any]] = {}
 
             for hourly in hourly_aggregates:
                 # DB stores naive UTC; bucket by local week boundary and persist naive UTC.
@@ -1025,7 +1034,7 @@ def aggregate_hourly_to_weekly(
                 week_start = to_db_utc(week_start_local)
                 week_end = to_db_utc(week_end_local)
 
-                key = (hourly.entity_id, week_start)
+                key = (hourly.entry_id, hourly.entity_id, week_start)
 
                 if key not in aggregates:
                     aggregates[key] = {
@@ -1109,6 +1118,7 @@ def aggregate_hourly_to_weekly(
                 existing = (
                     session.query(db.NumericAggregates)
                     .filter_by(
+                        entry_id=agg_data["entry_id"],
                         entity_id=agg_data["entity_id"],
                         aggregation_period=AGGREGATION_PERIOD_WEEKLY,
                         period_start=agg_data["period_start"],

--- a/custom_components/area_occupancy/db/schema.py
+++ b/custom_components/area_occupancy/db/schema.py
@@ -272,9 +272,10 @@ class Intervals(Base):
     # Relationship removed - SQLite doesn't support composite FKs properly
     # Use manual joins in queries instead (see db/queries.py)
 
-    # Add unique constraint on (entity_id, start_time, end_time, aggregation_level)
+    # Add unique constraint on (entry_id, entity_id, start_time, end_time, aggregation_level)
     __table_args__ = (
         UniqueConstraint(
+            "entry_id",
             "entity_id",
             "start_time",
             "end_time",
@@ -366,6 +367,7 @@ class IntervalAggregates(Base):
 
     __table_args__ = (
         UniqueConstraint(
+            "entry_id",
             "entity_id",
             "aggregation_period",
             "period_start",
@@ -467,6 +469,7 @@ class NumericSamples(Base):
 
     __table_args__ = (
         UniqueConstraint(
+            "entry_id",
             "entity_id",
             "timestamp",
             name="uq_numeric_samples_entity_timestamp",
@@ -512,6 +515,7 @@ class NumericAggregates(Base):
 
     __table_args__ = (
         UniqueConstraint(
+            "entry_id",
             "entity_id",
             "aggregation_period",
             "period_start",

--- a/custom_components/area_occupancy/db/sync.py
+++ b/custom_components/area_occupancy/db/sync.py
@@ -46,24 +46,27 @@ def _normalize_db_key_datetime(value: datetime) -> datetime:
 def _get_existing_interval_keys(
     session: sa.orm.Session,
     db: AreaOccupancyDB,
-    interval_keys: set[tuple[str, datetime, datetime]],
-) -> set[tuple[str, datetime, datetime]]:
+    interval_keys: set[tuple[str, str, datetime, datetime]],
+) -> set[tuple[str, str, datetime, datetime]]:
     """Return keys already stored in the database using batched tuple lookups."""
     if not interval_keys:
         return set()
 
     keys_list = list(interval_keys)
     interval_tuple = sa.tuple_(
-        db.Intervals.entity_id, db.Intervals.start_time, db.Intervals.end_time
+        db.Intervals.entry_id,
+        db.Intervals.entity_id,
+        db.Intervals.start_time,
+        db.Intervals.end_time,
     )
-    existing_keys: set[tuple[str, datetime, datetime]] = set()
+    existing_keys: set[tuple[str, str, datetime, datetime]] = set()
 
     for chunk in chunked(keys_list, _INTERVAL_LOOKUP_BATCH):
         matches = session.query(db.Intervals).filter(interval_tuple.in_(chunk)).all()
         for interval in matches:
             start = _normalize_db_key_datetime(interval.start_time)
             end = _normalize_db_key_datetime(interval.end_time)
-            existing_keys.add((interval.entity_id, start, end))
+            existing_keys.add((interval.entry_id, interval.entity_id, start, end))
 
     return existing_keys
 
@@ -71,21 +74,25 @@ def _get_existing_interval_keys(
 def _get_existing_numeric_sample_keys(
     session: sa.orm.Session,
     db: AreaOccupancyDB,
-    sample_keys: set[tuple[str, datetime]],
-) -> set[tuple[str, datetime]]:
+    sample_keys: set[tuple[str, str, datetime]],
+) -> set[tuple[str, str, datetime]]:
     """Return numeric samples already stored using batched tuple lookups."""
     if not sample_keys:
         return set()
 
     keys_list = list(sample_keys)
-    sample_tuple = sa.tuple_(db.NumericSamples.entity_id, db.NumericSamples.timestamp)
-    existing_keys: set[tuple[str, datetime]] = set()
+    sample_tuple = sa.tuple_(
+        db.NumericSamples.entry_id,
+        db.NumericSamples.entity_id,
+        db.NumericSamples.timestamp,
+    )
+    existing_keys: set[tuple[str, str, datetime]] = set()
 
     for chunk in chunked(keys_list, _NUMERIC_SAMPLE_LOOKUP_BATCH):
         matches = session.query(db.NumericSamples).filter(sample_tuple.in_(chunk)).all()
         for sample in matches:
             timestamp = _normalize_db_key_datetime(sample.timestamp)
-            existing_keys.add((sample.entity_id, timestamp))
+            existing_keys.add((sample.entry_id, sample.entity_id, timestamp))
 
     return existing_keys
 
@@ -223,6 +230,7 @@ def _commit_intervals(db: AreaOccupancyDB, intervals: list[dict[str, Any]]) -> N
     with db.get_session() as session:
         interval_keys = {
             (
+                interval_data["entry_id"],
                 interval_data["entity_id"],
                 interval_data["start_time"],
                 interval_data["end_time"],
@@ -237,11 +245,11 @@ def _commit_intervals(db: AreaOccupancyDB, intervals: list[dict[str, Any]]) -> N
         )
 
         new_intervals = []
-        seen_keys: set[tuple[str, datetime, datetime]] = set()
+        seen_keys: set[tuple[str, str, datetime, datetime]] = set()
         for interval_data in mapped_intervals:
             start = _normalize_db_key_datetime(interval_data["start_time"])
             end = _normalize_db_key_datetime(interval_data["end_time"])
-            key = (interval_data["entity_id"], start, end)
+            key = (interval_data["entry_id"], interval_data["entity_id"], start, end)
             if key in existing_keys or key in seen_keys:
                 continue
             seen_keys.add(key)
@@ -260,6 +268,7 @@ def _commit_numeric_samples(
     with db.get_session() as session:
         sample_keys = {
             (
+                sample_data["entry_id"],
                 sample_data["entity_id"],
                 sample_data["timestamp"],
             )
@@ -273,10 +282,10 @@ def _commit_numeric_samples(
         )
 
         new_samples = []
-        seen_sample_keys: set[tuple[str, datetime]] = set()
+        seen_sample_keys: set[tuple[str, str, datetime]] = set()
         for sample_data in numeric_samples:
             timestamp = _normalize_db_key_datetime(sample_data["timestamp"])
-            key = (sample_data["entity_id"], timestamp)
+            key = (sample_data["entry_id"], sample_data["entity_id"], timestamp)
             if key in existing_samples or key in seen_sample_keys:
                 continue
             seen_sample_keys.add(key)

--- a/tests/test_db_aggregation.py
+++ b/tests/test_db_aggregation.py
@@ -1579,3 +1579,111 @@ class TestSlidingCutoffMerge:
                 .count()
             )
             assert hourlies_left == 0
+
+
+class TestAggregationEntryIsolation:
+    """Regression tests for #533: aggregation must scope by entry_id.
+
+    Two different config entries can each have an area whose sensors happen
+    to share a physical HA entity_id (the same motion sensor assigned to two
+    overlapping areas). Aggregation must keep their rows separate instead of
+    merging them into one.
+    """
+
+    def test_raw_to_daily_keeps_entries_separate(
+        self, coordinator: AreaOccupancyCoordinator
+    ):
+        """Same entity_id/state/day across two entries aggregates into two rows."""
+        db = coordinator.db
+        entry_id_a = db.coordinator.entry_id
+        entry_id_b = "second-config-entry-id"
+        area_a = db.coordinator.get_area_names()[0]
+        area_b = "Second Entry Area"
+        shared_entity_id = "binary_sensor.shared_motion"
+
+        old_date = (
+            dt_util.as_local(_get_old_date(RETENTION_RAW_INTERVALS_DAYS))
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .astimezone(dt_util.UTC)
+        )
+
+        with db.get_session() as session:
+            for entry_id, area_name in ((entry_id_a, area_a), (entry_id_b, area_b)):
+                session.add(
+                    db.Intervals(
+                        entry_id=entry_id,
+                        area_name=area_name,
+                        entity_id=shared_entity_id,
+                        state="on",
+                        start_time=old_date,
+                        end_time=old_date + timedelta(minutes=30),
+                        duration_seconds=1800.0,
+                        aggregation_level="raw",
+                    )
+                )
+            session.commit()
+
+        # No area_name filter: exercises the same all-areas path the
+        # periodic analysis run uses (data/analysis.py run_interval_aggregation).
+        result_count, _ = aggregate_raw_to_daily(db)
+        assert result_count == 2
+
+        with db.get_session() as session:
+            aggregates = (
+                session.query(db.IntervalAggregates)
+                .filter_by(entity_id=shared_entity_id, aggregation_period="daily")
+                .all()
+            )
+            assert len(aggregates) == 2
+            entry_ids = {agg.entry_id for agg in aggregates}
+            assert entry_ids == {entry_id_a, entry_id_b}
+            for agg in aggregates:
+                # Each entry's row reflects only its own single interval,
+                # not a merge of both entries' intervals.
+                assert agg.interval_count == 1
+                assert agg.total_duration_seconds == 1800.0
+
+    def test_hourly_numeric_keeps_entries_separate(
+        self, coordinator: AreaOccupancyCoordinator
+    ):
+        """Same entity_id/hour across two entries aggregates into two rows."""
+        db = coordinator.db
+        entry_id_a = db.coordinator.entry_id
+        entry_id_b = "second-config-entry-id"
+        area_a = db.coordinator.get_area_names()[0]
+        area_b = "Second Entry Area"
+        shared_entity_id = "sensor.shared_temperature"
+
+        old_date = _get_old_date(RETENTION_RAW_NUMERIC_SAMPLES_DAYS)
+
+        with db.get_session() as session:
+            for entry_id, area_name, value in (
+                (entry_id_a, area_a, 20.0),
+                (entry_id_b, area_b, 30.0),
+            ):
+                session.add(
+                    db.NumericSamples(
+                        entry_id=entry_id,
+                        area_name=area_name,
+                        entity_id=shared_entity_id,
+                        timestamp=old_date,
+                        value=value,
+                        unit_of_measurement="°C",
+                    )
+                )
+            session.commit()
+
+        result_count, _ = aggregate_numeric_samples_to_hourly(db)
+        assert result_count == 2
+
+        with db.get_session() as session:
+            aggregates = (
+                session.query(db.NumericAggregates)
+                .filter_by(entity_id=shared_entity_id, aggregation_period="hourly")
+                .all()
+            )
+            assert len(aggregates) == 2
+            by_entry = {agg.entry_id: agg for agg in aggregates}
+            assert by_entry.keys() == {entry_id_a, entry_id_b}
+            assert by_entry[entry_id_a].avg_value == pytest.approx(20.0)
+            assert by_entry[entry_id_b].avg_value == pytest.approx(30.0)

--- a/tests/test_db_sync.py
+++ b/tests/test_db_sync.py
@@ -1134,13 +1134,16 @@ class TestIntervalLookup:
                         duration_seconds=(end - start).total_seconds(),
                     )
                 )
-                interval_defs.append((f"binary_sensor.motion_{idx}", start, end))
+                interval_defs.append(
+                    (db.coordinator.entry_id, f"binary_sensor.motion_{idx}", start, end)
+                )
             session.commit()
 
         interval_keys = set(interval_defs)
         # Add a non-existing key to ensure it's ignored
         interval_keys.add(
             (
+                db.coordinator.entry_id,
                 "binary_sensor.motion_new",
                 now + timedelta(hours=1),
                 now + timedelta(hours=1, minutes=5),
@@ -1159,8 +1162,8 @@ class TestIntervalLookup:
             existing = _get_existing_interval_keys(session, db, interval_keys)
 
         expected = {
-            (entity_id, normalize(start), normalize(end))
-            for entity_id, start, end in interval_defs
+            (entry_id, entity_id, normalize(start), normalize(end))
+            for entry_id, entity_id, start, end in interval_defs
         }
         assert existing == expected
 
@@ -1208,12 +1211,16 @@ class TestNumericSampleLookup:
                         state=str(20.0 + idx),
                     )
                 )
-                sample_defs.append((f"sensor.temp_{idx}", timestamp))
+                sample_defs.append(
+                    (db.coordinator.entry_id, f"sensor.temp_{idx}", timestamp)
+                )
             session.commit()
 
         sample_keys = set(sample_defs)
         # Add a non-existing key to ensure it's ignored
-        sample_keys.add(("sensor.temp_new", now + timedelta(hours=1)))
+        sample_keys.add(
+            (db.coordinator.entry_id, "sensor.temp_new", now + timedelta(hours=1))
+        )
 
         monkeypatch.setattr(
             "custom_components.area_occupancy.db.sync._NUMERIC_SAMPLE_LOOKUP_BATCH",
@@ -1227,7 +1234,8 @@ class TestNumericSampleLookup:
             existing = _get_existing_numeric_sample_keys(session, db, sample_keys)
 
         expected = {
-            (entity_id, normalize(timestamp)) for entity_id, timestamp in sample_defs
+            (entry_id, entity_id, normalize(timestamp))
+            for entry_id, entity_id, timestamp in sample_defs
         }
         assert existing == expected
 


### PR DESCRIPTION
## Summary

Fixes #533. Interval/numeric aggregation (`db/aggregation.py`) grouped and looked up rows using only `entity_id` + period + state, and the matching `UniqueConstraint`s on `IntervalAggregates`/`NumericAggregates`/`Intervals`/`NumericSamples` (`db/schema.py`) didn't include `entry_id`/`area_name` either — same gap in the raw dedup lookups in `db/sync.py`.

AOD uses a single shared SQLite file for every config entry (`db/core.py:_setup_paths()`), not one per entry. So two config entries whose areas happen to reference the same physical entity_id (e.g. the same motion sensor assigned to both "Hallway" and "Whole House") would collide — aggregation would silently merge their data into one row instead of keeping them scoped per entry.

- Widened all 5 aggregation grouping keys + `filter_by()` lookups to include `entry_id` (`entry_id` was already present on every row at aggregation time — no new data threading needed).
- Widened the 4 affected `UniqueConstraint`s in `schema.py` to match.
- Applied the same fix to the raw interval/numeric-sample dedup lookups in `db/sync.py`, which had the identical gap.

### Migration impact

This project has no in-place `ALTER TABLE` migration path — a schema/constraint change is applied by fully deleting and recreating the SQLite file on `CONF_VERSION` mismatch (`db/maintenance.py:_ensure_schema_up_to_date()`), same as every prior schema change. Bumped `CONF_VERSION` 18→19; users get a one-time relearn on upgrade (documented at the constant and will be called out in release notes).

## Test plan

- [x] New `TestAggregationEntryIsolation` class (`tests/test_db_aggregation.py`) — two entries sharing an entity_id now produce two separate aggregate rows for both the interval and numeric paths, instead of merging.
- [x] Updated the two existing `db/sync.py` dedup-lookup tests for the new key shape.
- [x] Full suite: 1825 passed.
- [x] `ruff check` / `ruff format --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JScVzM9kxqh9q5sZR2BTVV